### PR TITLE
Add cherry blossoms experiment report (CC vs Codex)

### DIFF
--- a/docs/presentation/experiments/cherry-blossoms/cc-initial.svg
+++ b/docs/presentation/experiments/cherry-blossoms/cc-initial.svg
@@ -1,0 +1,697 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 600" width="1200" height="600">
+  <defs>
+    <!-- Watercolor soft blur filter -->
+    <filter id="wc" x="-10%" y="-10%" width="120%" height="120%">
+      <feTurbulence type="fractalNoise" baseFrequency="0.065" numOctaves="3" seed="2" result="noise"/>
+      <feDisplacementMap in="SourceGraphic" in2="noise" scale="4" xChannelSelector="R" yChannelSelector="G" result="displaced"/>
+      <feGaussianBlur in="displaced" stdDeviation="1.2" result="blurred"/>
+      <feComposite in="blurred" in2="SourceGraphic" operator="in"/>
+    </filter>
+    <filter id="softBlur">
+      <feGaussianBlur stdDeviation="2"/>
+    </filter>
+    <filter id="glow">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feComposite in="SourceGraphic" in2="blur" operator="over"/>
+    </filter>
+
+    <!-- Sky gradients -->
+    <linearGradient id="skyL" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#b0cce0"/>
+      <stop offset="35%" stop-color="#d8e8f4"/>
+      <stop offset="70%" stop-color="#eddff0"/>
+      <stop offset="100%" stop-color="#f5e6ef"/>
+    </linearGradient>
+    <linearGradient id="skyR" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#aec8e0"/>
+      <stop offset="35%" stop-color="#d4e4f0"/>
+      <stop offset="70%" stop-color="#eadaf0"/>
+      <stop offset="100%" stop-color="#f2e0ee"/>
+    </linearGradient>
+
+    <!-- Ground -->
+    <linearGradient id="groundL" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#c8d8a0"/>
+      <stop offset="100%" stop-color="#a0b870"/>
+    </linearGradient>
+    <linearGradient id="groundR" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#90a868"/>
+      <stop offset="100%" stop-color="#6a8448"/>
+    </linearGradient>
+
+    <!-- Fountain pool -->
+    <radialGradient id="pool" cx="50%" cy="40%" r="60%">
+      <stop offset="0%" stop-color="#c4dff0" stop-opacity="0.95"/>
+      <stop offset="60%" stop-color="#88b8d8" stop-opacity="0.85"/>
+      <stop offset="100%" stop-color="#5090b8" stop-opacity="0.7"/>
+    </radialGradient>
+
+    <!-- Canopy pinks -->
+    <radialGradient id="cpink" cx="50%" cy="40%" r="65%">
+      <stop offset="0%" stop-color="#ffe0ec"/>
+      <stop offset="45%" stop-color="#ffb8ce"/>
+      <stop offset="100%" stop-color="#ff90aa" stop-opacity="0.6"/>
+    </radialGradient>
+    <radialGradient id="cwhite" cx="50%" cy="40%" r="65%">
+      <stop offset="0%" stop-color="#fff8fb"/>
+      <stop offset="45%" stop-color="#ffe8f2"/>
+      <stop offset="100%" stop-color="#ffd0e4" stop-opacity="0.65"/>
+    </radialGradient>
+    <radialGradient id="cdeep" cx="50%" cy="35%" r="60%">
+      <stop offset="0%" stop-color="#ffd0e4"/>
+      <stop offset="50%" stop-color="#ff98bc"/>
+      <stop offset="100%" stop-color="#ee6898" stop-opacity="0.55"/>
+    </radialGradient>
+
+    <!-- Stone architecture -->
+    <linearGradient id="stone" x1="0" y1="0" x2="0.2" y2="1">
+      <stop offset="0%" stop-color="#ddd4c0"/>
+      <stop offset="50%" stop-color="#c8bc9c"/>
+      <stop offset="100%" stop-color="#b0a080"/>
+    </linearGradient>
+    <linearGradient id="stoneShad" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#b0a080"/>
+      <stop offset="100%" stop-color="#d8caa8"/>
+    </linearGradient>
+
+    <!-- Pagoda roof -->
+    <linearGradient id="roof" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#c02000"/>
+      <stop offset="60%" stop-color="#8a1400"/>
+      <stop offset="100%" stop-color="#600c00"/>
+    </linearGradient>
+    <linearGradient id="roofBody" x1="0" y1="0" x2="0.1" y2="1">
+      <stop offset="0%" stop-color="#c82800"/>
+      <stop offset="100%" stop-color="#a01e00"/>
+    </linearGradient>
+
+    <!-- Water shimmer gradient -->
+    <linearGradient id="waterShimmer" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#a0ccec" stop-opacity="0.3"/>
+      <stop offset="30%" stop-color="#ffffff" stop-opacity="0.5"/>
+      <stop offset="60%" stop-color="#a0ccec" stop-opacity="0.2"/>
+      <stop offset="100%" stop-color="#c0dff5" stop-opacity="0.4"/>
+    </linearGradient>
+
+    <!-- Clip paths -->
+    <clipPath id="clipL"><rect x="0" y="0" width="600" height="600"/></clipPath>
+    <clipPath id="clipR"><rect x="600" y="0" width="600" height="600"/></clipPath>
+
+    <!-- Vignette -->
+    <radialGradient id="vig" cx="50%" cy="50%" r="70%">
+      <stop offset="55%" stop-color="transparent"/>
+      <stop offset="100%" stop-color="#b090a0" stop-opacity="0.3"/>
+    </radialGradient>
+  </defs>
+
+
+  <!-- ════════════════════════════════════════════
+       LEFT SCENE  –  UW Seattle / Drumheller Fountain
+       ════════════════════════════════════════════ -->
+  <g clip-path="url(#clipL)">
+
+    <!-- Sky wash -->
+    <rect x="0" y="0" width="600" height="600" fill="url(#skyL)"/>
+
+    <!-- Soft watercolor sky blush clouds -->
+    <ellipse cx="120" cy="80" rx="130" ry="55" fill="#ffe0ec" opacity="0.18" filter="url(#softBlur)"/>
+    <ellipse cx="400" cy="60" rx="160" ry="60" fill="#e8d8f4" opacity="0.18" filter="url(#softBlur)"/>
+    <ellipse cx="550" cy="100" rx="90" ry="40" fill="#ffd8e8" opacity="0.15" filter="url(#softBlur)"/>
+
+    <!-- Distant tree line wash -->
+    <path d="M0,300 Q60,265 120,275 Q180,258 240,268 Q300,250 360,262 Q420,248 480,260 Q540,248 600,255 L600,310 Q540,300 480,308 Q420,298 360,308 Q300,296 240,308 Q180,298 120,308 Q60,298 0,308 Z"
+          fill="#b8d0a0" opacity="0.35" filter="url(#softBlur)"/>
+
+    <!-- Background cherry blossom haze -->
+    <ellipse cx="60"  cy="235" rx="75"  ry="52" fill="#ffcce0" opacity="0.28" filter="url(#softBlur)"/>
+    <ellipse cx="190" cy="215" rx="95"  ry="62" fill="#ffd8e8" opacity="0.32" filter="url(#softBlur)"/>
+    <ellipse cx="370" cy="222" rx="85"  ry="55" fill="#ffcce0" opacity="0.28" filter="url(#softBlur)"/>
+    <ellipse cx="540" cy="208" rx="70"  ry="48" fill="#ffd4e4" opacity="0.28" filter="url(#softBlur)"/>
+
+    <!-- ── Suzzallo Library style Gothic building ── -->
+    <!-- Building main body -->
+    <rect x="148" y="158" width="304" height="230" fill="url(#stone)" filter="url(#wc)"/>
+    <!-- Side shading -->
+    <rect x="148" y="158" width="304" height="230" fill="url(#stoneShad)" opacity="0.15"/>
+
+    <!-- Gothic parapet crenellation along top -->
+    <rect x="148" y="140" width="304" height="22" fill="#ccc0a0"/>
+    <g fill="#bbb090">
+      <rect x="152" y="128" width="18" height="16"/>
+      <rect x="178" y="128" width="18" height="16"/>
+      <rect x="204" y="128" width="18" height="16"/>
+      <rect x="230" y="128" width="18" height="16"/>
+      <rect x="256" y="128" width="18" height="16"/>
+      <rect x="282" y="128" width="18" height="16"/>
+      <rect x="308" y="128" width="18" height="16"/>
+      <rect x="334" y="128" width="18" height="16"/>
+      <rect x="360" y="128" width="18" height="16"/>
+      <rect x="386" y="128" width="18" height="16"/>
+      <rect x="412" y="128" width="18" height="16"/>
+      <rect x="438" y="128" width="18" height="16"/>
+    </g>
+
+    <!-- Side towers -->
+    <rect x="148" y="100" width="45" height="62" fill="#d0c49a"/>
+    <rect x="407" y="100" width="45" height="62" fill="#d0c49a"/>
+    <!-- Tower tops (pyramidal) -->
+    <polygon points="148,100 170,72 193,100" fill="#bbb080"/>
+    <polygon points="407,100 429,72 452,100" fill="#bbb080"/>
+    <!-- Tower windows -->
+    <rect x="158" y="108" width="12" height="20" fill="#7888a0" rx="2"/>
+    <rect x="178" y="108" width="12" height="20" fill="#7888a0" rx="2"/>
+    <path d="M158,108 Q164,98 170,108" fill="#9090b0"/>
+    <path d="M178,108 Q184,98 190,108" fill="#9090b0"/>
+    <rect x="418" y="108" width="12" height="20" fill="#7888a0" rx="2"/>
+    <rect x="438" y="108" width="12" height="20" fill="#7888a0" rx="2"/>
+    <path d="M418,108 Q424,98 430,108" fill="#9090b0"/>
+    <path d="M438,108 Q444,98 450,108" fill="#9090b0"/>
+
+    <!-- Flying buttresses suggestion -->
+    <line x1="148" y1="250" x2="125" y2="290" stroke="#c0b090" stroke-width="6" opacity="0.7"/>
+    <line x1="148" y1="220" x2="118" y2="260" stroke="#c0b090" stroke-width="4" opacity="0.5"/>
+    <line x1="452" y1="250" x2="475" y2="290" stroke="#c0b090" stroke-width="6" opacity="0.7"/>
+    <line x1="452" y1="220" x2="482" y2="260" stroke="#c0b090" stroke-width="4" opacity="0.5"/>
+
+    <!-- Gothic arched windows (row 1) -->
+    <g fill="#7888a8" opacity="0.75">
+      <rect x="163" y="168" width="22" height="38"/>
+      <path d="M163,168 Q174,152 185,168" fill="#8898b8"/>
+      <rect x="196" y="168" width="22" height="38"/>
+      <path d="M196,168 Q207,152 218,168" fill="#8898b8"/>
+      <rect x="229" y="168" width="22" height="38"/>
+      <path d="M229,168 Q240,152 251,168" fill="#8898b8"/>
+      <rect x="262" y="168" width="22" height="38"/>
+      <path d="M262,168 Q273,152 284,168" fill="#8898b8"/>
+      <rect x="295" y="168" width="22" height="38"/>
+      <path d="M295,168 Q306,152 317,168" fill="#8898b8"/>
+      <rect x="328" y="168" width="22" height="38"/>
+      <path d="M328,168 Q339,152 350,168" fill="#8898b8"/>
+      <rect x="361" y="168" width="22" height="38"/>
+      <path d="M361,168 Q372,152 383,168" fill="#8898b8"/>
+      <rect x="394" y="168" width="22" height="38"/>
+      <path d="M394,168 Q405,152 416,168" fill="#8898b8"/>
+      <rect x="427" y="168" width="22" height="38"/>
+      <path d="M427,168 Q438,152 449,168" fill="#8898b8"/>
+    </g>
+
+    <!-- Gothic arched windows (row 2, slightly larger) -->
+    <g fill="#6878a0" opacity="0.65">
+      <rect x="163" y="222" width="28" height="52"/>
+      <path d="M163,222 Q177,204 191,222" fill="#7888b0"/>
+      <rect x="202" y="222" width="28" height="52"/>
+      <path d="M202,222 Q216,204 230,222" fill="#7888b0"/>
+      <rect x="241" y="222" width="28" height="52"/>
+      <path d="M241,222 Q255,204 269,222" fill="#7888b0"/>
+      <rect x="280" y="222" width="28" height="52"/>
+      <path d="M280,222 Q294,204 308,222" fill="#7888b0"/>
+      <rect x="319" y="222" width="28" height="52"/>
+      <path d="M319,222 Q333,204 347,222" fill="#7888b0"/>
+      <rect x="358" y="222" width="28" height="52"/>
+      <path d="M358,222 Q372,204 386,222" fill="#7888b0"/>
+      <rect x="397" y="222" width="28" height="52"/>
+      <path d="M397,222 Q411,204 425,222" fill="#7888b0"/>
+    </g>
+
+    <!-- Central entrance arch -->
+    <rect x="258" y="290" width="84" height="98" fill="#9a8868"/>
+    <path d="M258,290 Q300,255 342,290" fill="#a89878"/>
+    <!-- Door detail -->
+    <rect x="272" y="320" width="24" height="68" fill="#3a2810"/>
+    <rect x="304" y="320" width="24" height="68" fill="#3a2810"/>
+    <!-- Arch tracery lines -->
+    <path d="M268,290 Q300,262 332,290" fill="none" stroke="#c0b088" stroke-width="2" opacity="0.5"/>
+
+    <!-- Building shadow / depth -->
+    <rect x="148" y="158" width="20" height="230" fill="#000000" opacity="0.06"/>
+
+    <!-- ── Ground Lawn ── -->
+    <rect x="0" y="388" width="600" height="212" fill="url(#groundL)" filter="url(#wc)"/>
+    <!-- Lawn highlight -->
+    <ellipse cx="300" cy="420" rx="250" ry="40" fill="#d8e8a8" opacity="0.3" filter="url(#softBlur)"/>
+
+    <!-- Path to fountain -->
+    <rect x="262" y="388" width="76" height="110" fill="#c8c0a0" opacity="0.5" rx="4"/>
+
+    <!-- ── Drumheller Fountain ── -->
+    <!-- Outer shadow/reflection -->
+    <ellipse cx="300" cy="480" rx="158" ry="62" fill="#6090b0" opacity="0.2" filter="url(#softBlur)"/>
+    <!-- Pool water -->
+    <ellipse cx="300" cy="474" rx="148" ry="58" fill="url(#pool)" filter="url(#wc)"/>
+    <!-- Pool rim (stone curb) -->
+    <ellipse cx="300" cy="474" rx="148" ry="58" fill="none" stroke="#aabcc8" stroke-width="5" opacity="0.7"/>
+    <ellipse cx="300" cy="474" rx="142" ry="54" fill="none" stroke="#ccdde8" stroke-width="2" opacity="0.5"/>
+    <!-- Water shimmer highlights -->
+    <ellipse cx="285" cy="465" rx="45" ry="14" fill="url(#waterShimmer)" opacity="0.7"/>
+    <ellipse cx="330" cy="480" rx="30" ry="10" fill="#ffffff" opacity="0.2"/>
+    <ellipse cx="260" cy="480" rx="20" ry="6" fill="#ffffff" opacity="0.18"/>
+    <!-- Petal reflections in pool -->
+    <ellipse cx="268" cy="472" rx="6" ry="2" fill="#ffbbdd" opacity="0.4" transform="rotate(-10,268,472)"/>
+    <ellipse cx="338" cy="468" rx="5" ry="2" fill="#ffaac8" opacity="0.35" transform="rotate(15,338,468)"/>
+
+    <!-- Fountain pedestal -->
+    <ellipse cx="300" cy="455" rx="22" ry="9" fill="#c8b888"/>
+    <rect x="291" y="420" width="18" height="37" fill="#d0c090"/>
+    <ellipse cx="300" cy="420" rx="26" ry="10" fill="#dcd0a8"/>
+    <ellipse cx="300" cy="418" rx="18" ry="7" fill="#ccc0a0"/>
+
+    <!-- Fountain water jets -->
+    <!-- Central tall jet -->
+    <path d="M299,416 C297,390 296,365 299,338 C302,365 303,390 301,416 Z" fill="#b8dcf4" opacity="0.75"/>
+    <path d="M300,415 Q299,378 300,340 Q301,378 300,415" fill="#d8eff8" opacity="0.5"/>
+    <!-- Upper spray droplets at top of center jet -->
+    <circle cx="299" cy="338" r="3" fill="#d8eef8" opacity="0.7"/>
+    <circle cx="301" cy="342" r="2" fill="#e8f4fc" opacity="0.6"/>
+    <circle cx="297" cy="344" r="2" fill="#e0f0f8" opacity="0.6"/>
+
+    <!-- Mid-ring jets (8 jets angled out) -->
+    <path d="M300,415 Q285,393 266,374" stroke="#b0d0ec" stroke-width="3" fill="none" stroke-linecap="round" opacity="0.7"/>
+    <path d="M300,415 Q315,393 334,374" stroke="#b0d0ec" stroke-width="3" fill="none" stroke-linecap="round" opacity="0.7"/>
+    <path d="M300,415 Q278,395 256,379" stroke="#a8c8e4" stroke-width="2.5" fill="none" stroke-linecap="round" opacity="0.6"/>
+    <path d="M300,415 Q322,395 344,379" stroke="#a8c8e4" stroke-width="2.5" fill="none" stroke-linecap="round" opacity="0.6"/>
+    <path d="M300,415 Q282,396 262,384" stroke="#a0c0dc" stroke-width="2" fill="none" stroke-linecap="round" opacity="0.5"/>
+    <path d="M300,415 Q318,396 338,384" stroke="#a0c0dc" stroke-width="2" fill="none" stroke-linecap="round" opacity="0.5"/>
+    <path d="M300,415 Q300,396 300,378" stroke="#b8d8f0" stroke-width="2.5" fill="none" stroke-linecap="round" opacity="0.55"/>
+    <!-- Spray endpoints -->
+    <circle cx="266" cy="374" r="2.5" fill="#d0e8f8" opacity="0.8"/>
+    <circle cx="334" cy="374" r="2.5" fill="#d0e8f8" opacity="0.8"/>
+    <circle cx="256" cy="379" r="2" fill="#c8e4f4" opacity="0.7"/>
+    <circle cx="344" cy="379" r="2" fill="#c8e4f4" opacity="0.7"/>
+    <circle cx="262" cy="384" r="2" fill="#c0ddf0" opacity="0.65"/>
+    <circle cx="338" cy="384" r="2" fill="#c0ddf0" opacity="0.65"/>
+
+    <!-- Low outer ring spray (wider arcs) -->
+    <path d="M300,418 Q270,405 245,398" stroke="#90b8d8" stroke-width="2" fill="none" stroke-linecap="round" opacity="0.5"/>
+    <path d="M300,418 Q330,405 355,398" stroke="#90b8d8" stroke-width="2" fill="none" stroke-linecap="round" opacity="0.5"/>
+    <path d="M300,420 Q268,410 242,408" stroke="#88b0d0" stroke-width="1.5" fill="none" stroke-linecap="round" opacity="0.4"/>
+    <path d="M300,420 Q332,410 358,408" stroke="#88b0d0" stroke-width="1.5" fill="none" stroke-linecap="round" opacity="0.4"/>
+
+    <!-- ── Cherry blossom trees ── -->
+    <!-- FAR LEFT tree (partially cut off) -->
+    <path d="M-10,580 Q0,530 8,480 Q14,440 20,400 Q25,368 30,338" stroke="#7a5030" stroke-width="9" fill="none" stroke-linecap="round"/>
+    <path d="M30,338 Q38,308 46,285" stroke="#7a5030" stroke-width="5" fill="none"/>
+    <path d="M30,338 Q20,310 14,285" stroke="#7a5030" stroke-width="4" fill="none"/>
+    <ellipse cx="32" cy="258" rx="72" ry="65" fill="url(#cpink)" opacity="0.85" filter="url(#wc)"/>
+    <ellipse cx="18" cy="272" rx="52" ry="48" fill="#ffcce0" opacity="0.6"/>
+    <ellipse cx="48" cy="255" rx="60" ry="54" fill="#ffd4e6" opacity="0.55"/>
+    <ellipse cx="28" cy="244" rx="65" ry="58" fill="#ffbbcc" opacity="0.35" filter="url(#softBlur)"/>
+
+    <!-- LEFT MAIN tree -->
+    <path d="M105,580 Q108,530 112,478 Q115,440 118,400 Q122,368 126,335" stroke="#7a5030" stroke-width="10" fill="none" stroke-linecap="round"/>
+    <path d="M126,335 Q134,305 143,278" stroke="#7a5030" stroke-width="6" fill="none"/>
+    <path d="M126,335 Q115,306 108,280" stroke="#7a5030" stroke-width="5" fill="none"/>
+    <path d="M126,335 Q138,315 150,300" stroke="#7a5030" stroke-width="4" fill="none"/>
+    <!-- Lower branch -->
+    <path d="M118,400 Q100,380 88,362" stroke="#7a5030" stroke-width="4" fill="none"/>
+    <ellipse cx="78" cy="352" rx="38" ry="34" fill="#ffcce0" opacity="0.72"/>
+    <!-- Canopy -->
+    <ellipse cx="132" cy="250" rx="90" ry="80" fill="url(#cpink)" opacity="0.88" filter="url(#wc)"/>
+    <ellipse cx="112" cy="265" rx="65" ry="60" fill="#ffcce0" opacity="0.62"/>
+    <ellipse cx="150" cy="248" rx="72" ry="65" fill="#ffd8e8" opacity="0.58"/>
+    <ellipse cx="128" cy="238" rx="80" ry="72" fill="#ffbbcc" opacity="0.38" filter="url(#softBlur)"/>
+    <!-- Blossom clusters detail -->
+    <g opacity="0.75">
+      <circle cx="110" cy="238" r="6" fill="#ffd8ee"/>
+      <circle cx="130" cy="225" r="5" fill="#ffc0d8"/>
+      <circle cx="150" cy="240" r="6" fill="#ffd4e8"/>
+      <circle cx="118" cy="258" r="5" fill="#ffc8dc"/>
+      <circle cx="145" cy="255" r="5" fill="#ffd8ee"/>
+      <circle cx="96" cy="252" r="4" fill="#ffcce4"/>
+      <circle cx="138" cy="268" r="4" fill="#ffb8d0"/>
+    </g>
+
+    <!-- Small MID-LEFT tree -->
+    <path d="M208,560 Q210,528 213,498 Q216,472 219,448 Q221,430 223,412" stroke="#6a4422" stroke-width="6" fill="none" stroke-linecap="round"/>
+    <path d="M223,412 Q228,390 234,372" stroke="#6a4422" stroke-width="4" fill="none"/>
+    <path d="M223,412 Q216,390 211,372" stroke="#6a4422" stroke-width="3" fill="none"/>
+    <ellipse cx="224" cy="352" rx="52" ry="46" fill="url(#cwhite)" opacity="0.82" filter="url(#wc)"/>
+    <ellipse cx="218" cy="362" rx="40" ry="36" fill="#ffeef4" opacity="0.65"/>
+    <ellipse cx="232" cy="348" rx="46" ry="42" fill="#ffe8f2" opacity="0.6"/>
+
+    <!-- Small MID-RIGHT tree -->
+    <path d="M392,560 Q390,528 387,498 Q384,472 381,448 Q379,430 377,412" stroke="#6a4422" stroke-width="6" fill="none" stroke-linecap="round"/>
+    <path d="M377,412 Q372,390 366,372" stroke="#6a4422" stroke-width="4" fill="none"/>
+    <path d="M377,412 Q384,390 389,372" stroke="#6a4422" stroke-width="3" fill="none"/>
+    <ellipse cx="376" cy="352" rx="52" ry="46" fill="url(#cpink)" opacity="0.82" filter="url(#wc)"/>
+    <ellipse cx="382" cy="362" rx="40" ry="36" fill="#ffd0e4" opacity="0.65"/>
+    <ellipse cx="370" cy="348" rx="46" ry="42" fill="#ffccdc" opacity="0.6"/>
+
+    <!-- RIGHT MAIN tree -->
+    <path d="M510,580 Q507,530 504,478 Q501,440 498,400 Q495,368 492,335" stroke="#7a5030" stroke-width="10" fill="none" stroke-linecap="round"/>
+    <path d="M492,335 Q484,305 477,278" stroke="#7a5030" stroke-width="6" fill="none"/>
+    <path d="M492,335 Q502,306 509,280" stroke="#7a5030" stroke-width="5" fill="none"/>
+    <path d="M492,335 Q480,315 470,300" stroke="#7a5030" stroke-width="4" fill="none"/>
+    <!-- Lower branch -->
+    <path d="M498,400 Q516,380 528,362" stroke="#7a5030" stroke-width="4" fill="none"/>
+    <ellipse cx="538" cy="352" rx="38" ry="34" fill="#ffd8e8" opacity="0.72"/>
+    <!-- Canopy -->
+    <ellipse cx="486" cy="250" rx="90" ry="80" fill="url(#cwhite)" opacity="0.88" filter="url(#wc)"/>
+    <ellipse cx="505" cy="265" rx="66" ry="60" fill="#ffeef6" opacity="0.62"/>
+    <ellipse cx="470" cy="248" rx="74" ry="65" fill="#ffe8f4" opacity="0.58"/>
+    <ellipse cx="488" cy="238" rx="82" ry="72" fill="#ffd8e8" opacity="0.38" filter="url(#softBlur)"/>
+    <!-- Blossom clusters detail -->
+    <g opacity="0.75">
+      <circle cx="490" cy="238" r="6" fill="#fff4fa"/>
+      <circle cx="468" cy="225" r="5" fill="#ffeaf4"/>
+      <circle cx="508" cy="242" r="6" fill="#fff0f8"/>
+      <circle cx="478" cy="258" r="5" fill="#ffe4f0"/>
+      <circle cx="502" cy="255" r="5" fill="#fff4fa"/>
+      <circle cx="462" cy="252" r="4" fill="#ffd8ec"/>
+      <circle cx="488" cy="270" r="4" fill="#ffe0ee"/>
+    </g>
+
+    <!-- FAR RIGHT tree (partially cut off) -->
+    <path d="M614,580 Q610,530 607,480 Q604,440 601,400 Q598,368 595,338" stroke="#7a5030" stroke-width="9" fill="none" stroke-linecap="round"/>
+    <ellipse cx="592" cy="258" rx="72" ry="65" fill="url(#cdeep)" opacity="0.82" filter="url(#wc)"/>
+    <ellipse cx="578" cy="272" rx="52" ry="48" fill="#ffccdc" opacity="0.6"/>
+
+    <!-- Scattered petals on ground -->
+    <g opacity="0.65">
+      <ellipse cx="168" cy="528" rx="5" ry="2.2" fill="#ffaac8" transform="rotate(-18,168,528)"/>
+      <ellipse cx="215" cy="515" rx="4.5" ry="2" fill="#ffbbcc" transform="rotate(25,215,515)"/>
+      <ellipse cx="258" cy="530" rx="5" ry="2.2" fill="#ffaac0" transform="rotate(-8,258,530)"/>
+      <ellipse cx="300" cy="520" rx="4" ry="2" fill="#ffbbdd" transform="rotate(35,300,520)"/>
+      <ellipse cx="345" cy="512" rx="5" ry="2.2" fill="#ffaacc" transform="rotate(-22,345,512)"/>
+      <ellipse cx="398" cy="525" rx="4.5" ry="2" fill="#ffbbcc" transform="rotate(12,398,525)"/>
+      <ellipse cx="445" cy="518" rx="5" ry="2.2" fill="#ffaac8" transform="rotate(-30,445,518)"/>
+      <ellipse cx="490" cy="530" rx="4" ry="2" fill="#ffbbdd" transform="rotate(18,490,530)"/>
+      <ellipse cx="140" cy="510" rx="4.5" ry="2" fill="#ffccdd" transform="rotate(40,140,510)"/>
+      <ellipse cx="530" cy="510" rx="4" ry="2" fill="#ffbbcc" transform="rotate(-14,530,510)"/>
+    </g>
+
+    <!-- Falling petals (in air) -->
+    <g opacity="0.72">
+      <ellipse cx="152" cy="340" rx="4.5" ry="2" fill="#ffbbdd" transform="rotate(22,152,340)"/>
+      <ellipse cx="195" cy="358" rx="3.5" ry="1.8" fill="#ffc8d8" transform="rotate(-14,195,358)"/>
+      <ellipse cx="240" cy="318" rx="4.5" ry="2" fill="#ffaac8" transform="rotate(38,240,318)"/>
+      <ellipse cx="172" cy="390" rx="3.5" ry="1.8" fill="#ffbbdd" transform="rotate(-28,172,390)"/>
+      <ellipse cx="445" cy="328" rx="4.5" ry="2" fill="#ffd0e4" transform="rotate(14,445,328)"/>
+      <ellipse cx="475" cy="360" rx="3.5" ry="1.8" fill="#ffbbcc" transform="rotate(-22,475,360)"/>
+      <ellipse cx="395" cy="308" rx="4.5" ry="2" fill="#ffcce0" transform="rotate(32,395,308)"/>
+      <ellipse cx="330" cy="290" rx="4" ry="1.8" fill="#ffaac8" transform="rotate(-10,330,290)"/>
+      <ellipse cx="280" cy="340" rx="3.5" ry="1.8" fill="#ffbbdd" transform="rotate(44,280,340)"/>
+      <ellipse cx="420" cy="390" rx="4" ry="1.8" fill="#ffcce0" transform="rotate(-34,420,390)"/>
+    </g>
+
+    <!-- Scene label -->
+    <rect x="0" y="570" width="600" height="30" fill="#f5eaee" opacity="0.6"/>
+    <text x="300" y="590" text-anchor="middle" font-family="Georgia, 'Times New Roman', serif"
+          font-size="14" fill="#6a3850" opacity="0.9" letter-spacing="1">
+      UW Seattle — Drumheller Fountain
+    </text>
+  </g>
+
+
+  <!-- ════════════════════════════════════════════
+       RIGHT SCENE  –  Tokyo / Senso-ji Pagoda
+       ════════════════════════════════════════════ -->
+  <g clip-path="url(#clipR)">
+
+    <!-- Sky wash -->
+    <rect x="600" y="0" width="600" height="600" fill="url(#skyR)"/>
+
+    <!-- Soft clouds / sky blush -->
+    <ellipse cx="720"  cy="75" rx="120" ry="50" fill="#ffe8f0" opacity="0.18" filter="url(#softBlur)"/>
+    <ellipse cx="980"  cy="55" rx="150" ry="55" fill="#e0d8f4" opacity="0.17" filter="url(#softBlur)"/>
+    <ellipse cx="1160" cy="95" rx="85"  ry="38" fill="#ffd8e8" opacity="0.15" filter="url(#softBlur)"/>
+
+    <!-- Misty distant mountains -->
+    <path d="M600,360 Q660,290 740,310 Q820,278 900,298 Q990,262 1080,285 Q1150,268 1200,285
+             L1200,390 L600,390 Z" fill="#b0c4d8" opacity="0.22" filter="url(#softBlur)"/>
+    <path d="M600,390 Q680,335 770,352 Q860,318 940,338 Q1020,308 1100,328 Q1160,315 1200,328
+             L1200,408 L600,408 Z" fill="#c0ced8" opacity="0.18" filter="url(#softBlur)"/>
+
+    <!-- Background blossom haze -->
+    <ellipse cx="635"  cy="230" rx="72" ry="52" fill="#ffd0e0" opacity="0.28" filter="url(#softBlur)"/>
+    <ellipse cx="730"  cy="210" rx="90" ry="62" fill="#ffcce0" opacity="0.32" filter="url(#softBlur)"/>
+    <ellipse cx="1105" cy="220" rx="82" ry="58" fill="#ffd4e4" opacity="0.28" filter="url(#softBlur)"/>
+    <ellipse cx="1185" cy="238" rx="68" ry="50" fill="#ffcce0" opacity="0.28" filter="url(#softBlur)"/>
+
+    <!-- ── 5-story Senso-ji style Pagoda ── -->
+    <!-- BASE PLATFORM -->
+    <rect x="825" y="448" width="150" height="16" fill="#c8b888" rx="2"/>
+    <rect x="818" y="464" width="164" height="12" fill="#b8a878" rx="2"/>
+    <rect x="808" y="476" width="184" height="14" fill="#a89868" rx="3"/>
+
+    <!-- STORY 1 (bottom) -->
+    <rect x="835" y="390" width="130" height="58" fill="url(#roofBody)"/>
+    <!-- Story 1 windows/door -->
+    <rect x="868" y="408" width="26" height="40" fill="#2a1600" rx="2"/>
+    <rect x="906" y="408" width="26" height="40" fill="#2a1600" rx="2"/>
+    <rect x="848" y="415" width="14" height="22" fill="#2a1600" rx="1"/>
+    <rect x="938" y="415" width="14" height="22" fill="#2a1600" rx="1"/>
+    <!-- Story 1 beam line -->
+    <rect x="832" y="388" width="136" height="7" fill="#8a1400"/>
+    <!-- ROOF 1 (large, dramatic eave) -->
+    <path d="M785,388 Q900,358 1015,388 L1008,381 Q900,353 792,381 Z" fill="url(#roof)"/>
+    <!-- Eave upcurve tips -->
+    <path d="M785,388 Q775,378 778,366" stroke="#7a1200" stroke-width="3" fill="none" stroke-linecap="round"/>
+    <path d="M1015,388 Q1025,378 1022,366" stroke="#7a1200" stroke-width="3" fill="none" stroke-linecap="round"/>
+    <!-- Roof underside detail -->
+    <path d="M792,381 Q900,351 1008,381 L1015,388 Q900,358 785,388 Z" fill="#c82800" opacity="0.4"/>
+
+    <!-- STORY 2 -->
+    <rect x="848" y="335" width="104" height="55" fill="url(#roofBody)"/>
+    <!-- Story 2 windows -->
+    <rect x="876" y="350" width="18" height="30" fill="#2a1600" rx="1"/>
+    <rect x="906" y="350" width="18" height="30" fill="#2a1600" rx="1"/>
+    <rect x="860" y="356" width="10" height="18" fill="#2a1600" rx="1"/>
+    <rect x="930" y="356" width="10" height="18" fill="#2a1600" rx="1"/>
+    <!-- Story 2 beam -->
+    <rect x="845" y="333" width="110" height="7" fill="#8a1400"/>
+    <!-- ROOF 2 -->
+    <path d="M800,333 Q900,306 1000,333 L993,327 Q900,302 807,327 Z" fill="url(#roof)"/>
+    <path d="M800,333 Q790,324 793,313" stroke="#7a1200" stroke-width="2.5" fill="none" stroke-linecap="round"/>
+    <path d="M1000,333 Q1010,324 1007,313" stroke="#7a1200" stroke-width="2.5" fill="none" stroke-linecap="round"/>
+    <path d="M807,327 Q900,300 993,327 L1000,333 Q900,306 800,333 Z" fill="#c82800" opacity="0.38"/>
+
+    <!-- STORY 3 -->
+    <rect x="860" y="282" width="80" height="53" fill="url(#roofBody)"/>
+    <!-- Story 3 windows -->
+    <rect x="882" y="297" width="14" height="25" fill="#2a1600" rx="1"/>
+    <rect x="904" y="297" width="14" height="25" fill="#2a1600" rx="1"/>
+    <!-- Story 3 beam -->
+    <rect x="857" y="280" width="86" height="7" fill="#8a1400"/>
+    <!-- ROOF 3 -->
+    <path d="M818,280 Q900,256 982,280 L976,275 Q900,252 824,275 Z" fill="url(#roof)"/>
+    <path d="M818,280 Q808,271 811,262" stroke="#7a1200" stroke-width="2" fill="none" stroke-linecap="round"/>
+    <path d="M982,280 Q992,271 989,262" stroke="#7a1200" stroke-width="2" fill="none" stroke-linecap="round"/>
+    <path d="M824,275 Q900,250 976,275 L982,280 Q900,256 818,280 Z" fill="#c82800" opacity="0.36"/>
+
+    <!-- STORY 4 -->
+    <rect x="872" y="230" width="56" height="52" fill="url(#roofBody)"/>
+    <!-- Story 4 windows -->
+    <rect x="886" y="245" width="10" height="22" fill="#2a1600" rx="1"/>
+    <rect x="904" y="245" width="10" height="22" fill="#2a1600" rx="1"/>
+    <!-- Story 4 beam -->
+    <rect x="869" y="228" width="62" height="7" fill="#8a1400"/>
+    <!-- ROOF 4 -->
+    <path d="M836,228 Q900,207 964,228 L958,223 Q900,203 842,223 Z" fill="url(#roof)"/>
+    <path d="M836,228 Q827,220 830,211" stroke="#7a1200" stroke-width="2" fill="none" stroke-linecap="round"/>
+    <path d="M964,228 Q973,220 970,211" stroke="#7a1200" stroke-width="2" fill="none" stroke-linecap="round"/>
+    <path d="M842,223 Q900,201 958,223 L964,228 Q900,207 836,228 Z" fill="#c82800" opacity="0.34"/>
+
+    <!-- STORY 5 (top) -->
+    <rect x="882" y="180" width="36" height="50" fill="url(#roofBody)"/>
+    <!-- Story 5 tiny window -->
+    <rect x="893" y="195" width="7" height="18" fill="#2a1600" rx="1"/>
+    <rect x="900" y="195" width="7" height="18" fill="#2a1600" rx="1"/>
+    <!-- Story 5 beam -->
+    <rect x="879" y="178" width="42" height="6" fill="#8a1400"/>
+    <!-- ROOF 5 -->
+    <path d="M852,178 Q900,160 948,178 L943,174 Q900,157 857,174 Z" fill="url(#roof)"/>
+    <path d="M852,178 Q844,171 847,163" stroke="#7a1200" stroke-width="1.8" fill="none" stroke-linecap="round"/>
+    <path d="M948,178 Q956,171 953,163" stroke="#7a1200" stroke-width="1.8" fill="none" stroke-linecap="round"/>
+    <path d="M857,174 Q900,155 943,174 L948,178 Q900,160 852,178 Z" fill="#c82800" opacity="0.32"/>
+
+    <!-- SPIRE / SORIN -->
+    <rect x="897" y="115" width="6" height="65" fill="#9a7828"/>
+    <!-- Spire rings (suien) -->
+    <ellipse cx="900" cy="114" r="7"   fill="#c8a030"/>
+    <ellipse cx="900" cy="105" r="5.5" fill="#b89028"/>
+    <ellipse cx="900" cy="97"  r="4.8" fill="#b09020"/>
+    <ellipse cx="900" cy="90"  r="4.2" fill="#a88020"/>
+    <ellipse cx="900" cy="84"  r="3.8" fill="#a87818"/>
+    <ellipse cx="900" cy="79"  r="3.4" fill="#986810"/>
+    <ellipse cx="900" cy="75"  r="2.5" fill="#906008"/>
+    <!-- Tip -->
+    <path d="M899,74 Q900,68 901,74" fill="#808000"/>
+
+    <!-- ── Torii Gate ── -->
+    <!-- Left post (hashira) -->
+    <rect x="758" y="395" width="13" height="115" fill="#cc2200" rx="2"/>
+    <!-- Right post -->
+    <rect x="886" y="395" width="13" height="115" fill="#cc2200" rx="2"/>
+    <!-- Top beam - kasagi (slightly wider, upturned ends) -->
+    <path d="M748,388 Q757,385 770,388 L886,388 Q896,385 910,388 Q896,382 886,385 L770,385 Q757,382 748,388 Z"
+          fill="#bb1e00"/>
+    <rect x="748" y="382" width="162" height="11" fill="#cc2200" rx="2"/>
+    <!-- Kasagi end caps -->
+    <path d="M748,382 Q742,379 745,374" stroke="#aa1800" stroke-width="2" fill="none"/>
+    <path d="M910,382 Q916,379 913,374" stroke="#aa1800" stroke-width="2" fill="none"/>
+    <!-- Lower beam (nuki) -->
+    <rect x="761" y="404" width="135" height="9" fill="#bb1e00" rx="1"/>
+    <!-- Post caps (gakozuka) -->
+    <rect x="756" y="386" width="17" height="9" fill="#992000" rx="1"/>
+    <rect x="884" y="386" width="17" height="9" fill="#992000" rx="1"/>
+    <!-- Wedge pegs (kusabi) on nuki -->
+    <rect x="792" y="402" width="5" height="13" fill="#881800"/>
+    <rect x="860" y="402" width="5" height="13" fill="#881800"/>
+
+    <!-- ── Stone Lanterns ── -->
+    <!-- Left lantern (toro) -->
+    <rect x="746" y="472" width="18" height="8" fill="#b0a888" rx="1"/><!-- base -->
+    <rect x="750" y="454" width="10" height="18" fill="#c0b890" rx="1"/><!-- shaft -->
+    <path d="M749,454 L751,446 L764,446 L766,454 Z" fill="#b8b088"/><!-- cap -->
+    <rect x="753" y="443" width="9" height="5" fill="#a8a078" rx="1"/>
+    <!-- Lantern fire box -->
+    <rect x="748" y="456" width="14" height="14" fill="#ffe8a0" opacity="0.6" rx="1"/>
+    <rect x="748" y="456" width="14" height="14" fill="none" stroke="#a89868" stroke-width="1.5" rx="1"/>
+    <!-- Right lantern -->
+    <rect x="893" y="472" width="18" height="8" fill="#b0a888" rx="1"/>
+    <rect x="897" y="454" width="10" height="18" fill="#c0b890" rx="1"/>
+    <path d="M896,454 L898,446 L911,446 L913,454 Z" fill="#b8b088"/>
+    <rect x="900" y="443" width="9" height="5" fill="#a8a078" rx="1"/>
+    <rect x="895" y="456" width="14" height="14" fill="#ffe8a0" opacity="0.6" rx="1"/>
+    <rect x="895" y="456" width="14" height="14" fill="none" stroke="#a89868" stroke-width="1.5" rx="1"/>
+
+    <!-- ── Ground and stone path ── -->
+    <rect x="600" y="490" width="600" height="110" fill="url(#groundR)" filter="url(#wc)"/>
+    <!-- Path from gate to steps -->
+    <path d="M840,600 Q848,550 856,510 Q862,492 868,482" stroke="#c8b880" stroke-width="32" fill="none" opacity="0.45" stroke-linecap="round"/>
+    <path d="M960,600 Q952,550 944,510 Q938,492 932,482" stroke="#c8b880" stroke-width="32" fill="none" opacity="0.45" stroke-linecap="round"/>
+    <path d="M900,600 Q900,550 900,510 Q900,492 900,482" stroke="#d4c890" stroke-width="52" fill="none" opacity="0.3" stroke-linecap="round"/>
+    <!-- Stone pavers -->
+    <g opacity="0.6">
+      <ellipse cx="878" cy="525" rx="20" ry="9" fill="#d4cc98" transform="rotate(-5,878,525)"/>
+      <ellipse cx="900" cy="545" rx="22" ry="9" fill="#ccc490" transform="rotate(3,900,545)"/>
+      <ellipse cx="922" cy="522" rx="20" ry="9" fill="#d4cc98" transform="rotate(6,922,522)"/>
+      <ellipse cx="886" cy="558" rx="17" ry="7" fill="#ccc490" transform="rotate(-4,886,558)"/>
+      <ellipse cx="914" cy="560" rx="18" ry="7" fill="#d4cc98" transform="rotate(7,914,560)"/>
+      <ellipse cx="870" cy="540" rx="15" ry="6" fill="#ccc490" transform="rotate(-8,870,540)"/>
+      <ellipse cx="930" cy="542" rx="16" ry="6" fill="#d4cc98" transform="rotate(5,930,542)"/>
+    </g>
+    <!-- Moss/grass patches -->
+    <ellipse cx="800" cy="510" rx="30" ry="12" fill="#7a9848" opacity="0.4" filter="url(#softBlur)"/>
+    <ellipse cx="1005" cy="515" rx="28" ry="11" fill="#7a9848" opacity="0.4" filter="url(#softBlur)"/>
+    <ellipse cx="640" cy="535" rx="35" ry="14" fill="#8a9858" opacity="0.35" filter="url(#softBlur)"/>
+    <ellipse cx="1160" cy="530" rx="30" ry="12" fill="#8a9858" opacity="0.35" filter="url(#softBlur)"/>
+
+    <!-- ── Cherry blossom trees flanking pagoda ── -->
+    <!-- FAR LEFT tree (partial) -->
+    <path d="M600,600 Q604,548 608,498 Q612,458 616,420 Q619,390 622,358" stroke="#7a5030" stroke-width="8" fill="none" stroke-linecap="round"/>
+    <path d="M622,358 Q628,328 634,300" stroke="#7a5030" stroke-width="5" fill="none"/>
+    <path d="M622,358 Q614,328 608,300" stroke="#7a5030" stroke-width="4" fill="none"/>
+    <ellipse cx="624" cy="272" rx="80" ry="72" fill="url(#cdeep)" opacity="0.85" filter="url(#wc)"/>
+    <ellipse cx="610" cy="286" rx="60" ry="55" fill="#ffccdc" opacity="0.62"/>
+    <ellipse cx="636" cy="268" rx="68" ry="62" fill="#ffb8cc" opacity="0.55"/>
+
+    <!-- LEFT MAIN tree -->
+    <path d="M705,600 Q708,548 712,498 Q715,456 719,418 Q722,386 726,352" stroke="#7a5030" stroke-width="11" fill="none" stroke-linecap="round"/>
+    <path d="M726,352 Q734,320 742,290" stroke="#7a5030" stroke-width="6" fill="none"/>
+    <path d="M726,352 Q716,322 709,292" stroke="#7a5030" stroke-width="5" fill="none"/>
+    <path d="M726,352 Q740,330 752,314" stroke="#6a4020" stroke-width="4" fill="none"/>
+    <!-- Left overhanging branch toward pagoda -->
+    <path d="M719,418 Q740,398 760,380" stroke="#7a5030" stroke-width="4" fill="none"/>
+    <ellipse cx="772" cy="370" rx="42" ry="36" fill="#ffcce0" opacity="0.68"/>
+    <!-- Main canopy -->
+    <ellipse cx="732" cy="258" rx="100" ry="90" fill="url(#cpink)" opacity="0.88" filter="url(#wc)"/>
+    <ellipse cx="714" cy="272" rx="74" ry="68" fill="#ffcce0" opacity="0.62"/>
+    <ellipse cx="750" cy="256" rx="80" ry="72" fill="#ffd4e4" opacity="0.58"/>
+    <ellipse cx="728" cy="244" rx="90" ry="80" fill="#ffaac4" opacity="0.36" filter="url(#softBlur)"/>
+    <!-- Blossom clusters detail -->
+    <g opacity="0.78">
+      <circle cx="712" cy="242" r="7" fill="#ffd4e8"/>
+      <circle cx="734" cy="228" r="6" fill="#ffbcd8"/>
+      <circle cx="752" cy="244" r="7" fill="#ffcce0"/>
+      <circle cx="718" cy="262" r="5" fill="#ffc4d8"/>
+      <circle cx="746" cy="260" r="6" fill="#ffd4e8"/>
+      <circle cx="700" cy="256" r="5" fill="#ffcce0"/>
+      <circle cx="760" cy="268" r="5" fill="#ffb8cc"/>
+    </g>
+
+    <!-- RIGHT MAIN tree -->
+    <path d="M1095,600 Q1092,548 1088,498 Q1085,456 1081,418 Q1078,386 1074,352" stroke="#7a5030" stroke-width="11" fill="none" stroke-linecap="round"/>
+    <path d="M1074,352 Q1066,320 1058,290" stroke="#7a5030" stroke-width="6" fill="none"/>
+    <path d="M1074,352 Q1084,322 1091,292" stroke="#7a5030" stroke-width="5" fill="none"/>
+    <path d="M1074,352 Q1060,330 1048,314" stroke="#6a4020" stroke-width="4" fill="none"/>
+    <!-- Right overhanging branch toward pagoda -->
+    <path d="M1081,418 Q1060,398 1040,380" stroke="#7a5030" stroke-width="4" fill="none"/>
+    <ellipse cx="1028" cy="370" rx="42" ry="36" fill="#ffe8f4" opacity="0.68"/>
+    <!-- Main canopy -->
+    <ellipse cx="1068" cy="258" rx="100" ry="90" fill="url(#cwhite)" opacity="0.88" filter="url(#wc)"/>
+    <ellipse cx="1086" cy="272" rx="76" ry="68" fill="#fff0f8" opacity="0.62"/>
+    <ellipse cx="1050" cy="256" rx="82" ry="72" fill="#ffe8f4" opacity="0.58"/>
+    <ellipse cx="1070" cy="244" rx="92" ry="80" fill="#ffd8ec" opacity="0.36" filter="url(#softBlur)"/>
+    <!-- Blossom clusters detail -->
+    <g opacity="0.78">
+      <circle cx="1088" cy="242" r="7" fill="#fff4fa"/>
+      <circle cx="1066" cy="228" r="6" fill="#ffe8f4"/>
+      <circle cx="1048" cy="244" r="7" fill="#fff0f8"/>
+      <circle cx="1082" cy="262" r="5" fill="#ffe4f0"/>
+      <circle cx="1054" cy="260" r="6" fill="#fff4fa"/>
+      <circle cx="1100" cy="256" r="5" fill="#ffe0ee"/>
+      <circle cx="1040" cy="268" r="5" fill="#ffd8ec"/>
+    </g>
+
+    <!-- FAR RIGHT tree (partial) -->
+    <path d="M1200,600 Q1196,548 1192,498 Q1188,458 1184,420 Q1181,390 1178,358" stroke="#7a5030" stroke-width="8" fill="none" stroke-linecap="round"/>
+    <ellipse cx="1176" cy="272" rx="80" ry="72" fill="url(#cpink)" opacity="0.85" filter="url(#wc)"/>
+    <ellipse cx="1190" cy="286" rx="60" ry="55" fill="#ffcce0" opacity="0.62"/>
+
+    <!-- Scattered ground petals -->
+    <g opacity="0.65">
+      <ellipse cx="808" cy="497" rx="5" ry="2.2" fill="#ffaac8" transform="rotate(-20,808,497)"/>
+      <ellipse cx="845" cy="488" rx="4.5" ry="2" fill="#ffbbcc" transform="rotate(28,845,488)"/>
+      <ellipse cx="952" cy="493" rx="5" ry="2.2" fill="#ffaac0" transform="rotate(-10,952,493)"/>
+      <ellipse cx="996" cy="502" rx="4" ry="2" fill="#ffbbdd" transform="rotate(34,996,502)"/>
+      <ellipse cx="680" cy="520" rx="5" ry="2.2" fill="#ffaacc" transform="rotate(-24,680,520)"/>
+      <ellipse cx="1125" cy="515" rx="4.5" ry="2" fill="#ffbbcc" transform="rotate(14,1125,515)"/>
+      <ellipse cx="740" cy="508" rx="5" ry="2.2" fill="#ffaac8" transform="rotate(-32,740,508)"/>
+      <ellipse cx="1060" cy="510" rx="4" ry="2" fill="#ffbbdd" transform="rotate(20,1060,510)"/>
+    </g>
+
+    <!-- Falling petals (in air) -->
+    <g opacity="0.72">
+      <ellipse cx="762" cy="348" rx="4.5" ry="2" fill="#ffbbdd" transform="rotate(20,762,348)"/>
+      <ellipse cx="802" cy="335" rx="3.5" ry="1.8" fill="#ffccd8" transform="rotate(-16,802,335)"/>
+      <ellipse cx="845" cy="368" rx="4.5" ry="2" fill="#ffaac8" transform="rotate(36,845,368)"/>
+      <ellipse cx="775" cy="395" rx="3.5" ry="1.8" fill="#ffbbdd" transform="rotate(-26,775,395)"/>
+      <ellipse cx="1022" cy="342" rx="4.5" ry="2" fill="#ffe0f0" transform="rotate(16,1022,342)"/>
+      <ellipse cx="1060" cy="362" rx="3.5" ry="1.8" fill="#ffcce0" transform="rotate(-24,1060,362)"/>
+      <ellipse cx="980" cy="318" rx="4.5" ry="2" fill="#ffd8ec" transform="rotate(38,980,318)"/>
+      <ellipse cx="950" cy="375" rx="3.5" ry="1.8" fill="#ffe0f0" transform="rotate(-12,950,375)"/>
+      <ellipse cx="860" cy="302" rx="4" ry="1.8" fill="#ffbbdd" transform="rotate(44,860,302)"/>
+      <ellipse cx="940" cy="290" rx="4" ry="1.8" fill="#ffcce0" transform="rotate(-8,940,290)"/>
+    </g>
+
+    <!-- Scene label -->
+    <rect x="600" y="570" width="600" height="30" fill="#f5eaee" opacity="0.6"/>
+    <text x="900" y="590" text-anchor="middle" font-family="Georgia, 'Times New Roman', serif"
+          font-size="14" fill="#6a3850" opacity="0.9" letter-spacing="1">
+      Senso-ji Temple — Tokyo
+    </text>
+  </g>
+
+
+  <!-- ════════════════════════════════════════════
+       GLOBAL FINISHING TOUCHES
+       ════════════════════════════════════════════ -->
+
+  <!-- Center divider -->
+  <line x1="600" y1="0" x2="600" y2="600" stroke="#c8a0b8" stroke-width="2" opacity="0.55"/>
+
+  <!-- Vignette overlay -->
+  <rect x="0" y="0" width="1200" height="600" fill="url(#vig)"/>
+
+  <!-- Outer border double-line -->
+  <rect x="0" y="0" width="1200" height="600" fill="none" stroke="#c0a0b8" stroke-width="4" opacity="0.5"/>
+  <rect x="6" y="6" width="1188" height="588" fill="none" stroke="#e8d0dc" stroke-width="1.5" opacity="0.4"/>
+
+  <!-- Title banner at top -->
+  <rect x="420" y="0" width="360" height="38" fill="#f5e8ef" opacity="0.75"/>
+  <text x="600" y="26" text-anchor="middle" font-family="Georgia, 'Times New Roman', serif"
+        font-size="18" fill="#804060" opacity="0.92" letter-spacing="4" font-style="italic">
+    ✿  Cherry Blossoms  ✿
+  </text>
+</svg>

--- a/docs/presentation/experiments/cherry-blossoms/codex-initial.svg
+++ b/docs/presentation/experiments/cherry-blossoms/codex-initial.svg
@@ -1,0 +1,319 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="600" viewBox="0 0 1200 600" role="img" aria-labelledby="title desc">
+  <title id="title">Cherry blossoms at UW Seattle and Tokyo temple</title>
+  <desc id="desc">A soft watercolor style illustration with side-by-side scenes of cherry blossoms at the University of Washington campus with Drumheller Fountain and at Sensō-ji-inspired temple architecture in Tokyo.</desc>
+  <defs>
+    <linearGradient id="paperBg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#f8f1ea"/>
+      <stop offset="100%" stop-color="#f3eadf"/>
+    </linearGradient>
+    <linearGradient id="leftSky" x1="0" y1="0" x2="0.1" y2="1">
+      <stop offset="0%" stop-color="#dfeefa"/>
+      <stop offset="42%" stop-color="#f7eef5"/>
+      <stop offset="100%" stop-color="#eef1df"/>
+    </linearGradient>
+    <linearGradient id="rightSky" x1="0" y1="0" x2="0.1" y2="1">
+      <stop offset="0%" stop-color="#dce9f8"/>
+      <stop offset="42%" stop-color="#f9edf3"/>
+      <stop offset="100%" stop-color="#efe4d4"/>
+    </linearGradient>
+    <linearGradient id="leftGround" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#bfd1b3"/>
+      <stop offset="100%" stop-color="#92a77f"/>
+    </linearGradient>
+    <linearGradient id="rightGround" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#d3c4aa"/>
+      <stop offset="100%" stop-color="#b59f7e"/>
+    </linearGradient>
+    <filter id="paperGrain" x="-20%" y="-20%" width="140%" height="140%">
+      <feTurbulence type="fractalNoise" baseFrequency="0.8" numOctaves="2" seed="7" result="noise"/>
+      <feColorMatrix type="saturate" values="0"/>
+      <feComponentTransfer>
+        <feFuncA type="table" tableValues="0 0.05"/>
+      </feComponentTransfer>
+    </filter>
+    <filter id="washBlur" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur stdDeviation="10"/>
+    </filter>
+    <filter id="panelShadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="8" stdDeviation="12" flood-color="#896d6a" flood-opacity="0.16"/>
+    </filter>
+    <filter id="bloom" x="-30%" y="-30%" width="160%" height="160%">
+      <feGaussianBlur stdDeviation="1.2"/>
+    </filter>
+    <clipPath id="leftClip"><rect x="40" y="40" width="520" height="520" rx="26"/></clipPath>
+    <clipPath id="rightClip"><rect x="640" y="40" width="520" height="520" rx="26"/></clipPath>
+    <symbol id="blossom" viewBox="-18 -18 36 36">
+      <circle cx="0" cy="0" r="11.8" fill="currentColor" opacity="0.12" filter="url(#bloom)"/>
+      <g fill="currentColor" opacity="0.9">
+        <ellipse cx="0" cy="-7" rx="5.6" ry="8.4"/>
+        <ellipse cx="6.6" cy="-2.2" rx="5.6" ry="8.4" transform="rotate(72 6.6 -2.2)"/>
+        <ellipse cx="4.2" cy="5.8" rx="5.6" ry="8.4" transform="rotate(144 4.2 5.8)"/>
+        <ellipse cx="-4.2" cy="5.8" rx="5.6" ry="8.4" transform="rotate(-144 -4.2 5.8)"/>
+        <ellipse cx="-6.6" cy="-2.2" rx="5.6" ry="8.4" transform="rotate(-72 -6.6 -2.2)"/>
+      </g>
+      <g fill="#fffefe" opacity="0.18">
+        <ellipse cx="0" cy="-6.4" rx="2.8" ry="3.6"/>
+        <ellipse cx="5.8" cy="-1.8" rx="2.8" ry="3.6" transform="rotate(72 5.8 -1.8)"/>
+      </g>
+      <circle r="3.8" fill="#f3c56d" opacity="0.8"/>
+      <circle cx="-1.4" cy="0.6" r="0.95" fill="#a16b4a" opacity="0.72"/>
+      <circle cx="1.1" cy="-0.4" r="0.95" fill="#a16b4a" opacity="0.72"/>
+      <circle cx="0.4" cy="1.8" r="0.95" fill="#a16b4a" opacity="0.72"/>
+    </symbol>
+    <symbol id="petal" viewBox="-8 -8 16 16">
+      <path d="M0 -6 C4 -6 5 -1 0 6 C-5 -1 -4 -6 0 -6 Z"/>
+    </symbol>
+    <style>
+      .wash { filter:url(#washBlur); }
+      .inkfill { stroke:#6e5e67; stroke-opacity:0.26; stroke-width:1.2; stroke-linejoin:round; }
+      .branch { fill:none; stroke:#6e4b49; stroke-width:8; stroke-linecap:round; stroke-opacity:0.74; }
+      .branch-shadow { fill:none; stroke:#a88583; stroke-width:14; stroke-linecap:round; stroke-opacity:0.2; filter:url(#washBlur); }
+    </style>
+  </defs>
+  <rect width="1200" height="600" fill="url(#paperBg)"/>
+  <rect x="0" y="0" width="1200" height="600" fill="#ffffff" opacity="0.7" filter="url(#paperGrain)"/>
+  <g class="wash">
+    <ellipse cx="188" cy="72" rx="160" ry="48" fill="#f3dbe7" opacity="0.16"/>
+    <ellipse cx="1002" cy="92" rx="170" ry="54" fill="#e7edf8" opacity="0.2"/>
+    <ellipse cx="602" cy="542" rx="260" ry="42" fill="#efd9d8" opacity="0.1"/>
+  </g>
+  <g filter="url(#panelShadow)">
+    <rect x="40" y="40" width="520" height="520" rx="26" fill="#fffaf4" opacity="0.95"/>
+    <rect x="640" y="40" width="520" height="520" rx="26" fill="#fffaf4" opacity="0.95"/>
+  </g>
+  <rect x="40" y="40" width="520" height="520" rx="26" fill="none" stroke="#ffffff" stroke-opacity="0.72" stroke-width="6"/>
+  <rect x="640" y="40" width="520" height="520" rx="26" fill="none" stroke="#ffffff" stroke-opacity="0.72" stroke-width="6"/>
+
+<g clip-path="url(#leftClip)">
+  <g transform="translate(40 40)">
+    <rect width="520" height="520" fill="url(#leftSky)"/>
+    <g class="wash">
+      <ellipse cx="130" cy="84" rx="148" ry="98" fill="#f8d8e6" opacity="0.24" transform="rotate(-8 130 84)"/>
+      <ellipse cx="402" cy="110" rx="146" ry="110" fill="#d9eaf6" opacity="0.34" transform="rotate(7 402 110)"/>
+      <ellipse cx="246" cy="200" rx="220" ry="118" fill="#fff7f3" opacity="0.25"/>
+      <ellipse cx="258" cy="426" rx="230" ry="98" fill="#dfe9d5" opacity="0.26"/>
+    </g>
+    <path d="M0 262 C72 222 122 232 176 212 C226 194 290 210 340 188 C398 164 448 184 520 154 L520 304 L0 304 Z" fill="#c8d4da" opacity="0.52" class="wash"/>
+    <path d="M0 296 C96 262 172 278 252 250 C338 222 430 246 520 216 L520 340 L0 340 Z" fill="#dfe7e2" opacity="0.58"/>
+    <path d="M0 312 C94 290 168 300 230 284 C306 262 396 286 520 254 L520 520 L0 520 Z" fill="url(#leftGround)"/>
+    <path d="M42 352 C150 318 334 320 476 350" fill="none" stroke="#ece7da" stroke-width="20" stroke-linecap="round" opacity="0.72" class="wash"/>
+    <path d="M194 520 L236 366 L286 366 L328 520 Z" fill="#eee5d5" opacity="0.86"/>
+    <path d="M214 520 L245 388 L277 388 L307 520 Z" fill="#f5f0e6" opacity="0.84"/>
+
+    <g transform="translate(118 132)">
+      <ellipse cx="142" cy="66" rx="158" ry="52" fill="#f8e9e2" opacity="0.42" class="wash"/>
+      <rect x="0" y="82" width="56" height="130" rx="4" fill="#d7c4c0" class="inkfill"/>
+      <rect x="224" y="82" width="56" height="130" rx="4" fill="#d7c4c0" class="inkfill"/>
+      <rect x="56" y="100" width="168" height="112" fill="#d7c4c0" class="inkfill"/>
+      <path d="M34 98 Q140 18 246 98 L232 116 Q140 66 48 116 Z" fill="#766c87" class="inkfill"/>
+      <path d="M48 116 Q140 82 232 116 L222 130 Q140 102 58 130 Z" fill="#645876" opacity="0.92"/>
+      <path d="M-8 76 L28 36 L66 76 L58 92 Q28 72 -2 92 Z" fill="#7a6f89" class="inkfill"/>
+      <path d="M214 76 L252 36 L288 76 L282 92 Q252 72 222 92 Z" fill="#7a6f89" class="inkfill"/>
+      <path d="M8 48 L28 18 L48 48 L42 60 Q28 46 14 60 Z" fill="#8d7f96" opacity="0.95"/>
+      <path d="M232 48 L252 18 L272 48 L266 60 Q252 46 238 60 Z" fill="#8d7f96" opacity="0.95"/>
+      <path d="M12 212 L32 122 L40 122 L22 212 Z" fill="#c3b2b2" opacity="0.75"/>
+      <path d="M258 212 L240 122 L248 122 L268 212 Z" fill="#c3b2b2" opacity="0.75"/>
+      <g fill="#5b5462" opacity="0.55">
+        <rect x="12" y="102" width="8" height="18" rx="2"/><rect x="24" y="102" width="8" height="18" rx="2"/><rect x="36" y="102" width="8" height="18" rx="2"/>
+        <rect x="12" y="128" width="8" height="18" rx="2"/><rect x="24" y="128" width="8" height="18" rx="2"/><rect x="36" y="128" width="8" height="18" rx="2"/>
+        <rect x="236" y="102" width="8" height="18" rx="2"/><rect x="248" y="102" width="8" height="18" rx="2"/><rect x="260" y="102" width="8" height="18" rx="2"/>
+        <rect x="236" y="128" width="8" height="18" rx="2"/><rect x="248" y="128" width="8" height="18" rx="2"/><rect x="260" y="128" width="8" height="18" rx="2"/>
+        <rect x="76" y="126" width="12" height="32" rx="3"/><rect x="98" y="126" width="12" height="32" rx="3"/><rect x="120" y="126" width="12" height="32" rx="3"/>
+        <rect x="148" y="126" width="12" height="32" rx="3"/><rect x="170" y="126" width="12" height="32" rx="3"/><rect x="192" y="126" width="12" height="32" rx="3"/>
+      </g>
+      <path d="M118 212 v-34 q0-20 22-20 q22 0 22 20 v34 z" fill="#605568" opacity="0.6"/>
+      <g stroke="#8d7e84" stroke-opacity="0.36" stroke-width="2" fill="none">
+        <path d="M56 100 L76 210"/><path d="M224 100 L204 210"/>
+        <path d="M140 100 V212"/>
+      </g>
+    </g>
+
+    <g transform="translate(164 318)">
+      <ellipse cx="96" cy="46" rx="102" ry="38" fill="#7aa6c4" opacity="0.18" class="wash"/>
+      <ellipse cx="96" cy="48" rx="86" ry="32" fill="#96c6df" opacity="0.68"/>
+      <ellipse cx="96" cy="48" rx="90" ry="35" fill="none" stroke="#8c7b78" stroke-width="6" opacity="0.62"/>
+      <ellipse cx="96" cy="48" rx="76" ry="24" fill="none" stroke="#f4f0eb" stroke-width="5" opacity="0.52"/>
+      <path d="M94 12 q6 -12 12 0 l3 26 q6 28 -15 28 q-20 0 -13 -28 z" fill="#d9ddd8" opacity="0.76"/>
+      <path d="M96 0 C86 20 90 10 88 46 M96 0 C100 20 104 12 106 46 M96 4 C96 18 96 18 96 54" fill="none" stroke="#edf6ff" stroke-width="4" stroke-linecap="round" opacity="0.82"/>
+      <path d="M96 4 C80 28 76 34 66 56 M96 8 C112 28 118 34 128 56" fill="none" stroke="#edf6ff" stroke-width="2.8" stroke-linecap="round" opacity="0.62"/>
+      <ellipse cx="96" cy="42" rx="28" ry="10" fill="#dff2fb" opacity="0.74"/>
+    </g>
+
+    <g opacity="0.55">
+      <ellipse cx="98" cy="304" rx="34" ry="54" fill="#c1d2b8" class="wash"/>
+      <ellipse cx="422" cy="308" rx="34" ry="50" fill="#c0d3b7" class="wash"/>
+      <rect x="94" y="314" width="7" height="52" rx="3" fill="#84645e" opacity="0.65"/>
+      <rect x="418" y="320" width="7" height="48" rx="3" fill="#84645e" opacity="0.65"/>
+    </g>
+
+    <g>
+      <path class="branch-shadow" d="M-18 54 C68 12 122 64 188 94 C226 112 262 110 298 102"/>
+      <path class="branch" d="M-18 58 C66 18 120 68 186 96 C224 112 260 114 304 108"/>
+      <path class="branch-shadow" d="M542 48 C458 10 404 52 358 94 C332 118 304 126 278 132"/>
+      <path class="branch" d="M540 54 C456 16 404 58 358 98 C332 120 306 128 278 136"/>
+      <path class="branch-shadow" d="M28 196 C56 166 70 146 86 128"/>
+      <path class="branch" d="M30 200 C56 170 72 148 88 132"/>
+      <path class="branch-shadow" d="M482 204 C456 174 444 152 430 136"/>
+      <path class="branch" d="M480 206 C454 176 442 154 428 138"/>
+      <use href="#blossom" transform="translate({x} {y}) rotate({rot}) scale({scale})" style="color:{color}" opacity="{opacity}" />
+<use href="#blossom" transform="translate({x} {y}) rotate({rot}) scale({scale})" style="color:{color}" opacity="{opacity}" />
+<use href="#blossom" transform="translate({x} {y}) rotate({rot}) scale({scale})" style="color:{color}" opacity="{opacity}" />
+<use href="#blossom" transform="translate({x} {y}) rotate({rot}) scale({scale})" style="color:{color}" opacity="{opacity}" />
+<use href="#blossom" transform="translate({x} {y}) rotate({rot}) scale({scale})" style="color:{color}" opacity="{opacity}" />
+<use href="#blossom" transform="translate({x} {y}) rotate({rot}) scale({scale})" style="color:{color}" opacity="{opacity}" />
+<use href="#blossom" transform="translate({x} {y}) rotate({rot}) scale({scale})" style="color:{color}" opacity="{opacity}" />
+<use href="#blossom" transform="translate({x} {y}) rotate({rot}) scale({scale})" style="color:{color}" opacity="{opacity}" />
+<use href="#blossom" transform="translate({x} {y}) rotate({rot}) scale({scale})" style="color:{color}" opacity="{opacity}" />
+<use href="#blossom" transform="translate({x} {y}) rotate({rot}) scale({scale})" style="color:{color}" opacity="{opacity}" />
+<use href="#blossom" transform="translate({x} {y}) rotate({rot}) scale({scale})" style="color:{color}" opacity="{opacity}" />
+<use href="#blossom" transform="translate({x} {y}) rotate({rot}) scale({scale})" style="color:{color}" opacity="{opacity}" />
+<use href="#blossom" transform="translate({x} {y}) rotate({rot}) scale({scale})" style="color:{color}" opacity="{opacity}" />
+<use href="#blossom" transform="translate({x} {y}) rotate({rot}) scale({scale})" style="color:{color}" opacity="{opacity}" />
+<use href="#blossom" transform="translate({x} {y}) rotate({rot}) scale({scale})" style="color:{color}" opacity="{opacity}" />
+<use href="#blossom" transform="translate({x} {y}) rotate({rot}) scale({scale})" style="color:{color}" opacity="{opacity}" />
+<use href="#blossom" transform="translate({x} {y}) rotate({rot}) scale({scale})" style="color:{color}" opacity="{opacity}" />
+<use href="#blossom" transform="translate({x} {y}) rotate({rot}) scale({scale})" style="color:{color}" opacity="{opacity}" />
+<use href="#blossom" transform="translate({x} {y}) rotate({rot}) scale({scale})" style="color:{color}" opacity="{opacity}" />
+<use href="#blossom" transform="translate({x} {y}) rotate({rot}) scale({scale})" style="color:{color}" opacity="{opacity}" />
+<use href="#blossom" transform="translate({x} {y}) rotate({rot}) scale({scale})" style="color:{color}" opacity="{opacity}" />
+<use href="#blossom" transform="translate({x} {y}) rotate({rot}) scale({scale})" style="color:{color}" opacity="{opacity}" />
+<use href="#blossom" transform="translate({x} {y}) rotate({rot}) scale({scale})" style="color:{color}" opacity="{opacity}" />
+<use href="#blossom" transform="translate({x} {y}) rotate({rot}) scale({scale})" style="color:{color}" opacity="{opacity}" />
+      <use href="#petal" transform="translate(116 246) rotate(28) scale(0.55)" fill="#f9d7e4" opacity="0.6" />
+<use href="#petal" transform="translate(166 212) rotate(-22) scale(0.48)" fill="#fff9fc" opacity="0.58" />
+<use href="#petal" transform="translate(210 258) rotate(14) scale(0.44)" fill="#f8d3e2" opacity="0.55" />
+<use href="#petal" transform="translate(320 214) rotate(-18) scale(0.52)" fill="#fffbfd" opacity="0.52" />
+<use href="#petal" transform="translate(386 252) rotate(32) scale(0.56)" fill="#f7d2e0" opacity="0.58" />
+<use href="#petal" transform="translate(424 198) rotate(-24) scale(0.46)" fill="#fff9fb" opacity="0.5" />
+<use href="#petal" transform="translate(286 302) rotate(12) scale(0.5)" fill="#f7d4e2" opacity="0.48" />
+<use href="#petal" transform="translate(348 336) rotate(-16) scale(0.46)" fill="#fffbfd" opacity="0.42" />
+<use href="#petal" transform="translate(138 336) rotate(20) scale(0.42)" fill="#f7d5e3" opacity="0.42" />
+    </g>
+
+    <g opacity="0.5" fill="#fff7f7">
+      <circle cx="192" cy="430" r="3"/><circle cx="214" cy="438" r="2.4"/><circle cx="336" cy="446" r="2.6"/>
+    </g>
+  </g>
+</g>
+
+
+<g clip-path="url(#rightClip)">
+  <g transform="translate(640 40)">
+    <rect width="520" height="520" fill="url(#rightSky)"/>
+    <g class="wash">
+      <ellipse cx="110" cy="92" rx="160" ry="104" fill="#f9dde8" opacity="0.3" transform="rotate(-10 110 92)"/>
+      <ellipse cx="392" cy="94" rx="150" ry="108" fill="#dfe9fa" opacity="0.32" transform="rotate(6 392 94)"/>
+      <ellipse cx="252" cy="186" rx="214" ry="114" fill="#fff6ef" opacity="0.26"/>
+      <ellipse cx="278" cy="416" rx="240" ry="104" fill="#eadfce" opacity="0.24"/>
+    </g>
+    <path d="M0 294 C72 266 142 276 216 246 C284 218 356 232 430 210 C468 200 496 190 520 178 L520 326 L0 326 Z" fill="#d9ddd7" opacity="0.56"/>
+    <path d="M0 316 C120 286 222 300 320 276 C398 256 452 262 520 244 L520 520 L0 520 Z" fill="url(#rightGround)"/>
+    <path d="M72 516 C154 426 206 392 260 368 C322 340 388 332 452 344" fill="none" stroke="#efe6d6" stroke-width="22" stroke-linecap="round" opacity="0.76" class="wash"/>
+
+    <g transform="translate(328 146) scale(0.82)">
+      <ellipse cx="82" cy="174" rx="86" ry="32" fill="#f2dfd7" opacity="0.42" class="wash"/>
+      <rect x="54" y="112" width="56" height="126" fill="#efe3d6" opacity="0.92"/>
+      <path d="M38 110 Q82 80 126 110 L116 122 Q82 104 48 122 Z" fill="#4f5369"/>
+      <rect x="58" y="84" width="48" height="36" fill="#f2e6da" opacity="0.94"/>
+      <path d="M28 82 Q82 46 136 82 L124 96 Q82 76 40 96 Z" fill="#555a70"/>
+      <rect x="62" y="58" width="40" height="28" fill="#f5eadf" opacity="0.95"/>
+      <path d="M18 56 Q82 18 146 56 L132 70 Q82 48 32 70 Z" fill="#5a5f76"/>
+      <rect x="66" y="34" width="32" height="24" fill="#f6efe5" opacity="0.95"/>
+      <path d="M10 32 Q82 -6 154 32 L138 46 Q82 26 26 46 Z" fill="#60647b"/>
+      <rect x="71" y="8" width="22" height="24" fill="#f7efe2" opacity="0.96"/>
+      <path d="M0 6 Q82 -34 164 6 L146 20 Q82 0 18 20 Z" fill="#676b83"/>
+      <path d="M82 -8 V-34" stroke="#d4b36d" stroke-width="4" stroke-linecap="round"/>
+      <path d="M82 -34 l6 14 l-6 8 l-6 -8 z" fill="#d7b56c"/>
+      <g fill="#b98f4b" opacity="0.65">
+        <circle cx="82" cy="10" r="3"/><circle cx="82" cy="36" r="3"/><circle cx="82" cy="60" r="3"/>
+      </g>
+      <g fill="#6f3640" opacity="0.34">
+        <rect x="68" y="124" width="8" height="96"/><rect x="88" y="124" width="8" height="96"/>
+      </g>
+    </g>
+
+    <g transform="translate(88 168)">
+      <ellipse cx="158" cy="118" rx="168" ry="64" fill="#f4dfd8" opacity="0.5" class="wash"/>
+      <path d="M24 112 Q158 16 292 112 L272 130 Q158 82 44 130 Z" fill="#4d5568" class="inkfill"/>
+      <path d="M40 128 Q158 92 276 128 L266 142 Q158 114 50 142 Z" fill="#3f4757" opacity="0.94"/>
+      <path d="M44 94 Q158 24 272 94 L254 108 Q158 66 62 108 Z" fill="#636a80" opacity="0.86"/>
+      <rect x="62" y="136" width="192" height="112" fill="#cc604f" class="inkfill"/>
+      <rect x="54" y="244" width="208" height="20" fill="#8a4d42" opacity="0.76"/>
+      <rect x="86" y="136" width="18" height="120" fill="#9c433d" opacity="0.9"/>
+      <rect x="138" y="136" width="18" height="120" fill="#9c433d" opacity="0.9"/>
+      <rect x="190" y="136" width="18" height="120" fill="#9c433d" opacity="0.9"/>
+      <path d="M112 136 h92 v72 h-92 z" fill="#f2eadf" opacity="0.88"/>
+      <g stroke="#a14f45" stroke-width="3" opacity="0.56">
+        <path d="M112 160 h92"/><path d="M112 182 h92"/><path d="M112 204 h92"/>
+        <path d="M134 136 v72"/><path d="M156 136 v72"/><path d="M178 136 v72"/>
+      </g>
+      <path d="M152 164 q6 -10 12 0 v42 h-12 z" fill="#bc8f54" opacity="0.84"/>
+      <ellipse cx="158" cy="160" rx="26" ry="22" fill="#c43730" opacity="0.82"/>
+      <rect x="152" y="150" width="12" height="74" fill="#bf8c48" opacity="0.7"/>
+      <path d="M58 246 L102 286 L214 286 L258 246" fill="#8e5248" opacity="0.74"/>
+      <g stroke="#f2e7da" stroke-opacity="0.44" stroke-width="2" fill="none">
+        <path d="M72 112 L86 248"/><path d="M244 112 L230 248"/>
+        <path d="M158 112 V248"/>
+      </g>
+      <g fill="#d8cab6" opacity="0.84">
+        <rect x="18" y="222" width="18" height="64" rx="4"/><rect x="280" y="222" width="18" height="64" rx="4"/>
+      </g>
+      <path d="M27 220 q12 -26 18 0 q-9 16 -18 0 z" fill="#b8a87a" opacity="0.78"/>
+      <path d="M289 220 q12 -26 18 0 q-9 16 -18 0 z" fill="#b8a87a" opacity="0.78"/>
+    </g>
+
+    <g opacity="0.58">
+      <ellipse cx="58" cy="332" rx="38" ry="60" fill="#c7d0ba" class="wash"/>
+      <ellipse cx="462" cy="318" rx="42" ry="64" fill="#c6cfba" class="wash"/>
+      <rect x="54" y="340" width="8" height="62" rx="3" fill="#7d6059" opacity="0.66"/>
+      <rect x="458" y="328" width="8" height="74" rx="3" fill="#7d6059" opacity="0.66"/>
+    </g>
+
+    <g>
+      <path class="branch-shadow" d="M-18 86 C54 42 108 70 166 102 C214 128 266 128 320 114"/>
+      <path class="branch" d="M-18 90 C56 48 108 74 166 106 C214 130 266 130 322 118"/>
+      <path class="branch-shadow" d="M548 44 C474 22 428 56 388 94 C352 126 310 138 268 144"/>
+      <path class="branch" d="M546 48 C474 26 428 60 390 98 C354 128 312 140 270 148"/>
+      <path class="branch-shadow" d="M504 238 C480 206 468 184 454 166"/>
+      <path class="branch" d="M502 240 C478 208 466 186 452 168"/>
+      <path class="branch-shadow" d="M32 212 C56 188 70 166 82 144"/>
+      <path class="branch" d="M34 214 C58 190 72 168 84 146"/>
+      <use href="#blossom" transform="translate({x} {y}) rotate({rot}) scale({scale})" style="color:{color}" opacity="{opacity}" />
+<use href="#blossom" transform="translate({x} {y}) rotate({rot}) scale({scale})" style="color:{color}" opacity="{opacity}" />
+<use href="#blossom" transform="translate({x} {y}) rotate({rot}) scale({scale})" style="color:{color}" opacity="{opacity}" />
+<use href="#blossom" transform="translate({x} {y}) rotate({rot}) scale({scale})" style="color:{color}" opacity="{opacity}" />
+<use href="#blossom" transform="translate({x} {y}) rotate({rot}) scale({scale})" style="color:{color}" opacity="{opacity}" />
+<use href="#blossom" transform="translate({x} {y}) rotate({rot}) scale({scale})" style="color:{color}" opacity="{opacity}" />
+<use href="#blossom" transform="translate({x} {y}) rotate({rot}) scale({scale})" style="color:{color}" opacity="{opacity}" />
+<use href="#blossom" transform="translate({x} {y}) rotate({rot}) scale({scale})" style="color:{color}" opacity="{opacity}" />
+<use href="#blossom" transform="translate({x} {y}) rotate({rot}) scale({scale})" style="color:{color}" opacity="{opacity}" />
+<use href="#blossom" transform="translate({x} {y}) rotate({rot}) scale({scale})" style="color:{color}" opacity="{opacity}" />
+<use href="#blossom" transform="translate({x} {y}) rotate({rot}) scale({scale})" style="color:{color}" opacity="{opacity}" />
+<use href="#blossom" transform="translate({x} {y}) rotate({rot}) scale({scale})" style="color:{color}" opacity="{opacity}" />
+<use href="#blossom" transform="translate({x} {y}) rotate({rot}) scale({scale})" style="color:{color}" opacity="{opacity}" />
+<use href="#blossom" transform="translate({x} {y}) rotate({rot}) scale({scale})" style="color:{color}" opacity="{opacity}" />
+<use href="#blossom" transform="translate({x} {y}) rotate({rot}) scale({scale})" style="color:{color}" opacity="{opacity}" />
+<use href="#blossom" transform="translate({x} {y}) rotate({rot}) scale({scale})" style="color:{color}" opacity="{opacity}" />
+<use href="#blossom" transform="translate({x} {y}) rotate({rot}) scale({scale})" style="color:{color}" opacity="{opacity}" />
+<use href="#blossom" transform="translate({x} {y}) rotate({rot}) scale({scale})" style="color:{color}" opacity="{opacity}" />
+<use href="#blossom" transform="translate({x} {y}) rotate({rot}) scale({scale})" style="color:{color}" opacity="{opacity}" />
+<use href="#blossom" transform="translate({x} {y}) rotate({rot}) scale({scale})" style="color:{color}" opacity="{opacity}" />
+      <use href="#petal" transform="translate(126 248) rotate(-18) scale(0.5)" fill="#f7d1e0" opacity="0.58" />
+<use href="#petal" transform="translate(178 214) rotate(20) scale(0.46)" fill="#fff9fc" opacity="0.54" />
+<use href="#petal" transform="translate(256 238) rotate(-24) scale(0.44)" fill="#f8d4e2" opacity="0.5" />
+<use href="#petal" transform="translate(332 206) rotate(14) scale(0.54)" fill="#fffbfd" opacity="0.52" />
+<use href="#petal" transform="translate(388 258) rotate(-16) scale(0.52)" fill="#f9d7e4" opacity="0.58" />
+<use href="#petal" transform="translate(438 224) rotate(26) scale(0.48)" fill="#fff8fb" opacity="0.54" />
+<use href="#petal" transform="translate(284 308) rotate(-12) scale(0.46)" fill="#f8d2e1" opacity="0.44" />
+<use href="#petal" transform="translate(208 340) rotate(22) scale(0.42)" fill="#fffbfd" opacity="0.4" />
+<use href="#petal" transform="translate(472 322) rotate(-18) scale(0.5)" fill="#f8d6e4" opacity="0.45" />
+    </g>
+
+    <g fill="#f4efe4" opacity="0.7">
+      <circle cx="192" cy="414" r="3.2"/><circle cx="244" cy="452" r="2.4"/><circle cx="328" cy="430" r="2.8"/>
+    </g>
+  </g>
+</g>
+
+</svg>

--- a/docs/presentation/experiments/cherry-blossoms/final.svg
+++ b/docs/presentation/experiments/cherry-blossoms/final.svg
@@ -1,0 +1,697 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 600" width="1200" height="600">
+  <defs>
+    <!-- Watercolor soft blur filter -->
+    <filter id="wc" x="-10%" y="-10%" width="120%" height="120%">
+      <feTurbulence type="fractalNoise" baseFrequency="0.065" numOctaves="3" seed="2" result="noise"/>
+      <feDisplacementMap in="SourceGraphic" in2="noise" scale="4" xChannelSelector="R" yChannelSelector="G" result="displaced"/>
+      <feGaussianBlur in="displaced" stdDeviation="1.2" result="blurred"/>
+      <feComposite in="blurred" in2="SourceGraphic" operator="in"/>
+    </filter>
+    <filter id="softBlur">
+      <feGaussianBlur stdDeviation="2"/>
+    </filter>
+    <filter id="glow">
+      <feGaussianBlur stdDeviation="4" result="blur"/>
+      <feComposite in="SourceGraphic" in2="blur" operator="over"/>
+    </filter>
+
+    <!-- Sky gradients -->
+    <linearGradient id="skyL" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#b0cce0"/>
+      <stop offset="35%" stop-color="#d8e8f4"/>
+      <stop offset="70%" stop-color="#eddff0"/>
+      <stop offset="100%" stop-color="#f5e6ef"/>
+    </linearGradient>
+    <linearGradient id="skyR" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#aec8e0"/>
+      <stop offset="35%" stop-color="#d4e4f0"/>
+      <stop offset="70%" stop-color="#eadaf0"/>
+      <stop offset="100%" stop-color="#f2e0ee"/>
+    </linearGradient>
+
+    <!-- Ground -->
+    <linearGradient id="groundL" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#c8d8a0"/>
+      <stop offset="100%" stop-color="#a0b870"/>
+    </linearGradient>
+    <linearGradient id="groundR" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#90a868"/>
+      <stop offset="100%" stop-color="#6a8448"/>
+    </linearGradient>
+
+    <!-- Fountain pool -->
+    <radialGradient id="pool" cx="50%" cy="40%" r="60%">
+      <stop offset="0%" stop-color="#c4dff0" stop-opacity="0.95"/>
+      <stop offset="60%" stop-color="#88b8d8" stop-opacity="0.85"/>
+      <stop offset="100%" stop-color="#5090b8" stop-opacity="0.7"/>
+    </radialGradient>
+
+    <!-- Canopy pinks -->
+    <radialGradient id="cpink" cx="50%" cy="40%" r="65%">
+      <stop offset="0%" stop-color="#ffe0ec"/>
+      <stop offset="45%" stop-color="#ffb8ce"/>
+      <stop offset="100%" stop-color="#ff90aa" stop-opacity="0.6"/>
+    </radialGradient>
+    <radialGradient id="cwhite" cx="50%" cy="40%" r="65%">
+      <stop offset="0%" stop-color="#fff8fb"/>
+      <stop offset="45%" stop-color="#ffe8f2"/>
+      <stop offset="100%" stop-color="#ffd0e4" stop-opacity="0.65"/>
+    </radialGradient>
+    <radialGradient id="cdeep" cx="50%" cy="35%" r="60%">
+      <stop offset="0%" stop-color="#ffd0e4"/>
+      <stop offset="50%" stop-color="#ff98bc"/>
+      <stop offset="100%" stop-color="#ee6898" stop-opacity="0.55"/>
+    </radialGradient>
+
+    <!-- Stone architecture -->
+    <linearGradient id="stone" x1="0" y1="0" x2="0.2" y2="1">
+      <stop offset="0%" stop-color="#ddd4c0"/>
+      <stop offset="50%" stop-color="#c8bc9c"/>
+      <stop offset="100%" stop-color="#b0a080"/>
+    </linearGradient>
+    <linearGradient id="stoneShad" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#b0a080"/>
+      <stop offset="100%" stop-color="#d8caa8"/>
+    </linearGradient>
+
+    <!-- Pagoda roof -->
+    <linearGradient id="roof" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#c02000"/>
+      <stop offset="60%" stop-color="#8a1400"/>
+      <stop offset="100%" stop-color="#600c00"/>
+    </linearGradient>
+    <linearGradient id="roofBody" x1="0" y1="0" x2="0.1" y2="1">
+      <stop offset="0%" stop-color="#c82800"/>
+      <stop offset="100%" stop-color="#a01e00"/>
+    </linearGradient>
+
+    <!-- Water shimmer gradient -->
+    <linearGradient id="waterShimmer" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#a0ccec" stop-opacity="0.3"/>
+      <stop offset="30%" stop-color="#ffffff" stop-opacity="0.5"/>
+      <stop offset="60%" stop-color="#a0ccec" stop-opacity="0.2"/>
+      <stop offset="100%" stop-color="#c0dff5" stop-opacity="0.4"/>
+    </linearGradient>
+
+    <!-- Clip paths -->
+    <clipPath id="clipL"><rect x="0" y="0" width="600" height="600"/></clipPath>
+    <clipPath id="clipR"><rect x="600" y="0" width="600" height="600"/></clipPath>
+
+    <!-- Vignette -->
+    <radialGradient id="vig" cx="50%" cy="50%" r="70%">
+      <stop offset="55%" stop-color="transparent"/>
+      <stop offset="100%" stop-color="#b090a0" stop-opacity="0.3"/>
+    </radialGradient>
+  </defs>
+
+
+  <!-- ════════════════════════════════════════════
+       LEFT SCENE  –  UW Seattle / Drumheller Fountain
+       ════════════════════════════════════════════ -->
+  <g clip-path="url(#clipL)">
+
+    <!-- Sky wash -->
+    <rect x="0" y="0" width="600" height="600" fill="url(#skyL)"/>
+
+    <!-- Soft watercolor sky blush clouds -->
+    <ellipse cx="120" cy="80" rx="130" ry="55" fill="#ffe0ec" opacity="0.18" filter="url(#softBlur)"/>
+    <ellipse cx="400" cy="60" rx="160" ry="60" fill="#e8d8f4" opacity="0.18" filter="url(#softBlur)"/>
+    <ellipse cx="550" cy="100" rx="90" ry="40" fill="#ffd8e8" opacity="0.15" filter="url(#softBlur)"/>
+
+    <!-- Distant tree line wash -->
+    <path d="M0,300 Q60,265 120,275 Q180,258 240,268 Q300,250 360,262 Q420,248 480,260 Q540,248 600,255 L600,310 Q540,300 480,308 Q420,298 360,308 Q300,296 240,308 Q180,298 120,308 Q60,298 0,308 Z"
+          fill="#b8d0a0" opacity="0.35" filter="url(#softBlur)"/>
+
+    <!-- Background cherry blossom haze -->
+    <ellipse cx="60"  cy="235" rx="75"  ry="52" fill="#ffcce0" opacity="0.28" filter="url(#softBlur)"/>
+    <ellipse cx="190" cy="215" rx="95"  ry="62" fill="#ffd8e8" opacity="0.32" filter="url(#softBlur)"/>
+    <ellipse cx="370" cy="222" rx="85"  ry="55" fill="#ffcce0" opacity="0.28" filter="url(#softBlur)"/>
+    <ellipse cx="540" cy="208" rx="70"  ry="48" fill="#ffd4e4" opacity="0.28" filter="url(#softBlur)"/>
+
+    <!-- ── Suzzallo Library style Gothic building ── -->
+    <!-- Building main body -->
+    <rect x="148" y="158" width="304" height="230" fill="url(#stone)" filter="url(#wc)"/>
+    <!-- Side shading -->
+    <rect x="148" y="158" width="304" height="230" fill="url(#stoneShad)" opacity="0.15"/>
+
+    <!-- Gothic parapet crenellation along top -->
+    <rect x="148" y="140" width="304" height="22" fill="#ccc0a0"/>
+    <g fill="#bbb090">
+      <rect x="152" y="128" width="18" height="16"/>
+      <rect x="178" y="128" width="18" height="16"/>
+      <rect x="204" y="128" width="18" height="16"/>
+      <rect x="230" y="128" width="18" height="16"/>
+      <rect x="256" y="128" width="18" height="16"/>
+      <rect x="282" y="128" width="18" height="16"/>
+      <rect x="308" y="128" width="18" height="16"/>
+      <rect x="334" y="128" width="18" height="16"/>
+      <rect x="360" y="128" width="18" height="16"/>
+      <rect x="386" y="128" width="18" height="16"/>
+      <rect x="412" y="128" width="18" height="16"/>
+      <rect x="438" y="128" width="18" height="16"/>
+    </g>
+
+    <!-- Side towers -->
+    <rect x="148" y="100" width="45" height="62" fill="#d0c49a"/>
+    <rect x="407" y="100" width="45" height="62" fill="#d0c49a"/>
+    <!-- Tower tops (pyramidal) -->
+    <polygon points="148,100 170,72 193,100" fill="#bbb080"/>
+    <polygon points="407,100 429,72 452,100" fill="#bbb080"/>
+    <!-- Tower windows -->
+    <rect x="158" y="108" width="12" height="20" fill="#7888a0" rx="2"/>
+    <rect x="178" y="108" width="12" height="20" fill="#7888a0" rx="2"/>
+    <path d="M158,108 Q164,98 170,108" fill="#9090b0"/>
+    <path d="M178,108 Q184,98 190,108" fill="#9090b0"/>
+    <rect x="418" y="108" width="12" height="20" fill="#7888a0" rx="2"/>
+    <rect x="438" y="108" width="12" height="20" fill="#7888a0" rx="2"/>
+    <path d="M418,108 Q424,98 430,108" fill="#9090b0"/>
+    <path d="M438,108 Q444,98 450,108" fill="#9090b0"/>
+
+    <!-- Flying buttresses suggestion -->
+    <line x1="148" y1="250" x2="125" y2="290" stroke="#c0b090" stroke-width="6" opacity="0.7"/>
+    <line x1="148" y1="220" x2="118" y2="260" stroke="#c0b090" stroke-width="4" opacity="0.5"/>
+    <line x1="452" y1="250" x2="475" y2="290" stroke="#c0b090" stroke-width="6" opacity="0.7"/>
+    <line x1="452" y1="220" x2="482" y2="260" stroke="#c0b090" stroke-width="4" opacity="0.5"/>
+
+    <!-- Gothic arched windows (row 1) -->
+    <g fill="#7888a8" opacity="0.75">
+      <rect x="163" y="168" width="22" height="38"/>
+      <path d="M163,168 Q174,152 185,168" fill="#8898b8"/>
+      <rect x="196" y="168" width="22" height="38"/>
+      <path d="M196,168 Q207,152 218,168" fill="#8898b8"/>
+      <rect x="229" y="168" width="22" height="38"/>
+      <path d="M229,168 Q240,152 251,168" fill="#8898b8"/>
+      <rect x="262" y="168" width="22" height="38"/>
+      <path d="M262,168 Q273,152 284,168" fill="#8898b8"/>
+      <rect x="295" y="168" width="22" height="38"/>
+      <path d="M295,168 Q306,152 317,168" fill="#8898b8"/>
+      <rect x="328" y="168" width="22" height="38"/>
+      <path d="M328,168 Q339,152 350,168" fill="#8898b8"/>
+      <rect x="361" y="168" width="22" height="38"/>
+      <path d="M361,168 Q372,152 383,168" fill="#8898b8"/>
+      <rect x="394" y="168" width="22" height="38"/>
+      <path d="M394,168 Q405,152 416,168" fill="#8898b8"/>
+      <rect x="427" y="168" width="22" height="38"/>
+      <path d="M427,168 Q438,152 449,168" fill="#8898b8"/>
+    </g>
+
+    <!-- Gothic arched windows (row 2, slightly larger) -->
+    <g fill="#6878a0" opacity="0.65">
+      <rect x="163" y="222" width="28" height="52"/>
+      <path d="M163,222 Q177,204 191,222" fill="#7888b0"/>
+      <rect x="202" y="222" width="28" height="52"/>
+      <path d="M202,222 Q216,204 230,222" fill="#7888b0"/>
+      <rect x="241" y="222" width="28" height="52"/>
+      <path d="M241,222 Q255,204 269,222" fill="#7888b0"/>
+      <rect x="280" y="222" width="28" height="52"/>
+      <path d="M280,222 Q294,204 308,222" fill="#7888b0"/>
+      <rect x="319" y="222" width="28" height="52"/>
+      <path d="M319,222 Q333,204 347,222" fill="#7888b0"/>
+      <rect x="358" y="222" width="28" height="52"/>
+      <path d="M358,222 Q372,204 386,222" fill="#7888b0"/>
+      <rect x="397" y="222" width="28" height="52"/>
+      <path d="M397,222 Q411,204 425,222" fill="#7888b0"/>
+    </g>
+
+    <!-- Central entrance arch -->
+    <rect x="258" y="290" width="84" height="98" fill="#9a8868"/>
+    <path d="M258,290 Q300,255 342,290" fill="#a89878"/>
+    <!-- Door detail -->
+    <rect x="272" y="320" width="24" height="68" fill="#3a2810"/>
+    <rect x="304" y="320" width="24" height="68" fill="#3a2810"/>
+    <!-- Arch tracery lines -->
+    <path d="M268,290 Q300,262 332,290" fill="none" stroke="#c0b088" stroke-width="2" opacity="0.5"/>
+
+    <!-- Building shadow / depth -->
+    <rect x="148" y="158" width="20" height="230" fill="#000000" opacity="0.06"/>
+
+    <!-- ── Ground Lawn ── -->
+    <rect x="0" y="388" width="600" height="212" fill="url(#groundL)" filter="url(#wc)"/>
+    <!-- Lawn highlight -->
+    <ellipse cx="300" cy="420" rx="250" ry="40" fill="#d8e8a8" opacity="0.3" filter="url(#softBlur)"/>
+
+    <!-- Path to fountain -->
+    <rect x="262" y="388" width="76" height="110" fill="#c8c0a0" opacity="0.5" rx="4"/>
+
+    <!-- ── Drumheller Fountain ── -->
+    <!-- Outer shadow/reflection -->
+    <ellipse cx="300" cy="480" rx="158" ry="62" fill="#6090b0" opacity="0.2" filter="url(#softBlur)"/>
+    <!-- Pool water -->
+    <ellipse cx="300" cy="474" rx="148" ry="58" fill="url(#pool)" filter="url(#wc)"/>
+    <!-- Pool rim (stone curb) -->
+    <ellipse cx="300" cy="474" rx="148" ry="58" fill="none" stroke="#aabcc8" stroke-width="5" opacity="0.7"/>
+    <ellipse cx="300" cy="474" rx="142" ry="54" fill="none" stroke="#ccdde8" stroke-width="2" opacity="0.5"/>
+    <!-- Water shimmer highlights -->
+    <ellipse cx="285" cy="465" rx="45" ry="14" fill="url(#waterShimmer)" opacity="0.7"/>
+    <ellipse cx="330" cy="480" rx="30" ry="10" fill="#ffffff" opacity="0.2"/>
+    <ellipse cx="260" cy="480" rx="20" ry="6" fill="#ffffff" opacity="0.18"/>
+    <!-- Petal reflections in pool -->
+    <ellipse cx="268" cy="472" rx="6" ry="2" fill="#ffbbdd" opacity="0.4" transform="rotate(-10,268,472)"/>
+    <ellipse cx="338" cy="468" rx="5" ry="2" fill="#ffaac8" opacity="0.35" transform="rotate(15,338,468)"/>
+
+    <!-- Fountain pedestal -->
+    <ellipse cx="300" cy="455" rx="22" ry="9" fill="#c8b888"/>
+    <rect x="291" y="420" width="18" height="37" fill="#d0c090"/>
+    <ellipse cx="300" cy="420" rx="26" ry="10" fill="#dcd0a8"/>
+    <ellipse cx="300" cy="418" rx="18" ry="7" fill="#ccc0a0"/>
+
+    <!-- Fountain water jets -->
+    <!-- Central tall jet -->
+    <path d="M299,416 C297,390 296,365 299,338 C302,365 303,390 301,416 Z" fill="#b8dcf4" opacity="0.75"/>
+    <path d="M300,415 Q299,378 300,340 Q301,378 300,415" fill="#d8eff8" opacity="0.5"/>
+    <!-- Upper spray droplets at top of center jet -->
+    <circle cx="299" cy="338" r="3" fill="#d8eef8" opacity="0.7"/>
+    <circle cx="301" cy="342" r="2" fill="#e8f4fc" opacity="0.6"/>
+    <circle cx="297" cy="344" r="2" fill="#e0f0f8" opacity="0.6"/>
+
+    <!-- Mid-ring jets (8 jets angled out) -->
+    <path d="M300,415 Q285,393 266,374" stroke="#b0d0ec" stroke-width="3" fill="none" stroke-linecap="round" opacity="0.7"/>
+    <path d="M300,415 Q315,393 334,374" stroke="#b0d0ec" stroke-width="3" fill="none" stroke-linecap="round" opacity="0.7"/>
+    <path d="M300,415 Q278,395 256,379" stroke="#a8c8e4" stroke-width="2.5" fill="none" stroke-linecap="round" opacity="0.6"/>
+    <path d="M300,415 Q322,395 344,379" stroke="#a8c8e4" stroke-width="2.5" fill="none" stroke-linecap="round" opacity="0.6"/>
+    <path d="M300,415 Q282,396 262,384" stroke="#a0c0dc" stroke-width="2" fill="none" stroke-linecap="round" opacity="0.5"/>
+    <path d="M300,415 Q318,396 338,384" stroke="#a0c0dc" stroke-width="2" fill="none" stroke-linecap="round" opacity="0.5"/>
+    <path d="M300,415 Q300,396 300,378" stroke="#b8d8f0" stroke-width="2.5" fill="none" stroke-linecap="round" opacity="0.55"/>
+    <!-- Spray endpoints -->
+    <circle cx="266" cy="374" r="2.5" fill="#d0e8f8" opacity="0.8"/>
+    <circle cx="334" cy="374" r="2.5" fill="#d0e8f8" opacity="0.8"/>
+    <circle cx="256" cy="379" r="2" fill="#c8e4f4" opacity="0.7"/>
+    <circle cx="344" cy="379" r="2" fill="#c8e4f4" opacity="0.7"/>
+    <circle cx="262" cy="384" r="2" fill="#c0ddf0" opacity="0.65"/>
+    <circle cx="338" cy="384" r="2" fill="#c0ddf0" opacity="0.65"/>
+
+    <!-- Low outer ring spray (wider arcs) -->
+    <path d="M300,418 Q270,405 245,398" stroke="#90b8d8" stroke-width="2" fill="none" stroke-linecap="round" opacity="0.5"/>
+    <path d="M300,418 Q330,405 355,398" stroke="#90b8d8" stroke-width="2" fill="none" stroke-linecap="round" opacity="0.5"/>
+    <path d="M300,420 Q268,410 242,408" stroke="#88b0d0" stroke-width="1.5" fill="none" stroke-linecap="round" opacity="0.4"/>
+    <path d="M300,420 Q332,410 358,408" stroke="#88b0d0" stroke-width="1.5" fill="none" stroke-linecap="round" opacity="0.4"/>
+
+    <!-- ── Cherry blossom trees ── -->
+    <!-- FAR LEFT tree (partially cut off) -->
+    <path d="M-10,580 Q0,530 8,480 Q14,440 20,400 Q25,368 30,338" stroke="#7a5030" stroke-width="9" fill="none" stroke-linecap="round"/>
+    <path d="M30,338 Q38,308 46,285" stroke="#7a5030" stroke-width="5" fill="none"/>
+    <path d="M30,338 Q20,310 14,285" stroke="#7a5030" stroke-width="4" fill="none"/>
+    <ellipse cx="32" cy="258" rx="72" ry="65" fill="url(#cpink)" opacity="0.85" filter="url(#wc)"/>
+    <ellipse cx="18" cy="272" rx="52" ry="48" fill="#ffcce0" opacity="0.6"/>
+    <ellipse cx="48" cy="255" rx="60" ry="54" fill="#ffd4e6" opacity="0.55"/>
+    <ellipse cx="28" cy="244" rx="65" ry="58" fill="#ffbbcc" opacity="0.35" filter="url(#softBlur)"/>
+
+    <!-- LEFT MAIN tree -->
+    <path d="M105,580 Q108,530 112,478 Q115,440 118,400 Q122,368 126,335" stroke="#7a5030" stroke-width="10" fill="none" stroke-linecap="round"/>
+    <path d="M126,335 Q134,305 143,278" stroke="#7a5030" stroke-width="6" fill="none"/>
+    <path d="M126,335 Q115,306 108,280" stroke="#7a5030" stroke-width="5" fill="none"/>
+    <path d="M126,335 Q138,315 150,300" stroke="#7a5030" stroke-width="4" fill="none"/>
+    <!-- Lower branch -->
+    <path d="M118,400 Q100,380 88,362" stroke="#7a5030" stroke-width="4" fill="none"/>
+    <ellipse cx="78" cy="352" rx="38" ry="34" fill="#ffcce0" opacity="0.72"/>
+    <!-- Canopy -->
+    <ellipse cx="132" cy="250" rx="90" ry="80" fill="url(#cpink)" opacity="0.88" filter="url(#wc)"/>
+    <ellipse cx="112" cy="265" rx="65" ry="60" fill="#ffcce0" opacity="0.62"/>
+    <ellipse cx="150" cy="248" rx="72" ry="65" fill="#ffd8e8" opacity="0.58"/>
+    <ellipse cx="128" cy="238" rx="80" ry="72" fill="#ffbbcc" opacity="0.38" filter="url(#softBlur)"/>
+    <!-- Blossom clusters detail -->
+    <g opacity="0.75">
+      <circle cx="110" cy="238" r="6" fill="#ffd8ee"/>
+      <circle cx="130" cy="225" r="5" fill="#ffc0d8"/>
+      <circle cx="150" cy="240" r="6" fill="#ffd4e8"/>
+      <circle cx="118" cy="258" r="5" fill="#ffc8dc"/>
+      <circle cx="145" cy="255" r="5" fill="#ffd8ee"/>
+      <circle cx="96" cy="252" r="4" fill="#ffcce4"/>
+      <circle cx="138" cy="268" r="4" fill="#ffb8d0"/>
+    </g>
+
+    <!-- Small MID-LEFT tree -->
+    <path d="M208,560 Q210,528 213,498 Q216,472 219,448 Q221,430 223,412" stroke="#6a4422" stroke-width="6" fill="none" stroke-linecap="round"/>
+    <path d="M223,412 Q228,390 234,372" stroke="#6a4422" stroke-width="4" fill="none"/>
+    <path d="M223,412 Q216,390 211,372" stroke="#6a4422" stroke-width="3" fill="none"/>
+    <ellipse cx="224" cy="352" rx="52" ry="46" fill="url(#cwhite)" opacity="0.82" filter="url(#wc)"/>
+    <ellipse cx="218" cy="362" rx="40" ry="36" fill="#ffeef4" opacity="0.65"/>
+    <ellipse cx="232" cy="348" rx="46" ry="42" fill="#ffe8f2" opacity="0.6"/>
+
+    <!-- Small MID-RIGHT tree -->
+    <path d="M392,560 Q390,528 387,498 Q384,472 381,448 Q379,430 377,412" stroke="#6a4422" stroke-width="6" fill="none" stroke-linecap="round"/>
+    <path d="M377,412 Q372,390 366,372" stroke="#6a4422" stroke-width="4" fill="none"/>
+    <path d="M377,412 Q384,390 389,372" stroke="#6a4422" stroke-width="3" fill="none"/>
+    <ellipse cx="376" cy="352" rx="52" ry="46" fill="url(#cpink)" opacity="0.82" filter="url(#wc)"/>
+    <ellipse cx="382" cy="362" rx="40" ry="36" fill="#ffd0e4" opacity="0.65"/>
+    <ellipse cx="370" cy="348" rx="46" ry="42" fill="#ffccdc" opacity="0.6"/>
+
+    <!-- RIGHT MAIN tree -->
+    <path d="M510,580 Q507,530 504,478 Q501,440 498,400 Q495,368 492,335" stroke="#7a5030" stroke-width="10" fill="none" stroke-linecap="round"/>
+    <path d="M492,335 Q484,305 477,278" stroke="#7a5030" stroke-width="6" fill="none"/>
+    <path d="M492,335 Q502,306 509,280" stroke="#7a5030" stroke-width="5" fill="none"/>
+    <path d="M492,335 Q480,315 470,300" stroke="#7a5030" stroke-width="4" fill="none"/>
+    <!-- Lower branch -->
+    <path d="M498,400 Q516,380 528,362" stroke="#7a5030" stroke-width="4" fill="none"/>
+    <ellipse cx="538" cy="352" rx="38" ry="34" fill="#ffd8e8" opacity="0.72"/>
+    <!-- Canopy -->
+    <ellipse cx="486" cy="250" rx="90" ry="80" fill="url(#cwhite)" opacity="0.88" filter="url(#wc)"/>
+    <ellipse cx="505" cy="265" rx="66" ry="60" fill="#ffeef6" opacity="0.62"/>
+    <ellipse cx="470" cy="248" rx="74" ry="65" fill="#ffe8f4" opacity="0.58"/>
+    <ellipse cx="488" cy="238" rx="82" ry="72" fill="#ffd8e8" opacity="0.38" filter="url(#softBlur)"/>
+    <!-- Blossom clusters detail -->
+    <g opacity="0.75">
+      <circle cx="490" cy="238" r="6" fill="#fff4fa"/>
+      <circle cx="468" cy="225" r="5" fill="#ffeaf4"/>
+      <circle cx="508" cy="242" r="6" fill="#fff0f8"/>
+      <circle cx="478" cy="258" r="5" fill="#ffe4f0"/>
+      <circle cx="502" cy="255" r="5" fill="#fff4fa"/>
+      <circle cx="462" cy="252" r="4" fill="#ffd8ec"/>
+      <circle cx="488" cy="270" r="4" fill="#ffe0ee"/>
+    </g>
+
+    <!-- FAR RIGHT tree (partially cut off) -->
+    <path d="M614,580 Q610,530 607,480 Q604,440 601,400 Q598,368 595,338" stroke="#7a5030" stroke-width="9" fill="none" stroke-linecap="round"/>
+    <ellipse cx="592" cy="258" rx="72" ry="65" fill="url(#cdeep)" opacity="0.82" filter="url(#wc)"/>
+    <ellipse cx="578" cy="272" rx="52" ry="48" fill="#ffccdc" opacity="0.6"/>
+
+    <!-- Scattered petals on ground -->
+    <g opacity="0.65">
+      <ellipse cx="168" cy="528" rx="5" ry="2.2" fill="#ffaac8" transform="rotate(-18,168,528)"/>
+      <ellipse cx="215" cy="515" rx="4.5" ry="2" fill="#ffbbcc" transform="rotate(25,215,515)"/>
+      <ellipse cx="258" cy="530" rx="5" ry="2.2" fill="#ffaac0" transform="rotate(-8,258,530)"/>
+      <ellipse cx="300" cy="520" rx="4" ry="2" fill="#ffbbdd" transform="rotate(35,300,520)"/>
+      <ellipse cx="345" cy="512" rx="5" ry="2.2" fill="#ffaacc" transform="rotate(-22,345,512)"/>
+      <ellipse cx="398" cy="525" rx="4.5" ry="2" fill="#ffbbcc" transform="rotate(12,398,525)"/>
+      <ellipse cx="445" cy="518" rx="5" ry="2.2" fill="#ffaac8" transform="rotate(-30,445,518)"/>
+      <ellipse cx="490" cy="530" rx="4" ry="2" fill="#ffbbdd" transform="rotate(18,490,530)"/>
+      <ellipse cx="140" cy="510" rx="4.5" ry="2" fill="#ffccdd" transform="rotate(40,140,510)"/>
+      <ellipse cx="530" cy="510" rx="4" ry="2" fill="#ffbbcc" transform="rotate(-14,530,510)"/>
+    </g>
+
+    <!-- Falling petals (in air) -->
+    <g opacity="0.72">
+      <ellipse cx="152" cy="340" rx="4.5" ry="2" fill="#ffbbdd" transform="rotate(22,152,340)"/>
+      <ellipse cx="195" cy="358" rx="3.5" ry="1.8" fill="#ffc8d8" transform="rotate(-14,195,358)"/>
+      <ellipse cx="240" cy="318" rx="4.5" ry="2" fill="#ffaac8" transform="rotate(38,240,318)"/>
+      <ellipse cx="172" cy="390" rx="3.5" ry="1.8" fill="#ffbbdd" transform="rotate(-28,172,390)"/>
+      <ellipse cx="445" cy="328" rx="4.5" ry="2" fill="#ffd0e4" transform="rotate(14,445,328)"/>
+      <ellipse cx="475" cy="360" rx="3.5" ry="1.8" fill="#ffbbcc" transform="rotate(-22,475,360)"/>
+      <ellipse cx="395" cy="308" rx="4.5" ry="2" fill="#ffcce0" transform="rotate(32,395,308)"/>
+      <ellipse cx="330" cy="290" rx="4" ry="1.8" fill="#ffaac8" transform="rotate(-10,330,290)"/>
+      <ellipse cx="280" cy="340" rx="3.5" ry="1.8" fill="#ffbbdd" transform="rotate(44,280,340)"/>
+      <ellipse cx="420" cy="390" rx="4" ry="1.8" fill="#ffcce0" transform="rotate(-34,420,390)"/>
+    </g>
+
+    <!-- Scene label -->
+    <rect x="0" y="570" width="600" height="30" fill="#f5eaee" opacity="0.6"/>
+    <text x="300" y="590" text-anchor="middle" font-family="Georgia, 'Times New Roman', serif"
+          font-size="14" fill="#6a3850" opacity="0.9" letter-spacing="1">
+      UW Seattle — Drumheller Fountain
+    </text>
+  </g>
+
+
+  <!-- ════════════════════════════════════════════
+       RIGHT SCENE  –  Tokyo / Senso-ji Pagoda
+       ════════════════════════════════════════════ -->
+  <g clip-path="url(#clipR)">
+
+    <!-- Sky wash -->
+    <rect x="600" y="0" width="600" height="600" fill="url(#skyR)"/>
+
+    <!-- Soft clouds / sky blush -->
+    <ellipse cx="720"  cy="75" rx="120" ry="50" fill="#ffe8f0" opacity="0.18" filter="url(#softBlur)"/>
+    <ellipse cx="980"  cy="55" rx="150" ry="55" fill="#e0d8f4" opacity="0.17" filter="url(#softBlur)"/>
+    <ellipse cx="1160" cy="95" rx="85"  ry="38" fill="#ffd8e8" opacity="0.15" filter="url(#softBlur)"/>
+
+    <!-- Misty distant mountains -->
+    <path d="M600,360 Q660,290 740,310 Q820,278 900,298 Q990,262 1080,285 Q1150,268 1200,285
+             L1200,390 L600,390 Z" fill="#b0c4d8" opacity="0.22" filter="url(#softBlur)"/>
+    <path d="M600,390 Q680,335 770,352 Q860,318 940,338 Q1020,308 1100,328 Q1160,315 1200,328
+             L1200,408 L600,408 Z" fill="#c0ced8" opacity="0.18" filter="url(#softBlur)"/>
+
+    <!-- Background blossom haze -->
+    <ellipse cx="635"  cy="230" rx="72" ry="52" fill="#ffd0e0" opacity="0.28" filter="url(#softBlur)"/>
+    <ellipse cx="730"  cy="210" rx="90" ry="62" fill="#ffcce0" opacity="0.32" filter="url(#softBlur)"/>
+    <ellipse cx="1105" cy="220" rx="82" ry="58" fill="#ffd4e4" opacity="0.28" filter="url(#softBlur)"/>
+    <ellipse cx="1185" cy="238" rx="68" ry="50" fill="#ffcce0" opacity="0.28" filter="url(#softBlur)"/>
+
+    <!-- ── 5-story Senso-ji style Pagoda ── -->
+    <!-- BASE PLATFORM -->
+    <rect x="825" y="448" width="150" height="16" fill="#c8b888" rx="2"/>
+    <rect x="818" y="464" width="164" height="12" fill="#b8a878" rx="2"/>
+    <rect x="808" y="476" width="184" height="14" fill="#a89868" rx="3"/>
+
+    <!-- STORY 1 (bottom) -->
+    <rect x="835" y="390" width="130" height="58" fill="url(#roofBody)"/>
+    <!-- Story 1 windows/door -->
+    <rect x="868" y="408" width="26" height="40" fill="#2a1600" rx="2"/>
+    <rect x="906" y="408" width="26" height="40" fill="#2a1600" rx="2"/>
+    <rect x="848" y="415" width="14" height="22" fill="#2a1600" rx="1"/>
+    <rect x="938" y="415" width="14" height="22" fill="#2a1600" rx="1"/>
+    <!-- Story 1 beam line -->
+    <rect x="832" y="388" width="136" height="7" fill="#8a1400"/>
+    <!-- ROOF 1 (large, dramatic eave) -->
+    <path d="M785,388 Q900,358 1015,388 L1008,381 Q900,353 792,381 Z" fill="url(#roof)"/>
+    <!-- Eave upcurve tips -->
+    <path d="M785,388 Q775,378 778,366" stroke="#7a1200" stroke-width="3" fill="none" stroke-linecap="round"/>
+    <path d="M1015,388 Q1025,378 1022,366" stroke="#7a1200" stroke-width="3" fill="none" stroke-linecap="round"/>
+    <!-- Roof underside detail -->
+    <path d="M792,381 Q900,351 1008,381 L1015,388 Q900,358 785,388 Z" fill="#c82800" opacity="0.4"/>
+
+    <!-- STORY 2 -->
+    <rect x="848" y="335" width="104" height="55" fill="url(#roofBody)"/>
+    <!-- Story 2 windows -->
+    <rect x="876" y="350" width="18" height="30" fill="#2a1600" rx="1"/>
+    <rect x="906" y="350" width="18" height="30" fill="#2a1600" rx="1"/>
+    <rect x="860" y="356" width="10" height="18" fill="#2a1600" rx="1"/>
+    <rect x="930" y="356" width="10" height="18" fill="#2a1600" rx="1"/>
+    <!-- Story 2 beam -->
+    <rect x="845" y="333" width="110" height="7" fill="#8a1400"/>
+    <!-- ROOF 2 -->
+    <path d="M800,333 Q900,306 1000,333 L993,327 Q900,302 807,327 Z" fill="url(#roof)"/>
+    <path d="M800,333 Q790,324 793,313" stroke="#7a1200" stroke-width="2.5" fill="none" stroke-linecap="round"/>
+    <path d="M1000,333 Q1010,324 1007,313" stroke="#7a1200" stroke-width="2.5" fill="none" stroke-linecap="round"/>
+    <path d="M807,327 Q900,300 993,327 L1000,333 Q900,306 800,333 Z" fill="#c82800" opacity="0.38"/>
+
+    <!-- STORY 3 -->
+    <rect x="860" y="282" width="80" height="53" fill="url(#roofBody)"/>
+    <!-- Story 3 windows -->
+    <rect x="882" y="297" width="14" height="25" fill="#2a1600" rx="1"/>
+    <rect x="904" y="297" width="14" height="25" fill="#2a1600" rx="1"/>
+    <!-- Story 3 beam -->
+    <rect x="857" y="280" width="86" height="7" fill="#8a1400"/>
+    <!-- ROOF 3 -->
+    <path d="M818,280 Q900,256 982,280 L976,275 Q900,252 824,275 Z" fill="url(#roof)"/>
+    <path d="M818,280 Q808,271 811,262" stroke="#7a1200" stroke-width="2" fill="none" stroke-linecap="round"/>
+    <path d="M982,280 Q992,271 989,262" stroke="#7a1200" stroke-width="2" fill="none" stroke-linecap="round"/>
+    <path d="M824,275 Q900,250 976,275 L982,280 Q900,256 818,280 Z" fill="#c82800" opacity="0.36"/>
+
+    <!-- STORY 4 -->
+    <rect x="872" y="230" width="56" height="52" fill="url(#roofBody)"/>
+    <!-- Story 4 windows -->
+    <rect x="886" y="245" width="10" height="22" fill="#2a1600" rx="1"/>
+    <rect x="904" y="245" width="10" height="22" fill="#2a1600" rx="1"/>
+    <!-- Story 4 beam -->
+    <rect x="869" y="228" width="62" height="7" fill="#8a1400"/>
+    <!-- ROOF 4 -->
+    <path d="M836,228 Q900,207 964,228 L958,223 Q900,203 842,223 Z" fill="url(#roof)"/>
+    <path d="M836,228 Q827,220 830,211" stroke="#7a1200" stroke-width="2" fill="none" stroke-linecap="round"/>
+    <path d="M964,228 Q973,220 970,211" stroke="#7a1200" stroke-width="2" fill="none" stroke-linecap="round"/>
+    <path d="M842,223 Q900,201 958,223 L964,228 Q900,207 836,228 Z" fill="#c82800" opacity="0.34"/>
+
+    <!-- STORY 5 (top) -->
+    <rect x="882" y="180" width="36" height="50" fill="url(#roofBody)"/>
+    <!-- Story 5 tiny window -->
+    <rect x="893" y="195" width="7" height="18" fill="#2a1600" rx="1"/>
+    <rect x="900" y="195" width="7" height="18" fill="#2a1600" rx="1"/>
+    <!-- Story 5 beam -->
+    <rect x="879" y="178" width="42" height="6" fill="#8a1400"/>
+    <!-- ROOF 5 -->
+    <path d="M852,178 Q900,160 948,178 L943,174 Q900,157 857,174 Z" fill="url(#roof)"/>
+    <path d="M852,178 Q844,171 847,163" stroke="#7a1200" stroke-width="1.8" fill="none" stroke-linecap="round"/>
+    <path d="M948,178 Q956,171 953,163" stroke="#7a1200" stroke-width="1.8" fill="none" stroke-linecap="round"/>
+    <path d="M857,174 Q900,155 943,174 L948,178 Q900,160 852,178 Z" fill="#c82800" opacity="0.32"/>
+
+    <!-- SPIRE / SORIN -->
+    <rect x="897" y="115" width="6" height="65" fill="#9a7828"/>
+    <!-- Spire rings (suien) -->
+    <ellipse cx="900" cy="114" r="7"   fill="#c8a030"/>
+    <ellipse cx="900" cy="105" r="5.5" fill="#b89028"/>
+    <ellipse cx="900" cy="97"  r="4.8" fill="#b09020"/>
+    <ellipse cx="900" cy="90"  r="4.2" fill="#a88020"/>
+    <ellipse cx="900" cy="84"  r="3.8" fill="#a87818"/>
+    <ellipse cx="900" cy="79"  r="3.4" fill="#986810"/>
+    <ellipse cx="900" cy="75"  r="2.5" fill="#906008"/>
+    <!-- Tip -->
+    <path d="M899,74 Q900,68 901,74" fill="#808000"/>
+
+    <!-- ── Torii Gate ── -->
+    <!-- Left post (hashira) -->
+    <rect x="758" y="395" width="13" height="115" fill="#cc2200" rx="2"/>
+    <!-- Right post -->
+    <rect x="886" y="395" width="13" height="115" fill="#cc2200" rx="2"/>
+    <!-- Top beam - kasagi (slightly wider, upturned ends) -->
+    <path d="M748,388 Q757,385 770,388 L886,388 Q896,385 910,388 Q896,382 886,385 L770,385 Q757,382 748,388 Z"
+          fill="#bb1e00"/>
+    <rect x="748" y="382" width="162" height="11" fill="#cc2200" rx="2"/>
+    <!-- Kasagi end caps -->
+    <path d="M748,382 Q742,379 745,374" stroke="#aa1800" stroke-width="2" fill="none"/>
+    <path d="M910,382 Q916,379 913,374" stroke="#aa1800" stroke-width="2" fill="none"/>
+    <!-- Lower beam (nuki) -->
+    <rect x="761" y="404" width="135" height="9" fill="#bb1e00" rx="1"/>
+    <!-- Post caps (gakozuka) -->
+    <rect x="756" y="386" width="17" height="9" fill="#992000" rx="1"/>
+    <rect x="884" y="386" width="17" height="9" fill="#992000" rx="1"/>
+    <!-- Wedge pegs (kusabi) on nuki -->
+    <rect x="792" y="402" width="5" height="13" fill="#881800"/>
+    <rect x="860" y="402" width="5" height="13" fill="#881800"/>
+
+    <!-- ── Stone Lanterns ── -->
+    <!-- Left lantern (toro) -->
+    <rect x="746" y="472" width="18" height="8" fill="#b0a888" rx="1"/><!-- base -->
+    <rect x="750" y="454" width="10" height="18" fill="#c0b890" rx="1"/><!-- shaft -->
+    <path d="M749,454 L751,446 L764,446 L766,454 Z" fill="#b8b088"/><!-- cap -->
+    <rect x="753" y="443" width="9" height="5" fill="#a8a078" rx="1"/>
+    <!-- Lantern fire box -->
+    <rect x="748" y="456" width="14" height="14" fill="#ffe8a0" opacity="0.6" rx="1"/>
+    <rect x="748" y="456" width="14" height="14" fill="none" stroke="#a89868" stroke-width="1.5" rx="1"/>
+    <!-- Right lantern -->
+    <rect x="893" y="472" width="18" height="8" fill="#b0a888" rx="1"/>
+    <rect x="897" y="454" width="10" height="18" fill="#c0b890" rx="1"/>
+    <path d="M896,454 L898,446 L911,446 L913,454 Z" fill="#b8b088"/>
+    <rect x="900" y="443" width="9" height="5" fill="#a8a078" rx="1"/>
+    <rect x="895" y="456" width="14" height="14" fill="#ffe8a0" opacity="0.6" rx="1"/>
+    <rect x="895" y="456" width="14" height="14" fill="none" stroke="#a89868" stroke-width="1.5" rx="1"/>
+
+    <!-- ── Ground and stone path ── -->
+    <rect x="600" y="490" width="600" height="110" fill="url(#groundR)" filter="url(#wc)"/>
+    <!-- Path from gate to steps -->
+    <path d="M840,600 Q848,550 856,510 Q862,492 868,482" stroke="#c8b880" stroke-width="32" fill="none" opacity="0.45" stroke-linecap="round"/>
+    <path d="M960,600 Q952,550 944,510 Q938,492 932,482" stroke="#c8b880" stroke-width="32" fill="none" opacity="0.45" stroke-linecap="round"/>
+    <path d="M900,600 Q900,550 900,510 Q900,492 900,482" stroke="#d4c890" stroke-width="52" fill="none" opacity="0.3" stroke-linecap="round"/>
+    <!-- Stone pavers -->
+    <g opacity="0.6">
+      <ellipse cx="878" cy="525" rx="20" ry="9" fill="#d4cc98" transform="rotate(-5,878,525)"/>
+      <ellipse cx="900" cy="545" rx="22" ry="9" fill="#ccc490" transform="rotate(3,900,545)"/>
+      <ellipse cx="922" cy="522" rx="20" ry="9" fill="#d4cc98" transform="rotate(6,922,522)"/>
+      <ellipse cx="886" cy="558" rx="17" ry="7" fill="#ccc490" transform="rotate(-4,886,558)"/>
+      <ellipse cx="914" cy="560" rx="18" ry="7" fill="#d4cc98" transform="rotate(7,914,560)"/>
+      <ellipse cx="870" cy="540" rx="15" ry="6" fill="#ccc490" transform="rotate(-8,870,540)"/>
+      <ellipse cx="930" cy="542" rx="16" ry="6" fill="#d4cc98" transform="rotate(5,930,542)"/>
+    </g>
+    <!-- Moss/grass patches -->
+    <ellipse cx="800" cy="510" rx="30" ry="12" fill="#7a9848" opacity="0.4" filter="url(#softBlur)"/>
+    <ellipse cx="1005" cy="515" rx="28" ry="11" fill="#7a9848" opacity="0.4" filter="url(#softBlur)"/>
+    <ellipse cx="640" cy="535" rx="35" ry="14" fill="#8a9858" opacity="0.35" filter="url(#softBlur)"/>
+    <ellipse cx="1160" cy="530" rx="30" ry="12" fill="#8a9858" opacity="0.35" filter="url(#softBlur)"/>
+
+    <!-- ── Cherry blossom trees flanking pagoda ── -->
+    <!-- FAR LEFT tree (partial) -->
+    <path d="M600,600 Q604,548 608,498 Q612,458 616,420 Q619,390 622,358" stroke="#7a5030" stroke-width="8" fill="none" stroke-linecap="round"/>
+    <path d="M622,358 Q628,328 634,300" stroke="#7a5030" stroke-width="5" fill="none"/>
+    <path d="M622,358 Q614,328 608,300" stroke="#7a5030" stroke-width="4" fill="none"/>
+    <ellipse cx="624" cy="272" rx="80" ry="72" fill="url(#cdeep)" opacity="0.85" filter="url(#wc)"/>
+    <ellipse cx="610" cy="286" rx="60" ry="55" fill="#ffccdc" opacity="0.62"/>
+    <ellipse cx="636" cy="268" rx="68" ry="62" fill="#ffb8cc" opacity="0.55"/>
+
+    <!-- LEFT MAIN tree -->
+    <path d="M705,600 Q708,548 712,498 Q715,456 719,418 Q722,386 726,352" stroke="#7a5030" stroke-width="11" fill="none" stroke-linecap="round"/>
+    <path d="M726,352 Q734,320 742,290" stroke="#7a5030" stroke-width="6" fill="none"/>
+    <path d="M726,352 Q716,322 709,292" stroke="#7a5030" stroke-width="5" fill="none"/>
+    <path d="M726,352 Q740,330 752,314" stroke="#6a4020" stroke-width="4" fill="none"/>
+    <!-- Left overhanging branch toward pagoda -->
+    <path d="M719,418 Q740,398 760,380" stroke="#7a5030" stroke-width="4" fill="none"/>
+    <ellipse cx="772" cy="370" rx="42" ry="36" fill="#ffcce0" opacity="0.68"/>
+    <!-- Main canopy -->
+    <ellipse cx="732" cy="258" rx="100" ry="90" fill="url(#cpink)" opacity="0.88" filter="url(#wc)"/>
+    <ellipse cx="714" cy="272" rx="74" ry="68" fill="#ffcce0" opacity="0.62"/>
+    <ellipse cx="750" cy="256" rx="80" ry="72" fill="#ffd4e4" opacity="0.58"/>
+    <ellipse cx="728" cy="244" rx="90" ry="80" fill="#ffaac4" opacity="0.36" filter="url(#softBlur)"/>
+    <!-- Blossom clusters detail -->
+    <g opacity="0.78">
+      <circle cx="712" cy="242" r="7" fill="#ffd4e8"/>
+      <circle cx="734" cy="228" r="6" fill="#ffbcd8"/>
+      <circle cx="752" cy="244" r="7" fill="#ffcce0"/>
+      <circle cx="718" cy="262" r="5" fill="#ffc4d8"/>
+      <circle cx="746" cy="260" r="6" fill="#ffd4e8"/>
+      <circle cx="700" cy="256" r="5" fill="#ffcce0"/>
+      <circle cx="760" cy="268" r="5" fill="#ffb8cc"/>
+    </g>
+
+    <!-- RIGHT MAIN tree -->
+    <path d="M1095,600 Q1092,548 1088,498 Q1085,456 1081,418 Q1078,386 1074,352" stroke="#7a5030" stroke-width="11" fill="none" stroke-linecap="round"/>
+    <path d="M1074,352 Q1066,320 1058,290" stroke="#7a5030" stroke-width="6" fill="none"/>
+    <path d="M1074,352 Q1084,322 1091,292" stroke="#7a5030" stroke-width="5" fill="none"/>
+    <path d="M1074,352 Q1060,330 1048,314" stroke="#6a4020" stroke-width="4" fill="none"/>
+    <!-- Right overhanging branch toward pagoda -->
+    <path d="M1081,418 Q1060,398 1040,380" stroke="#7a5030" stroke-width="4" fill="none"/>
+    <ellipse cx="1028" cy="370" rx="42" ry="36" fill="#ffe8f4" opacity="0.68"/>
+    <!-- Main canopy -->
+    <ellipse cx="1068" cy="258" rx="100" ry="90" fill="url(#cwhite)" opacity="0.88" filter="url(#wc)"/>
+    <ellipse cx="1086" cy="272" rx="76" ry="68" fill="#fff0f8" opacity="0.62"/>
+    <ellipse cx="1050" cy="256" rx="82" ry="72" fill="#ffe8f4" opacity="0.58"/>
+    <ellipse cx="1070" cy="244" rx="92" ry="80" fill="#ffd8ec" opacity="0.36" filter="url(#softBlur)"/>
+    <!-- Blossom clusters detail -->
+    <g opacity="0.78">
+      <circle cx="1088" cy="242" r="7" fill="#fff4fa"/>
+      <circle cx="1066" cy="228" r="6" fill="#ffe8f4"/>
+      <circle cx="1048" cy="244" r="7" fill="#fff0f8"/>
+      <circle cx="1082" cy="262" r="5" fill="#ffe4f0"/>
+      <circle cx="1054" cy="260" r="6" fill="#fff4fa"/>
+      <circle cx="1100" cy="256" r="5" fill="#ffe0ee"/>
+      <circle cx="1040" cy="268" r="5" fill="#ffd8ec"/>
+    </g>
+
+    <!-- FAR RIGHT tree (partial) -->
+    <path d="M1200,600 Q1196,548 1192,498 Q1188,458 1184,420 Q1181,390 1178,358" stroke="#7a5030" stroke-width="8" fill="none" stroke-linecap="round"/>
+    <ellipse cx="1176" cy="272" rx="80" ry="72" fill="url(#cpink)" opacity="0.85" filter="url(#wc)"/>
+    <ellipse cx="1190" cy="286" rx="60" ry="55" fill="#ffcce0" opacity="0.62"/>
+
+    <!-- Scattered ground petals -->
+    <g opacity="0.65">
+      <ellipse cx="808" cy="497" rx="5" ry="2.2" fill="#ffaac8" transform="rotate(-20,808,497)"/>
+      <ellipse cx="845" cy="488" rx="4.5" ry="2" fill="#ffbbcc" transform="rotate(28,845,488)"/>
+      <ellipse cx="952" cy="493" rx="5" ry="2.2" fill="#ffaac0" transform="rotate(-10,952,493)"/>
+      <ellipse cx="996" cy="502" rx="4" ry="2" fill="#ffbbdd" transform="rotate(34,996,502)"/>
+      <ellipse cx="680" cy="520" rx="5" ry="2.2" fill="#ffaacc" transform="rotate(-24,680,520)"/>
+      <ellipse cx="1125" cy="515" rx="4.5" ry="2" fill="#ffbbcc" transform="rotate(14,1125,515)"/>
+      <ellipse cx="740" cy="508" rx="5" ry="2.2" fill="#ffaac8" transform="rotate(-32,740,508)"/>
+      <ellipse cx="1060" cy="510" rx="4" ry="2" fill="#ffbbdd" transform="rotate(20,1060,510)"/>
+    </g>
+
+    <!-- Falling petals (in air) -->
+    <g opacity="0.72">
+      <ellipse cx="762" cy="348" rx="4.5" ry="2" fill="#ffbbdd" transform="rotate(20,762,348)"/>
+      <ellipse cx="802" cy="335" rx="3.5" ry="1.8" fill="#ffccd8" transform="rotate(-16,802,335)"/>
+      <ellipse cx="845" cy="368" rx="4.5" ry="2" fill="#ffaac8" transform="rotate(36,845,368)"/>
+      <ellipse cx="775" cy="395" rx="3.5" ry="1.8" fill="#ffbbdd" transform="rotate(-26,775,395)"/>
+      <ellipse cx="1022" cy="342" rx="4.5" ry="2" fill="#ffe0f0" transform="rotate(16,1022,342)"/>
+      <ellipse cx="1060" cy="362" rx="3.5" ry="1.8" fill="#ffcce0" transform="rotate(-24,1060,362)"/>
+      <ellipse cx="980" cy="318" rx="4.5" ry="2" fill="#ffd8ec" transform="rotate(38,980,318)"/>
+      <ellipse cx="950" cy="375" rx="3.5" ry="1.8" fill="#ffe0f0" transform="rotate(-12,950,375)"/>
+      <ellipse cx="860" cy="302" rx="4" ry="1.8" fill="#ffbbdd" transform="rotate(44,860,302)"/>
+      <ellipse cx="940" cy="290" rx="4" ry="1.8" fill="#ffcce0" transform="rotate(-8,940,290)"/>
+    </g>
+
+    <!-- Scene label -->
+    <rect x="600" y="570" width="600" height="30" fill="#f5eaee" opacity="0.6"/>
+    <text x="900" y="590" text-anchor="middle" font-family="Georgia, 'Times New Roman', serif"
+          font-size="14" fill="#6a3850" opacity="0.9" letter-spacing="1">
+      Senso-ji Temple — Tokyo
+    </text>
+  </g>
+
+
+  <!-- ════════════════════════════════════════════
+       GLOBAL FINISHING TOUCHES
+       ════════════════════════════════════════════ -->
+
+  <!-- Center divider -->
+  <line x1="600" y1="0" x2="600" y2="600" stroke="#c8a0b8" stroke-width="2" opacity="0.55"/>
+
+  <!-- Vignette overlay -->
+  <rect x="0" y="0" width="1200" height="600" fill="url(#vig)"/>
+
+  <!-- Outer border double-line -->
+  <rect x="0" y="0" width="1200" height="600" fill="none" stroke="#c0a0b8" stroke-width="4" opacity="0.5"/>
+  <rect x="6" y="6" width="1188" height="588" fill="none" stroke="#e8d0dc" stroke-width="1.5" opacity="0.4"/>
+
+  <!-- Title banner at top -->
+  <rect x="420" y="0" width="360" height="38" fill="#f5e8ef" opacity="0.75"/>
+  <text x="600" y="26" text-anchor="middle" font-family="Georgia, 'Times New Roman', serif"
+        font-size="18" fill="#804060" opacity="0.92" letter-spacing="4" font-style="italic">
+    ✿  Cherry Blossoms  ✿
+  </text>
+</svg>

--- a/docs/presentation/experiments/cherry-blossoms/index.html
+++ b/docs/presentation/experiments/cherry-blossoms/index.html
@@ -1,0 +1,228 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>MassGen Experiment: Cherry Blossoms SVG</title>
+<style>
+  :root {
+    --bg: #0f0f1a;
+    --surface: #1a1a2e;
+    --border: #2a2a4a;
+    --text: #e0e0f0;
+    --muted: #8888aa;
+    --accent: #7c5cbf;
+    --cc: #6b8aff;
+    --codex: #50c878;
+    --winner: #ffd700;
+  }
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body { background: var(--bg); color: var(--text); font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; line-height: 1.6; }
+  .container { max-width: 1200px; margin: 0 auto; padding: 2rem 1.5rem; }
+  h1 { font-size: 2rem; margin-bottom: 0.25rem; }
+  h2 { font-size: 1.4rem; margin: 2.5rem 0 1rem; color: var(--accent); border-bottom: 1px solid var(--border); padding-bottom: 0.5rem; }
+  h3 { font-size: 1.1rem; margin-bottom: 0.5rem; }
+  .subtitle { color: var(--muted); margin-bottom: 2rem; }
+  .prompt-box { background: var(--surface); border: 1px solid var(--border); border-radius: 8px; padding: 1.25rem; font-style: italic; color: #c8c8e0; margin-bottom: 1rem; }
+  .agents { display: grid; grid-template-columns: 1fr 1fr; gap: 1.5rem; margin-bottom: 1rem; }
+  .agent-card { background: var(--surface); border: 1px solid var(--border); border-radius: 8px; padding: 1.25rem; }
+  .agent-card.cc { border-left: 4px solid var(--cc); }
+  .agent-card.codex { border-left: 4px solid var(--codex); }
+  .agent-name { font-weight: 700; font-size: 1.1rem; }
+  .agent-name.cc { color: var(--cc); }
+  .agent-name.codex { color: var(--codex); }
+  .agent-meta { color: var(--muted); font-size: 0.85rem; margin-top: 0.25rem; }
+  .badge { display: inline-block; padding: 0.15rem 0.5rem; border-radius: 4px; font-size: 0.75rem; font-weight: 600; }
+  .badge-winner { background: rgba(255,215,0,0.15); color: var(--winner); border: 1px solid rgba(255,215,0,0.3); }
+  .badge-lost { background: rgba(255,80,80,0.1); color: #ff8888; border: 1px solid rgba(255,80,80,0.2); }
+  .comparison { display: grid; grid-template-columns: 1fr 1fr; gap: 1.5rem; }
+  .svg-panel { background: var(--surface); border: 1px solid var(--border); border-radius: 8px; overflow: hidden; }
+  .svg-panel h3 { padding: 0.75rem 1rem 0; }
+  .svg-panel object, .svg-panel iframe { width: 100%; height: 320px; border: none; background: white; }
+  .svg-panel-full object { width: 100%; height: 400px; border: none; background: white; }
+  .svg-panel-full { background: var(--surface); border: 1px solid var(--border); border-radius: 8px; overflow: hidden; }
+  .timeline { background: var(--surface); border: 1px solid var(--border); border-radius: 8px; padding: 1.25rem; }
+  .event { display: flex; gap: 1rem; padding: 0.5rem 0; border-bottom: 1px solid rgba(255,255,255,0.05); }
+  .event:last-child { border-bottom: none; }
+  .event-id { color: var(--muted); font-size: 0.8rem; min-width: 2.5rem; padding-top: 0.15rem; }
+  .event-icon { font-size: 1.1rem; min-width: 1.5rem; text-align: center; }
+  .event-desc { flex: 1; font-size: 0.9rem; }
+  .event-agent { font-weight: 600; }
+  .event-agent.cc { color: var(--cc); }
+  .event-agent.codex { color: var(--codex); }
+  .vote-box { background: var(--surface); border: 1px solid var(--border); border-radius: 8px; padding: 1.25rem; margin-bottom: 1rem; }
+  .vote-result { font-size: 1.5rem; font-weight: 700; margin-bottom: 0.75rem; }
+  .vote-reason { background: rgba(255,255,255,0.03); border-left: 3px solid var(--border); padding: 0.75rem 1rem; margin: 0.75rem 0; border-radius: 0 4px 4px 0; font-size: 0.85rem; color: #b0b0cc; }
+  .vote-reason strong { color: var(--text); }
+  .stats { display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 1rem; }
+  .stat { background: var(--surface); border: 1px solid var(--border); border-radius: 8px; padding: 1rem; text-align: center; }
+  .stat-value { font-size: 1.5rem; font-weight: 700; color: var(--accent); }
+  .stat-label { font-size: 0.8rem; color: var(--muted); margin-top: 0.25rem; }
+  .finding { background: rgba(124,92,191,0.08); border: 1px solid rgba(124,92,191,0.25); border-radius: 8px; padding: 1.25rem; margin-top: 1rem; }
+  .finding-title { font-weight: 700; color: var(--accent); margin-bottom: 0.5rem; }
+  code { background: rgba(255,255,255,0.06); padding: 0.15rem 0.4rem; border-radius: 3px; font-size: 0.85em; }
+  @media (max-width: 700px) {
+    .agents, .comparison, .stats { grid-template-columns: 1fr; }
+    h1 { font-size: 1.5rem; }
+  }
+</style>
+</head>
+<body>
+<div class="container">
+
+<h1>MassGen Experiment: Cherry Blossoms SVG</h1>
+<p class="subtitle">Multi-agent generation with Claude Code + Codex &mdash; March 31, 2026</p>
+
+<h2>Prompt</h2>
+<div class="prompt-box">
+  Generate cherry-blossoms.svg with two side-by-side scenes: left scene shows cherry blossoms at UW campus in Seattle with Drumheller Fountain, right scene shows cherry blossoms at a famous Tokyo temple. Use pink and white blossoms, detailed architecture, soft watercolor style. The SVG should be 1200x600px.
+</div>
+
+<h2>Agents</h2>
+<div class="agents">
+  <div class="agent-card cc">
+    <div class="agent-name cc">Agent 1 &mdash; Claude Code <span class="badge badge-winner">Winner</span></div>
+    <div class="agent-meta">
+      Model: claude-sonnet-4-6<br>
+      Backend: claude_code<br>
+      Rounds: 3 (generate, vote, final checkout)<br>
+      Result: 629-line hand-authored SVG with watercolor filters, Gothic architecture, detailed fountain
+    </div>
+  </div>
+  <div class="agent-card codex">
+    <div class="agent-name codex">Agent 2 &mdash; Codex <span class="badge badge-lost">Lost</span></div>
+    <div class="agent-meta">
+      Model: gpt-5.4<br>
+      Backend: codex (native)<br>
+      Rounds: 2 (generate, vote)<br>
+      Result: Postcard-panel concept with Python generator, but 44 blossom elements had unresolved <code>{x}</code>, <code>{y}</code> template placeholders
+    </div>
+  </div>
+</div>
+
+<h2>Initial Outputs &mdash; Side by Side</h2>
+<div class="comparison">
+  <div class="svg-panel">
+    <h3 class="agent-name cc" style="padding-left:1rem">Claude Code</h3>
+    <object data="cc-initial.svg" type="image/svg+xml">CC SVG</object>
+  </div>
+  <div class="svg-panel">
+    <h3 class="agent-name codex" style="padding-left:1rem">Codex</h3>
+    <object data="codex-initial.svg" type="image/svg+xml">Codex SVG</object>
+  </div>
+</div>
+
+<h2>Coordination Timeline</h2>
+<div class="timeline">
+  <div class="event">
+    <span class="event-id">E1</span>
+    <span class="event-icon">&#x1F4AD;</span>
+    <span class="event-desc"><span class="event-agent cc">CC</span> starts streaming (no prior context)</span>
+  </div>
+  <div class="event">
+    <span class="event-id">E2</span>
+    <span class="event-icon">&#x1F4AD;</span>
+    <span class="event-desc"><span class="event-agent codex">Codex</span> starts streaming (no prior context)</span>
+  </div>
+  <div class="event">
+    <span class="event-id">E3</span>
+    <span class="event-icon">&#x2728;</span>
+    <span class="event-desc"><span class="event-agent cc">CC</span> submits answer <strong>agent1.1</strong> &mdash; 629-line hand-authored SVG</span>
+  </div>
+  <div class="event">
+    <span class="event-id">E5</span>
+    <span class="event-icon">&#x1F501;</span>
+    <span class="event-desc"><span class="event-agent cc">CC</span> restart triggered &rarr; enters vote phase with context [agent1.1]</span>
+  </div>
+  <div class="event">
+    <span class="event-id">E7</span>
+    <span class="event-icon">&#x1F5F3;</span>
+    <span class="event-desc"><span class="event-agent cc">CC</span> votes for <strong>agent1.1</strong> (own answer &mdash; only option at this point)</span>
+  </div>
+  <div class="event">
+    <span class="event-id">E8</span>
+    <span class="event-icon">&#x2728;</span>
+    <span class="event-desc"><span class="event-agent codex">Codex</span> submits answer <strong>agent2.1</strong> &mdash; postcard-panel SVG with Python generator</span>
+  </div>
+  <div class="event">
+    <span class="event-id">E10</span>
+    <span class="event-icon">&#x1F501;</span>
+    <span class="event-desc"><span class="event-agent codex">Codex</span> restart triggered &rarr; enters vote phase with context [agent1.1, agent2.1]</span>
+  </div>
+  <div class="event">
+    <span class="event-id">E12</span>
+    <span class="event-icon">&#x1F5F3;</span>
+    <span class="event-desc"><span class="event-agent cc">CC</span> votes for <strong>agent1.1</strong> &mdash; "Agent2's SVG has 44 blossom elements with unresolved template placeholders"</span>
+  </div>
+  <div class="event">
+    <span class="event-id">E13</span>
+    <span class="event-icon">&#x1F5F3;</span>
+    <span class="event-desc"><span class="event-agent codex">Codex</span> votes for <strong>agent1.1</strong> &mdash; "Verified both SVGs; agent2 has hundreds of unresolved placeholders rendering as black artifacts"</span>
+  </div>
+  <div class="event">
+    <span class="event-id">E14</span>
+    <span class="event-icon">&#x1F3AF;</span>
+    <span class="event-desc"><span class="event-agent cc">CC</span> selected as winner &rarr; produces final answer <strong>agent1.final</strong></span>
+  </div>
+</div>
+
+<h2>Vote Results</h2>
+<div class="vote-box">
+  <div class="vote-result" style="color: var(--winner)">CC wins 2&ndash;0</div>
+  <p>Both agents voted for CC's output (agent1.1). The vote was unanimous.</p>
+  <div class="vote-reason">
+    <strong>CC's vote:</strong> "Agent1 has a complete, detailed 629-line SVG with proper architecture (Suzzallo Library Gothic facade, Drumheller Fountain with water jets, 5-story pagoda, torii gate), watercolor filters, and actual cherry blossom canopy elements. Agent2's SVG has a critical defect: all 44 blossom &lt;use&gt; elements contain literal template placeholders ({x}, {y}, {rot}, {scale}, {color}, {opacity}) that were never substituted with actual values."
+  </div>
+  <div class="vote-reason">
+    <strong>Codex's vote:</strong> "Verified both SVGs from source and rendered output. Agent1's deliverable is a coherent, on-spec 1200x600 illustration with recognizable UW Drumheller Fountain and a Tokyo temple scene in the requested soft pink watercolor style. Agent2 has a nice postcard-panel concept, but its main SVG contains hundreds of unresolved template placeholders that render as obvious black artifact blobs."
+  </div>
+</div>
+
+<h2>Winner</h2>
+<div class="svg-panel-full">
+  <h3 style="padding: 0.75rem 1rem 0; color: var(--winner)">Final Output &mdash; Claude Code (agent1.final)</h3>
+  <object data="final.svg" type="image/svg+xml" style="width:100%; height:400px; background:white;">Final SVG</object>
+</div>
+
+<h2>Stats</h2>
+<div class="stats">
+  <div class="stat">
+    <div class="stat-value">2</div>
+    <div class="stat-label">Agents</div>
+  </div>
+  <div class="stat">
+    <div class="stat-value">6</div>
+    <div class="stat-label">Total Rounds</div>
+  </div>
+  <div class="stat">
+    <div class="stat-value">2&ndash;0</div>
+    <div class="stat-label">Vote (CC wins)</div>
+  </div>
+  <div class="stat">
+    <div class="stat-value">$4.95</div>
+    <div class="stat-label">Estimated Cost</div>
+  </div>
+  <div class="stat">
+    <div class="stat-value">3.8M</div>
+    <div class="stat-label">Input Tokens</div>
+  </div>
+  <div class="stat">
+    <div class="stat-value">102K</div>
+    <div class="stat-label">Output Tokens</div>
+  </div>
+</div>
+
+<h2>Experiment Notes</h2>
+<div class="finding">
+  <div class="finding-title">Finding: <code>--cwd-context rw</code> and shadow workspaces</div>
+  <p>An earlier run (demo5) used <code>--cwd-context rw</code>, which creates <code>massgen_shadow_*</code> temp directories for file isolation. This caused Codex to write SVGs to the shadow dir instead of its assigned workspace, making them appear "missing" from logs. The ChangeApplier successfully copied files back to the project root, but the logs workspace snapshot didn't capture them.</p>
+  <p style="margin-top:0.5rem">This run (demo6) omitted <code>--cwd-context rw</code>, and both agents' SVGs were properly persisted in snapshots, workspaces, and logs.</p>
+</div>
+
+<div style="margin-top:3rem; padding-top:1rem; border-top:1px solid var(--border); color:var(--muted); font-size:0.8rem; text-align:center">
+  Generated by <a href="https://sutando.ai" style="color:var(--accent)">Sutando</a> using <a href="https://massgen.ai" style="color:var(--accent)">MassGen</a>
+</div>
+
+</div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Side-by-side experiment report: Claude Code (Sonnet 4.6) vs Codex (GPT-5.4) generating a 1200x600 cherry blossom SVG
- CC won 2-0 — both agents voted for CC after finding Codex's SVG had unresolved template placeholders
- Interactive HTML report with SVG comparison, coordination timeline, vote reasoning, and stats
- Placed in `docs/presentation/experiments/cherry-blossoms/`

## Files
- `index.html` — experiment report page (dark theme, inline CSS)
- `cc-initial.svg` — Claude Code's initial output
- `codex-initial.svg` — Codex's initial output  
- `final.svg` — winning output (CC)

## Stats
- Cost: $4.95
- Tokens: 3.8M input, 102K output
- Rounds: 6 total (CC: 3, Codex: 2, + final)
- Config: separate `cwd` per agent, no `--cwd-context rw`

## Live preview
Also hosted at: https://sutando.ai/massgen-demo/

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added comprehensive experiment documentation for the Cherry Blossoms SVG project, featuring detailed reports with side-by-side SVG comparisons, agent performance metrics, vote results analysis, generation timeline, statistical data, and experiment findings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->