### PR TITLE
fix: Fix openai responses api issues

### DIFF
--- a/massgen/formatter/_response_formatter.py
+++ b/massgen/formatter/_response_formatter.py
@@ -64,8 +64,9 @@ class ResponseFormatter(FormatterBase):
                 converted_messages.append(message)
             elif message.get("type") == "function_call":
                 call_id = message.get("call_id")
-                # Strip 'id' to decouple from reasoning items
-                cleaned_fc = {k: v for k, v in message.items() if k != "id"}
+                # Preserve 'id' field to maintain pairing with reasoning items (required by OpenAI Responses API)
+                # See: https://github.com/langchain-ai/langchainjs/pull/9082
+                cleaned_fc = message.copy()
 
                 if call_id and call_id not in output_call_ids:
                     converted_messages.append(cleaned_fc)

--- a/massgen/orchestrator.py
+++ b/massgen/orchestrator.py
@@ -3788,38 +3788,21 @@ Your answer:"""
                         error_msg = getattr(chunk, "error", str(chunk.content)) if hasattr(chunk, "error") else str(chunk.content)
                         yield ("content", f"❌ Error: {error_msg}\n")
 
-                # Check for multiple vote calls before processing
+                # Handle multiple vote calls - take the last vote (agent's final decision)
                 vote_calls = [tc for tc in tool_calls if agent.backend.extract_tool_name(tc) == "vote"]
                 if len(vote_calls) > 1:
-                    if attempt < max_attempts - 1:
-                        if self._check_restart_pending(agent_id):
-                            should_continue = await self._inject_update_and_continue(
-                                agent_id,
-                                answers,
-                                conversation_messages,
-                            )
-                            if should_continue:
-                                yield ("content", f"📨 [{agent_id}] receiving update with new answers\n")
-                                continue  # Agent continues working with update
-                            # else: No new answers, proceed with normal error handling
-                        error_msg = f"Multiple vote calls not allowed. Made {len(vote_calls)} calls but must make exactly 1. Call vote tool once with chosen agent."
-                        yield ("content", f"❌ {error_msg}")
+                    # Take the last vote - represents the agent's final, most refined decision
+                    num_votes = len(vote_calls)
+                    final_vote_call = vote_calls[-1]
+                    final_vote_args = agent.backend.extract_tool_arguments(final_vote_call)
+                    final_voted_agent = final_vote_args.get("agent_id", "unknown")
 
-                        # Send tool error response for all tool calls
-                        enforcement_msg = self._create_tool_error_messages(
-                            agent,
-                            tool_calls,
-                            error_msg,
-                            "Vote rejected due to multiple votes.",
-                        )
-                        continue  # Retry this attempt
-                    else:
-                        yield (
-                            "error",
-                            f"Agent made {len(vote_calls)} vote calls in single response after max attempts",
-                        )
-                        yield ("done", None)
-                        return
+                    # Replace tool_calls with deduplicated list (all non-votes + final vote)
+                    vote_calls = [final_vote_call]
+                    tool_calls = [tc for tc in tool_calls if agent.backend.extract_tool_name(tc) != "vote"] + [final_vote_call]
+
+                    logger.info(f"[Orchestrator] Agent {agent_id} made {num_votes} votes - using last vote: {final_voted_agent}")
+                    yield ("content", f"⚠️ Agent made {num_votes} votes - using last (final decision): {final_voted_agent}\n")
 
                 # Check for mixed new_answer and vote calls - violates binary decision framework
                 new_answer_calls = [tc for tc in tool_calls if agent.backend.extract_tool_name(tc) == "new_answer"]


### PR DESCRIPTION
# Fix GPT-5 Reasoning Token Errors and Double Voting

## Summary

This PR fixes two critical issues affecting GPT-5 reasoning models and multi-agent voting:

1. **GPT-5-mini (and other GPT-5-X models) reasoning token errors** - Fixed malformed Response API requests causing 400 errors
2. **Double voting handling** - Gracefully handle when reasoning models make multiple vote calls

Closes MAS-181

## Issues Fixed

### Issue 1: GPT-5 Reasoning Token Errors

**Error**:
```
Error code: 400 - {'error': {'message': "Item 'rs_...' of type 'reasoning' was provided without its required following item."}}
```

**Root Causes**:
1. The `id` field was being stripped from `function_call` items, breaking reasoning-to-function-call pairing required by OpenAI's Response API
2. When using `previous_response_id`, response items were being added both manually AND automatically, causing duplicate reasoning items

**Fixes**:
- **`massgen/formatter/_response_formatter.py`**: Preserve `id` field in function_call items (required for reasoning pairing per [LangChain PR #9082](https://github.com/langchain-ai/langchainjs/pull/9082))
- **`massgen/backend/response.py`**: Only add response items manually when NOT using `previous_response_id` to avoid duplicates

### Issue 2: Double Voting in Multi-Agent Workflows

**Issue**: Certain GPT-5 models (particularly gpt-5.1 and gpt-5.2) make multiple vote calls despite enforcement messages, causing workflow failures.

**Model Behavior**:
- ❌ **gpt-5.1, gpt-5.2**: Ignore tool error enforcement, repeat violations
- ✅ **gpt-5(-X), gpt-5.1-codex**: Respond to enforcement correctly

**Fix**: Instead of rejecting multiple votes, gracefully handle by taking the **last vote** as the agent's final decision.

**Rationale**:
- The last vote represents the agent's most refined thinking
- Reasoning models iterate through their logic - later votes are more informed
- Simpler than vote counting and more aligned with how reasoning models work

## Changes

### Files Modified

1. **`massgen/formatter/_response_formatter.py`**
   - Preserve `id` field for reasoning item pairing
   - Added reference to LangChain's similar fix

2. **`massgen/backend/response.py`**
   - Conditional response item addition based on `response_id` presence
   - Deduplicate items by ID to prevent duplicate reasoning tokens
   - Improved logging (debug level instead of info)

3. **`massgen/orchestrator.py`**
   - Simplified multiple vote handling (38 lines → 14 lines)
   - Take last vote instead of complex counting/enforcement
   - Removed unnecessary debug logging
   - Cleaner variable names

### Lines Changed
```
massgen/backend/response.py              | +16 -3
massgen/formatter/_response_formatter.py | +5 -2
massgen/orchestrator.py                  | +14 -38
Total: +35 -43 (net -8 lines, cleaner code)
```

## Testing

### Test Case 1: Reasoning Models
```bash
uv run massgen --automation --model gpt-5-mini "Create a simple website"
```

**Before**: 400 error about reasoning tokens
**After**: ✅ Completes successfully

### Test Case 2: Multi-Agent Voting with gpt-5.1/5.2
```bash
uv run massgen --config config.yaml "Create a simple website"
```

**Before**: `Agent execution failed: 'agent1'` (KeyError)
**After**:
```
⚠️ Agent made 2 votes - using last (final decision): agent1
🏆 Turn 1 winner: agent_a
```

### Verified Behavior
- ✅ No reasoning token errors with GPT-5 models
- ✅ Warning shown when multiple votes detected
- ✅ Execution completes successfully using last vote
- ✅ Anonymous ID mapping works correctly (agent1 → agent_a)

## Related Documentation

- **LangChain PR #9082**: https://github.com/langchain-ai/langchainjs/pull/9082 (same reasoning token issue)
- **OpenAI Response API**: Requires strict item ordering for reasoning models
- **MassGen Issue**: Model-specific behavior where gpt-5.1/5.2 don't respect tool error enforcement

## Known Limitations

**GPT-5 Model Variants**: Some models (gpt-5.1, gpt-5.2) don't properly respond to tool error enforcement. This fix works around the limitation by handling multiple votes gracefully rather than relying on enforcement.

**Recommendation**: For critical voting scenarios, prefer models that respond to enforcement (gpt-5(-X), gpt-5.1-codex) or accept that multiple votes will be deduplicated to the last vote.

## Migration Notes

No breaking changes. This is purely a bug fix that:
- Makes reasoning models work correctly
- Handles edge cases more gracefully
- Improves user experience with better messaging

Users will see informational warnings when multiple votes are detected, but workflows will continue successfully.
