### PR TITLE
fix: sanitize function_call messages for Response API format

### DIFF
--- a/massgen/formatter/_response_formatter.py
+++ b/massgen/formatter/_response_formatter.py
@@ -6,6 +6,7 @@ Handles formatting for OpenAI Response API format with multimodal support.
 
 from __future__ import annotations
 
+import json
 from typing import Any, Dict, List
 
 from ._formatter_base import FormatterBase
@@ -103,7 +104,13 @@ class ResponseFormatter(FormatterBase):
                 call_id = message.get("call_id")
                 # Preserve 'id' field to maintain pairing with reasoning items (required by OpenAI Responses API)
                 # See: https://github.com/langchain-ai/langchainjs/pull/9082
-                cleaned_fc = message.copy()
+                # Only keep valid function_call fields - Response API rejects unknown fields like 'content'
+                valid_fc_fields = {"type", "name", "arguments", "call_id", "id"}
+                cleaned_fc = {k: v for k, v in message.items() if k in valid_fc_fields}
+
+                # Ensure arguments is a JSON string, not an object (Response API requirement)
+                if "arguments" in cleaned_fc and not isinstance(cleaned_fc["arguments"], str):
+                    cleaned_fc["arguments"] = json.dumps(cleaned_fc["arguments"])
 
                 if call_id and call_id not in output_call_ids:
                     converted_messages.append(cleaned_fc)


### PR DESCRIPTION
## Description
The OpenAI Response API rejects function_call messages with invalid fields. This PR fixes message formatting in the Response API formatter to:
- Filter function_call messages to only include valid fields (type, name, arguments, call_id, id), removing invalid fields like 'content'
- Ensure 'arguments' field is JSON-serialized string, not an object

This fixes errors when using the Python API with OpenAI models:
- `Unknown parameter: 'input[N].content'`
- `Invalid type for 'input[N].arguments': expected a string, but got an object`

## Type of change
- [x] Bug fix (`fix:`) - Non-breaking change which fixes an issue

## Checklist
- [x] I have run pre-commit on my changed files and all checks pass
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Pre-commit status
```
check python ast.........................................................Passed
check docstring is first.................................................Passed
fix python encoding pragma...............................................Passed
detect private key.......................................................Passed
trim trailing whitespace.................................................Passed
Add trailing commas......................................................Passed
isort....................................................................Passed
autoflake................................................................Passed
black....................................................................Passed
flake8...................................................................Passed
Check package with Pyroma................................................Passed
```

## How to Test

### Test CLI Command
```bash
uv run python -c "
import asyncio
import os
os.environ['OPENAI_API_KEY'] = 'your-api-key'
import massgen
result = asyncio.run(massgen.run(query='What is 2+2?', model='gpt-4o-mini', enable_filesystem=False))
print('SUCCESS:', result['final_answer'][:100])
" 2>&1 | grep -E "(ERROR|SUCCESS|Unknown parameter|invalid_type)"
```

### Expected Results
- Should print `SUCCESS: ...` with the answer
- Should NOT show errors like `Unknown parameter: 'input[N].content'` or `Invalid type for 'input[N].arguments'`

## Additional context
This bug was discovered while testing the Python API examples in the user guide (`docs/source/user_guide/integration/python_api.rst`). The Response API was rejecting messages because function_call items included a `content` field (invalid) and had `arguments` as an object instead of a JSON string.