### PR TITLE
fix: show Codex backend in WebUI without OPENAI_API_KEY

### DIFF
--- a/massgen/frontend/web/server.py
+++ b/massgen/frontend/web/server.py
@@ -1037,6 +1037,9 @@ def create_app(
             elif backend_type == "copilot":
                 # Copilot always shows - works with gh CLI login, no API key needed
                 has_api_key = True
+            elif backend_type == "codex":
+                # Codex always shows - works with OAuth (codex login) or OPENAI_API_KEY
+                has_api_key = True
             elif caps.env_var:
                 api_key = os.getenv(caps.env_var, "")
                 # Check it's not empty and not a placeholder from .env.example


### PR DESCRIPTION
Codex supports OAuth authentication via `codex login` and does not require `OPENAI_API_KEY`. The WebUI provider list currently hides it when the env var is absent.

This adds `codex` to the same auth-not-required whitelist as `claude_code` and `copilot`.

Fixes #936

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved API key configuration consistency across backend providers to ensure uniform handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->