### PR TITLE
feat: add distributed store backend for circuit breaker (Phase 4)

### DIFF
--- a/massgen/backend/cb_store.py
+++ b/massgen/backend/cb_store.py
@@ -23,16 +23,37 @@ def _default_state() -> dict[str, Any]:
 
 @runtime_checkable
 class CircuitBreakerStore(Protocol):
-    """Protocol for shared circuit breaker state stores."""
+    """Protocol for shared circuit breaker state stores.
+
+    Implementations must persist state using Unix wall-clock timestamps
+    (``time.time()``) for ``open_until`` and ``last_failure_time`` so that
+    values remain meaningful across processes. Returned dicts also include
+    the auxiliary keys ``_prev_state`` (str) and ``_prev_was_half_open``
+    (bool) for the atomic_record_* methods, so callers can emit transition
+    logs/metrics without a separate get_state() call.
+    """
 
     def get_state(self, backend: str) -> dict:
-        """Return the circuit breaker state for a backend."""
+        """Return a snapshot of the backend's circuit breaker state.
+
+        Args:
+            backend: Logical backend name used as the store key.
+
+        Returns:
+            Dict with keys: ``state`` (str), ``failure_count`` (int),
+            ``last_failure_time`` (float, Unix time), ``open_until``
+            (float, Unix time), ``half_open_probe_active`` (bool).
+        """
 
     def set_state(self, backend: str, state: dict) -> None:
         """Persist the complete circuit breaker state for a backend."""
 
     def cas_state(self, backend: str, expected_state: str, updates: dict) -> bool:
-        """Apply updates if the current state field matches expected_state."""
+        """Apply updates if the current state field matches expected_state.
+
+        Returns:
+            True if the update was applied, False otherwise.
+        """
 
     def increment_failure(self, backend: str) -> int:
         """Atomically increment and return the backend failure count."""
@@ -47,7 +68,8 @@ class CircuitBreakerStore(Protocol):
 
         The operation increments failure_count, records the current failure
         time, and applies the CLOSED/HALF_OPEN -> OPEN transition rules in one
-        store-level critical section.
+        store-level critical section. The returned dict includes ``_prev_state``
+        and ``_prev_was_half_open`` describing the state before this call.
         """
 
     def atomic_record_success(
@@ -59,7 +81,39 @@ class CircuitBreakerStore(Protocol):
 
         When expected_state is provided, the update is constrained to that
         current state. Without an expected state, OPEN is treated as a forced
-        open guard and is returned unchanged.
+        open guard and is returned unchanged. The returned dict includes
+        ``_prev_state`` and ``_prev_was_half_open``.
+        """
+
+    def try_transition_and_claim_probe(
+        self,
+        backend: str,
+        now: float,
+        recovery_timeout: float,
+    ) -> tuple[bool, dict, str | None]:
+        """Atomically transition OPEN->HALF_OPEN or claim HALF_OPEN probe.
+
+        All checks and writes occur in one store-level critical section:
+
+        - If state==OPEN and now >= open_until: set state=HALF_OPEN,
+          half_open_probe_active=True. Returns ``(True, new_state,
+          "open->half_open")``.
+        - Elif state==HALF_OPEN and not half_open_probe_active: set
+          half_open_probe_active=True. Returns ``(True, new_state,
+          "half_open_probe_claimed")``.
+        - Else: returns ``(False, current_state, None)``.
+
+        Args:
+            backend: Logical backend name.
+            now: Unix timestamp (``time.time()``) used for the open_until
+                comparison. The caller owns the clock to match the values
+                the store persists via ``atomic_record_failure`` and
+                ``force_open``.
+            recovery_timeout: Reserved for future TTL computation.
+
+        Returns:
+            ``(won, new_state, transition_label)`` -- ``won`` is True iff
+            this caller successfully transitioned or claimed the probe.
         """
 
     def clear(self, backend: str) -> None:
@@ -67,7 +121,13 @@ class CircuitBreakerStore(Protocol):
 
 
 class InMemoryStore:
-    """Thread-safe in-process circuit breaker store."""
+    """Thread-safe in-process circuit breaker store.
+
+    Uses an RLock for mutual exclusion. All timestamps are ``time.time()``
+    (Unix wall-clock) to stay consistent with RedisStore semantics. This
+    store is intended for single-process deployments and as the default
+    test fixture; use RedisStore for multi-process coordination.
+    """
 
     def __init__(self) -> None:
         self._lock = threading.RLock()
@@ -112,7 +172,8 @@ class InMemoryStore:
                 self._storage[backend] = _default_state()
 
             state = copy.deepcopy(self._storage[backend])
-            now = time.monotonic()
+            prev_state_str = str(state["state"])
+            now = time.time()
             failure_count = int(state["failure_count"]) + 1
             state["failure_count"] = failure_count
             state["last_failure_time"] = now
@@ -127,7 +188,10 @@ class InMemoryStore:
                 state["half_open_probe_active"] = False
 
             self._storage[backend] = state
-            return copy.deepcopy(state)
+            result = copy.deepcopy(state)
+            result["_prev_state"] = prev_state_str
+            result["_prev_was_half_open"] = prev_state_str == "half_open"
+            return result
 
     def atomic_record_success(
         self,
@@ -139,25 +203,64 @@ class InMemoryStore:
                 self._storage[backend] = _default_state()
 
             state = copy.deepcopy(self._storage[backend])
-            current_state = str(state["state"])
+            prev_state_str = str(state["state"])
 
-            if expected_state is not None and current_state != expected_state:
-                return copy.deepcopy(state)
+            if expected_state is not None and prev_state_str != expected_state:
+                result = copy.deepcopy(state)
+                result["_prev_state"] = prev_state_str
+                result["_prev_was_half_open"] = prev_state_str == "half_open"
+                return result
 
-            if expected_state is None and current_state == "open":
-                return copy.deepcopy(state)
+            if expected_state is None and prev_state_str == "open":
+                result = copy.deepcopy(state)
+                result["_prev_state"] = prev_state_str
+                result["_prev_was_half_open"] = False
+                return result
 
-            if current_state == "closed":
+            if prev_state_str == "closed":
                 state["failure_count"] = 0
                 state["half_open_probe_active"] = False
                 self._storage[backend] = state
-            elif current_state == "half_open":
+            elif prev_state_str == "half_open":
                 state["state"] = "closed"
                 state["failure_count"] = 0
                 state["half_open_probe_active"] = False
                 self._storage[backend] = state
 
-            return copy.deepcopy(state)
+            result = copy.deepcopy(state)
+            result["_prev_state"] = prev_state_str
+            result["_prev_was_half_open"] = prev_state_str == "half_open"
+            return result
+
+    def try_transition_and_claim_probe(
+        self,
+        backend: str,
+        now: float,
+        recovery_timeout: float,
+    ) -> tuple[bool, dict, str | None]:
+        """Atomically transition OPEN->HALF_OPEN or claim HALF_OPEN probe.
+
+        See ``CircuitBreakerStore.try_transition_and_claim_probe`` for the
+        protocol contract. ``recovery_timeout`` is accepted for API
+        compatibility but not used in-memory.
+        """
+        del recovery_timeout  # reserved for future use
+        with self._lock:
+            if backend not in self._storage:
+                self._storage[backend] = _default_state()
+            state = self._storage[backend]
+            current = state["state"]
+
+            if current == "open" and now >= float(state["open_until"]):
+                state["state"] = "half_open"
+                state["half_open_probe_active"] = True
+                return True, copy.deepcopy(state), "open->half_open"
+
+            if current == "half_open" and not state["half_open_probe_active"]:
+                state["half_open_probe_active"] = True
+                return True, copy.deepcopy(state), "half_open_probe_claimed"
+
+            return False, copy.deepcopy(state), None
 
     def clear(self, backend: str) -> None:
         with self._lock:
@@ -165,7 +268,20 @@ class InMemoryStore:
 
 
 class RedisStore:
-    """Redis hash-backed circuit breaker store."""
+    """Redis hash-backed circuit breaker store.
+
+    Provides cross-process atomicity via Lua scripts with WATCH/MULTI/EXEC
+    fallback when Lua scripting is unavailable. All persisted timestamps
+    (``open_until``, ``last_failure_time``) are Unix wall-clock seconds so
+    that they remain comparable across processes and machines.
+
+    Args:
+        redis_client: A ``redis.Redis``-compatible client.
+        ttl: Default TTL in seconds applied to the per-backend hash key.
+        key_prefix: Namespace prefix -- allows multiple logical breakers
+            (e.g. test vs prod) to share one Redis instance without key
+            collisions.
+    """
 
     _CAS_SCRIPT = """
 local current_state = redis.call("HGET", KEYS[1], "state")
@@ -228,6 +344,7 @@ if now == nil then
     now = tonumber(redis_time[1]) + (tonumber(redis_time[2]) / 1000000)
 end
 
+local prev_state = state["state"]
 local failure_count = tonumber(state["failure_count"]) or 0
 failure_count = failure_count + 1
 state["failure_count"] = tostring(failure_count)
@@ -268,6 +385,8 @@ if state["state"] == "open" then
     end
 end
 redis.call("EXPIRE", KEYS[1], effective_ttl)
+local prev_was_half_open = "False"
+if prev_state == "half_open" then prev_was_half_open = "True" end
 return {
     "state",
     state["state"],
@@ -278,7 +397,11 @@ return {
     "open_until",
     state["open_until"],
     "half_open_probe_active",
-    state["half_open_probe_active"]
+    state["half_open_probe_active"],
+    "_prev_state",
+    prev_state,
+    "_prev_was_half_open",
+    prev_was_half_open
 }
 """
 
@@ -298,8 +421,11 @@ end
 local expected_state = ARGV[1]
 local ttl = tonumber(ARGV[2])
 local should_write = 0
+local prev_state = state["state"]
 
 if expected_state ~= "" and state["state"] ~= expected_state then
+    local prev_was_half_open = "False"
+    if prev_state == "half_open" then prev_was_half_open = "True" end
     return {
         "state",
         state["state"],
@@ -310,7 +436,11 @@ if expected_state ~= "" and state["state"] ~= expected_state then
         "open_until",
         state["open_until"],
         "half_open_probe_active",
-        state["half_open_probe_active"]
+        state["half_open_probe_active"],
+        "_prev_state",
+        prev_state,
+        "_prev_was_half_open",
+        prev_was_half_open
     }
 end
 
@@ -325,7 +455,11 @@ if state["state"] == "open" and expected_state == "" then
         "open_until",
         state["open_until"],
         "half_open_probe_active",
-        state["half_open_probe_active"]
+        state["half_open_probe_active"],
+        "_prev_state",
+        prev_state,
+        "_prev_was_half_open",
+        "False"
     }
 end
 
@@ -354,6 +488,8 @@ if should_write == 1 then
     redis.call("EXPIRE", KEYS[1], ttl)
 end
 
+local prev_was_half_open = "False"
+if prev_state == "half_open" then prev_was_half_open = "True" end
 return {
     "state",
     state["state"],
@@ -364,7 +500,63 @@ return {
     "open_until",
     state["open_until"],
     "half_open_probe_active",
-    state["half_open_probe_active"]
+    state["half_open_probe_active"],
+    "_prev_state",
+    prev_state,
+    "_prev_was_half_open",
+    prev_was_half_open
+}
+"""
+
+    _TRANSITION_PROBE_SCRIPT = """
+local raw = redis.call("HGETALL", KEYS[1])
+local state = {
+    state = "closed",
+    failure_count = "0",
+    last_failure_time = "0.0",
+    open_until = "0.0",
+    half_open_probe_active = "False"
+}
+for i = 1, #raw, 2 do
+    state[raw[i]] = raw[i + 1]
+end
+
+local now = tonumber(ARGV[1])
+if now == nil then
+    local redis_time = redis.call("TIME")
+    now = tonumber(redis_time[1]) + (tonumber(redis_time[2]) / 1000000)
+end
+local ttl = tonumber(ARGV[2])
+local transition = ""
+
+if state["state"] == "open" and now >= tonumber(state["open_until"]) then
+    state["state"] = "half_open"
+    state["half_open_probe_active"] = "True"
+    transition = "open->half_open"
+elseif state["state"] == "half_open" and state["half_open_probe_active"] == "False" then
+    state["half_open_probe_active"] = "True"
+    transition = "half_open_probe_claimed"
+end
+
+if transition ~= "" then
+    redis.call(
+        "HSET", KEYS[1],
+        "state", state["state"],
+        "failure_count", state["failure_count"],
+        "last_failure_time", state["last_failure_time"],
+        "open_until", state["open_until"],
+        "half_open_probe_active", state["half_open_probe_active"]
+    )
+    redis.call("EXPIRE", KEYS[1], ttl)
+end
+
+return {
+    transition,
+    "state", state["state"],
+    "failure_count", state["failure_count"],
+    "last_failure_time", state["last_failure_time"],
+    "open_until", state["open_until"],
+    "half_open_probe_active", state["half_open_probe_active"]
 }
 """
 
@@ -431,7 +623,7 @@ return {
                 str(int(failure_threshold)),
                 str(float(recovery_timeout)),
                 str(self._ttl),
-                str(time.monotonic()),
+                str(time.time()),
             )
         except Exception as exc:
             if not self._script_unavailable(exc):
@@ -462,6 +654,81 @@ return {
             return self._atomic_record_success_without_lua(backend, expected_state)
         return self._state_from_flat_pairs(result)
 
+    def try_transition_and_claim_probe(
+        self,
+        backend: str,
+        now: float,
+        recovery_timeout: float,
+    ) -> tuple[bool, dict, str | None]:
+        """Atomically transition OPEN->HALF_OPEN or claim HALF_OPEN probe.
+
+        See ``CircuitBreakerStore.try_transition_and_claim_probe`` for the
+        contract. ``recovery_timeout`` is accepted for API parity and
+        reserved for future TTL policy decisions.
+        """
+        del recovery_timeout  # reserved
+        try:
+            result = self._client.eval(
+                self._TRANSITION_PROBE_SCRIPT,
+                1,
+                self._key(backend),
+                str(now),
+                str(max(1, self._ttl)),
+            )
+        except Exception as exc:
+            if not self._script_unavailable(exc):
+                raise
+            return self._try_transition_and_claim_probe_without_lua(backend, now)
+        pairs = list(result)
+        if not pairs:
+            return False, self.get_state(backend), None
+        transition_label = self._decode(pairs[0])
+        state = self._state_from_flat_pairs(pairs[1:])
+        if transition_label:
+            return True, state, transition_label
+        return False, state, None
+
+    def _try_transition_and_claim_probe_without_lua(
+        self,
+        backend: str,
+        now: float,
+    ) -> tuple[bool, dict, str | None]:
+        key = self._key(backend)
+        with self._fallback_lock:
+            for attempt in range(3):
+                pipe = self._client.pipeline(True)
+                try:
+                    pipe.watch(key)
+                    raw_state = pipe.hgetall(key)
+                    state = self._state_from_items(raw_state.items())
+                    current = state["state"]
+                    transition: str | None = None
+
+                    if current == "open" and now >= float(state["open_until"]):
+                        state["state"] = "half_open"
+                        state["half_open_probe_active"] = True
+                        transition = "open->half_open"
+                    elif current == "half_open" and not state["half_open_probe_active"]:
+                        state["half_open_probe_active"] = True
+                        transition = "half_open_probe_claimed"
+                    else:
+                        pipe.reset()
+                        return False, state, None
+
+                    pipe.multi()
+                    pipe.hset(key, mapping=self._state_to_mapping(state))
+                    pipe.expire(key, self._compute_ttl(state))
+                    pipe.execute()
+                    return True, state, transition
+                except Exception as exc:
+                    if self._watch_retryable(exc):
+                        time.sleep(0.001 * (2**attempt))
+                        continue
+                    raise
+                finally:
+                    pipe.reset()
+        return False, self.get_state(backend), None
+
     def clear(self, backend: str) -> None:
         self._client.delete(self._key(backend))
 
@@ -489,9 +756,9 @@ return {
                 state[key] = int(value)
             elif key in {"last_failure_time", "open_until"}:
                 state[key] = float(value)
-            elif key == "half_open_probe_active":
+            elif key in {"half_open_probe_active", "_prev_was_half_open"}:
                 state[key] = value == "True"
-            elif key == "state":
+            elif key in {"state", "_prev_state"}:
                 state[key] = value
         return state
 
@@ -517,7 +784,7 @@ return {
     def _compute_ttl(self, updates: dict) -> int:
         if updates.get("state") == "open":
             open_until = float(updates.get("open_until", 0))
-            remaining = int(open_until - time.monotonic())
+            remaining = int(open_until - time.time())
             return max(1, self._ttl, remaining + 60)
         return max(1, self._ttl)
 
@@ -599,7 +866,8 @@ return {
                     pipe.watch(key)
                     raw_state = pipe.hgetall(key)
                     state = self._state_from_items(raw_state.items())
-                    now = time.monotonic()
+                    prev_state_str = str(state["state"])
+                    now = time.time()
                     failure_count = int(state["failure_count"]) + 1
                     state["failure_count"] = failure_count
                     state["last_failure_time"] = now
@@ -617,6 +885,8 @@ return {
                     pipe.hset(key, mapping=self._state_to_mapping(state))
                     pipe.expire(key, self._compute_ttl(state))
                     pipe.execute()
+                    state["_prev_state"] = prev_state_str
+                    state["_prev_was_half_open"] = prev_state_str == "half_open"
                     return state
                 except Exception as exc:
                     if self._watch_retryable(exc):
@@ -642,15 +912,19 @@ return {
                     pipe.watch(key)
                     raw_state = pipe.hgetall(key)
                     state = self._state_from_items(raw_state.items())
-                    current_state = str(state["state"])
+                    prev_state_str = str(state["state"])
 
-                    if expected_state is not None and current_state != expected_state:
+                    if expected_state is not None and prev_state_str != expected_state:
+                        state["_prev_state"] = prev_state_str
+                        state["_prev_was_half_open"] = prev_state_str == "half_open"
                         return state
 
-                    if expected_state is None and current_state == "open":
+                    if expected_state is None and prev_state_str == "open":
+                        state["_prev_state"] = prev_state_str
+                        state["_prev_was_half_open"] = False
                         return state
 
-                    if current_state in {"closed", "half_open"}:
+                    if prev_state_str in {"closed", "half_open"}:
                         state["state"] = "closed"
                         state["failure_count"] = 0
                         state["half_open_probe_active"] = False
@@ -659,6 +933,8 @@ return {
                         pipe.expire(key, self._compute_ttl(state))
                         pipe.execute()
 
+                    state["_prev_state"] = prev_state_str
+                    state["_prev_was_half_open"] = prev_state_str == "half_open"
                     return state
                 except Exception as exc:
                     if self._watch_retryable(exc):
@@ -673,12 +949,29 @@ return {
 
 
 def make_store(backend: str = "memory", **kwargs: Any) -> CircuitBreakerStore:
-    """Create a circuit breaker state store."""
+    """Create a circuit breaker state store.
+
+    Args:
+        backend: ``"memory"`` for the in-process store or ``"redis"`` for the
+            Redis-backed store.
+        **kwargs: For ``"redis"``, ``redis_client`` is required; ``ttl``
+            (default 3600) and ``key_prefix`` (default ``"massgen:cb"``)
+            are forwarded to ``RedisStore``.
+
+    Raises:
+        ValueError: If ``backend`` is unknown, or if ``backend=="redis"`` but
+            ``redis_client`` is missing.
+    """
     if backend == "memory":
         return InMemoryStore()
     if backend == "redis":
-        return RedisStore(
-            kwargs["redis_client"],
-            ttl=kwargs.get("ttl", 3600),
-        )
+        redis_client = kwargs.get("redis_client")
+        if redis_client is None:
+            raise ValueError(
+                "redis_client is required for backend='redis'",
+            )
+        redis_kwargs: dict[str, Any] = {"ttl": kwargs.get("ttl", 3600)}
+        if "key_prefix" in kwargs:
+            redis_kwargs["key_prefix"] = kwargs["key_prefix"]
+        return RedisStore(redis_client, **redis_kwargs)
     raise ValueError(f"Unknown circuit breaker store backend: {backend}")

--- a/massgen/backend/cb_store.py
+++ b/massgen/backend/cb_store.py
@@ -604,9 +604,7 @@ return {
         # Probe TTL must be at least as long as the base TTL so the
         # half_open state survives a long probe request even when callers
         # configure a small base TTL.
-        self._half_open_probe_ttl = (
-            max(ttl, half_open_probe_ttl) if half_open_probe_ttl is not None else ttl
-        )
+        self._half_open_probe_ttl = max(ttl, half_open_probe_ttl) if half_open_probe_ttl is not None else ttl
         self._fallback_lock = threading.Lock()
 
     def get_state(self, backend: str) -> dict:
@@ -617,10 +615,7 @@ return {
         key = self._key(backend)
         complete_state = _default_state()
         complete_state.update(copy.deepcopy(state))
-        mapping = {
-            field: self._to_redis_value(complete_state[field])
-            for field in DEFAULT_CIRCUIT_BREAKER_STATE
-        }
+        mapping = {field: self._to_redis_value(complete_state[field]) for field in DEFAULT_CIRCUIT_BREAKER_STATE}
         self._client.hset(key, mapping=mapping)
         self._client.expire(key, self._compute_ttl(complete_state))
 
@@ -815,10 +810,7 @@ return {
         return self._state_from_items(zip(pairs[0::2], pairs[1::2], strict=True))
 
     def _state_to_mapping(self, state: dict) -> dict:
-        return {
-            field: self._to_redis_value(state[field])
-            for field in DEFAULT_CIRCUIT_BREAKER_STATE
-        }
+        return {field: self._to_redis_value(state[field]) for field in DEFAULT_CIRCUIT_BREAKER_STATE}
 
     @staticmethod
     def _script_unavailable(exc: Exception) -> bool:
@@ -826,11 +818,7 @@ return {
         # Require "unknown command" context to avoid classifying READONLY,
         # ACL-denied, proxy, or other operational errors as Lua unavailability.
         message = str(exc).lower()
-        unknown_command = (
-            "unknown command" in message
-            or "unknown redis command" in message
-            or "err unknown command" in message
-        )
+        unknown_command = "unknown command" in message or "unknown redis command" in message or "err unknown command" in message
         mentions_script_command = "eval" in message or "evalsha" in message
         return "lupa" in message or (unknown_command and mentions_script_command)
 
@@ -840,7 +828,7 @@ return {
             remaining = int(open_until - time.time())
             return max(1, self._ttl, remaining + 60)
         if updates.get("state") == "half_open" and updates.get(
-            "half_open_probe_active"
+            "half_open_probe_active",
         ):
             return max(1, self._half_open_probe_ttl)
         return max(1, self._ttl)
@@ -849,13 +837,7 @@ return {
     def _watch_retryable(exc: Exception) -> bool:
         err_msg = str(exc).lower()
         class_name = exc.__class__.__name__.lower()
-        return (
-            "watch" in err_msg
-            or "execabort" in err_msg
-            or "multi" in err_msg
-            or "wrongtype" in err_msg
-            or class_name == "watcherror"
-        )
+        return "watch" in err_msg or "execabort" in err_msg or "multi" in err_msg or "wrongtype" in err_msg or class_name == "watcherror"
 
     def _cas_state_without_lua(
         self,
@@ -887,12 +869,7 @@ return {
                 return True
             except Exception as exc:
                 err_msg = str(exc).lower()
-                if (
-                    "watch" in err_msg
-                    or "multi" in err_msg
-                    or "wrongtype" in err_msg
-                    or "execabort" in err_msg
-                ):
+                if "watch" in err_msg or "multi" in err_msg or "wrongtype" in err_msg or "execabort" in err_msg:
                     time.sleep(0.001 * (2**attempt))
                     continue
                 raise
@@ -909,10 +886,7 @@ return {
                 state = self.get_state(backend)
                 state["failure_count"] = int(state["failure_count"]) + 1
                 pipe.multi()
-                mapping = {
-                    field: self._to_redis_value(state[field])
-                    for field in DEFAULT_CIRCUIT_BREAKER_STATE
-                }
+                mapping = {field: self._to_redis_value(state[field]) for field in DEFAULT_CIRCUIT_BREAKER_STATE}
                 pipe.hset(key, mapping=mapping)
                 pipe.expire(key, self._compute_ttl(state))
                 pipe.execute()
@@ -926,8 +900,7 @@ return {
             finally:
                 pipe.reset()
         raise RuntimeError(
-            f"Failed to atomically increment failure count for {backend!r} "
-            "after 3 retries",
+            f"Failed to atomically increment failure count for {backend!r} " "after 3 retries",
         )
 
     def _atomic_record_failure_without_lua(
@@ -954,17 +927,15 @@ return {
                         state["state"] = "open"
                         state["open_until"] = now + recovery_timeout
                         state["half_open_probe_active"] = False
-                    elif (
-                        state["state"] == "closed"
-                        and failure_count >= failure_threshold
-                    ):
+                    elif state["state"] == "closed" and failure_count >= failure_threshold:
                         state["state"] = "open"
                         state["open_until"] = now + recovery_timeout
                         state["half_open_probe_active"] = False
                     elif state["state"] == "open":
                         current_open_until = float(state.get("open_until", 0))
                         state["open_until"] = max(
-                            current_open_until, now + recovery_timeout
+                            current_open_until,
+                            now + recovery_timeout,
                         )
 
                     pipe.multi()

--- a/massgen/backend/cb_store.py
+++ b/massgen/backend/cb_store.py
@@ -387,10 +387,7 @@ return {
         key = self._key(backend)
         complete_state = _default_state()
         complete_state.update(copy.deepcopy(state))
-        mapping = {
-            field: self._to_redis_value(complete_state[field])
-            for field in DEFAULT_CIRCUIT_BREAKER_STATE
-        }
+        mapping = {field: self._to_redis_value(complete_state[field]) for field in DEFAULT_CIRCUIT_BREAKER_STATE}
         self._client.hset(key, mapping=mapping)
         self._client.expire(key, self._compute_ttl(complete_state))
 
@@ -505,10 +502,7 @@ return {
         return self._state_from_items(zip(pairs[0::2], pairs[1::2]))
 
     def _state_to_mapping(self, state: dict) -> dict:
-        return {
-            field: self._to_redis_value(state[field])
-            for field in DEFAULT_CIRCUIT_BREAKER_STATE
-        }
+        return {field: self._to_redis_value(state[field]) for field in DEFAULT_CIRCUIT_BREAKER_STATE}
 
     @staticmethod
     def _script_unavailable(exc: Exception) -> bool:
@@ -516,11 +510,7 @@ return {
         # Require "unknown command" context to avoid classifying READONLY,
         # ACL-denied, proxy, or other operational errors as Lua unavailability.
         message = str(exc).lower()
-        unknown_command = (
-            "unknown command" in message
-            or "unknown redis command" in message
-            or "err unknown command" in message
-        )
+        unknown_command = "unknown command" in message or "unknown redis command" in message or "err unknown command" in message
         mentions_script_command = "eval" in message or "evalsha" in message
         return "lupa" in message or (unknown_command and mentions_script_command)
 
@@ -535,13 +525,7 @@ return {
     def _watch_retryable(exc: Exception) -> bool:
         err_msg = str(exc).lower()
         class_name = exc.__class__.__name__.lower()
-        return (
-            "watch" in err_msg
-            or "execabort" in err_msg
-            or "multi" in err_msg
-            or "wrongtype" in err_msg
-            or class_name == "watcherror"
-        )
+        return "watch" in err_msg or "execabort" in err_msg or "multi" in err_msg or "wrongtype" in err_msg or class_name == "watcherror"
 
     def _cas_state_without_lua(
         self,
@@ -571,12 +555,7 @@ return {
                 return True
             except Exception as exc:
                 err_msg = str(exc).lower()
-                if (
-                    "watch" in err_msg
-                    or "multi" in err_msg
-                    or "wrongtype" in err_msg
-                    or "execabort" in err_msg
-                ):
+                if "watch" in err_msg or "multi" in err_msg or "wrongtype" in err_msg or "execabort" in err_msg:
                     time.sleep(0.001 * (2**attempt))
                     continue
                 raise
@@ -591,10 +570,7 @@ return {
                 state = self.get_state(backend)
                 state["failure_count"] = int(state["failure_count"]) + 1
                 pipe.multi()
-                mapping = {
-                    field: self._to_redis_value(state[field])
-                    for field in DEFAULT_CIRCUIT_BREAKER_STATE
-                }
+                mapping = {field: self._to_redis_value(state[field]) for field in DEFAULT_CIRCUIT_BREAKER_STATE}
                 pipe.hset(key, mapping=mapping)
                 pipe.expire(key, self._compute_ttl(state))
                 pipe.execute()
@@ -606,8 +582,7 @@ return {
                     continue
                 raise
         raise RuntimeError(
-            f"Failed to atomically increment failure count for {backend!r} "
-            "after 3 retries",
+            f"Failed to atomically increment failure count for {backend!r} " "after 3 retries",
         )
 
     def _atomic_record_failure_without_lua(
@@ -633,10 +608,7 @@ return {
                         state["state"] = "open"
                         state["open_until"] = now + recovery_timeout
                         state["half_open_probe_active"] = False
-                    elif (
-                        state["state"] == "closed"
-                        and failure_count >= failure_threshold
-                    ):
+                    elif state["state"] == "closed" and failure_count >= failure_threshold:
                         state["state"] = "open"
                         state["open_until"] = now + recovery_timeout
                         state["half_open_probe_active"] = False

--- a/massgen/backend/cb_store.py
+++ b/massgen/backend/cb_store.py
@@ -186,6 +186,9 @@ class InMemoryStore:
                 state["state"] = "open"
                 state["open_until"] = now + recovery_timeout
                 state["half_open_probe_active"] = False
+            elif state["state"] == "open":
+                current_open_until = float(state.get("open_until", 0))
+                state["open_until"] = max(current_open_until, now + recovery_timeout)
 
             self._storage[backend] = state
             result = copy.deepcopy(state)
@@ -358,6 +361,9 @@ elseif state["state"] == "closed" and failure_count >= failure_threshold then
     state["state"] = "open"
     state["open_until"] = tostring(now + recovery_timeout)
     state["half_open_probe_active"] = "False"
+elseif state["state"] == "open" then
+    local current_open_until = tonumber(state["open_until"]) or 0
+    state["open_until"] = tostring(math.max(current_open_until, now + recovery_timeout))
 end
 
 redis.call(
@@ -766,7 +772,7 @@ return {
         pairs = list(raw_pairs)
         if len(pairs) % 2 != 0:
             raise ValueError("Redis circuit breaker script returned uneven field pairs")
-        return self._state_from_items(zip(pairs[0::2], pairs[1::2]))
+        return self._state_from_items(zip(pairs[0::2], pairs[1::2], strict=True))
 
     def _state_to_mapping(self, state: dict) -> dict:
         return {field: self._to_redis_value(state[field]) for field in DEFAULT_CIRCUIT_BREAKER_STATE}
@@ -884,6 +890,9 @@ return {
                         state["state"] = "open"
                         state["open_until"] = now + recovery_timeout
                         state["half_open_probe_active"] = False
+                    elif state["state"] == "open":
+                        current_open_until = float(state.get("open_until", 0))
+                        state["open_until"] = max(current_open_until, now + recovery_timeout)
 
                     pipe.multi()
                     pipe.hset(key, mapping=self._state_to_mapping(state))

--- a/massgen/backend/cb_store.py
+++ b/massgen/backend/cb_store.py
@@ -1,0 +1,286 @@
+"""State stores for LLM circuit breakers."""
+
+from __future__ import annotations
+
+import copy
+import threading
+import time
+from typing import Any, Protocol, runtime_checkable
+
+DEFAULT_CIRCUIT_BREAKER_STATE: dict[str, Any] = {
+    "state": "closed",
+    "failure_count": 0,
+    "last_failure_time": 0.0,
+    "open_until": 0.0,
+    "half_open_probe_active": False,
+}
+
+
+def _default_state() -> dict[str, Any]:
+    return copy.deepcopy(DEFAULT_CIRCUIT_BREAKER_STATE)
+
+
+@runtime_checkable
+class CircuitBreakerStore(Protocol):
+    """Protocol for shared circuit breaker state stores."""
+
+    def get_state(self, backend: str) -> dict:
+        """Return the circuit breaker state for a backend."""
+
+    def set_state(self, backend: str, state: dict) -> None:
+        """Persist the complete circuit breaker state for a backend."""
+
+    def cas_state(self, backend: str, expected_state: str, updates: dict) -> bool:
+        """Apply updates if the current state field matches expected_state."""
+
+    def increment_failure(self, backend: str) -> int:
+        """Atomically increment and return the backend failure count."""
+
+    def clear(self, backend: str) -> None:
+        """Remove persisted state for a backend."""
+
+
+class InMemoryStore:
+    """Thread-safe in-process circuit breaker store."""
+
+    def __init__(self) -> None:
+        self._lock = threading.RLock()
+        self._storage: dict[str, dict] = {}
+
+    def get_state(self, backend: str) -> dict:
+        with self._lock:
+            if backend not in self._storage:
+                self._storage[backend] = _default_state()
+            return copy.deepcopy(self._storage[backend])
+
+    def set_state(self, backend: str, state: dict) -> None:
+        with self._lock:
+            complete_state = _default_state()
+            complete_state.update(copy.deepcopy(state))
+            self._storage[backend] = complete_state
+
+    def cas_state(self, backend: str, expected_state: str, updates: dict) -> bool:
+        with self._lock:
+            if backend not in self._storage:
+                self._storage[backend] = _default_state()
+            if self._storage[backend].get("state") != expected_state:
+                return False
+            self._storage[backend].update(copy.deepcopy(updates))
+            return True
+
+    def increment_failure(self, backend: str) -> int:
+        with self._lock:
+            state = self.get_state(backend)
+            state["failure_count"] = int(state["failure_count"]) + 1
+            self.set_state(backend, state)
+            return int(state["failure_count"])
+
+    def clear(self, backend: str) -> None:
+        with self._lock:
+            self._storage.pop(backend, None)
+
+
+class RedisStore:
+    """Redis hash-backed circuit breaker store."""
+
+    _CAS_SCRIPT = """
+local current_state = redis.call("HGET", KEYS[1], "state")
+if current_state == false then
+    current_state = "closed"
+end
+if current_state ~= ARGV[1] then
+    return 0
+end
+for i = 3, #ARGV, 2 do
+redis.call("HSET", KEYS[1], ARGV[i], ARGV[i + 1])
+end
+redis.call("EXPIRE", KEYS[1], ARGV[2])
+return 1
+"""
+
+    _INCREMENT_SCRIPT = """
+local count = redis.call("HINCRBY", KEYS[1], "failure_count", 1)
+if redis.call("HGET", KEYS[1], "state") == false then
+    redis.call(
+        "HSET",
+        KEYS[1],
+        "state",
+        "closed",
+        "last_failure_time",
+        "0.0",
+        "open_until",
+        "0.0",
+        "half_open_probe_active",
+        "False"
+    )
+end
+local existing_ttl = redis.call("TTL", KEYS[1])
+local new_ttl = tonumber(ARGV[1])
+if existing_ttl == -2 then existing_ttl = 0 end
+if existing_ttl > new_ttl then new_ttl = existing_ttl end
+redis.call("EXPIRE", KEYS[1], new_ttl)
+return count
+"""
+
+    def __init__(
+        self,
+        redis_client: Any,
+        ttl: int = 3600,
+        key_prefix: str = "massgen:cb",
+    ) -> None:
+        self._client = redis_client
+        self._ttl = ttl
+        self._key_prefix = key_prefix
+
+    def get_state(self, backend: str) -> dict:
+        raw_state = self._client.hgetall(self._key(backend))
+        state = _default_state()
+        for raw_key, raw_value in raw_state.items():
+            key = self._decode(raw_key)
+            value = self._decode(raw_value)
+            if key == "failure_count":
+                state[key] = int(value)
+            elif key in {"last_failure_time", "open_until"}:
+                state[key] = float(value)
+            elif key == "half_open_probe_active":
+                state[key] = value == "True"
+            elif key == "state":
+                state[key] = value
+        return state
+
+    def set_state(self, backend: str, state: dict) -> None:
+        key = self._key(backend)
+        mapping = {field: self._to_redis_value(state[field]) for field in DEFAULT_CIRCUIT_BREAKER_STATE}
+        self._client.hset(key, mapping=mapping)
+        self._client.expire(key, self._compute_ttl(state))
+
+    def cas_state(self, backend: str, expected_state: str, updates: dict) -> bool:
+        args: list[Any] = [expected_state, str(self._compute_ttl(updates))]
+        for field, value in updates.items():
+            args.extend([field, self._to_redis_value(value)])
+        try:
+            result = self._client.eval(self._CAS_SCRIPT, 1, self._key(backend), *args)
+        except Exception as exc:
+            if not self._script_unavailable(exc):
+                raise
+            return self._cas_state_without_lua(backend, expected_state, updates)
+        return int(result) == 1
+
+    def increment_failure(self, backend: str) -> int:
+        try:
+            result = self._client.eval(
+                self._INCREMENT_SCRIPT,
+                1,
+                self._key(backend),
+                str(self._ttl),
+            )
+        except Exception as exc:
+            if not self._script_unavailable(exc):
+                raise
+            return self._increment_failure_without_lua(backend)
+        return int(result)
+
+    def clear(self, backend: str) -> None:
+        self._client.delete(self._key(backend))
+
+    def _key(self, backend: str) -> str:
+        return f"{self._key_prefix}:{backend}"
+
+    @staticmethod
+    def _decode(value: Any) -> str:
+        if isinstance(value, bytes):
+            return value.decode("utf-8")
+        return str(value)
+
+    @staticmethod
+    def _to_redis_value(value: Any) -> str:
+        if isinstance(value, bool):
+            return "True" if value else "False"
+        return str(value)
+
+    @staticmethod
+    def _script_unavailable(exc: Exception) -> bool:
+        # Match only known Lua/EVAL unavailability signatures.
+        # Require "unknown command" context to avoid classifying READONLY,
+        # ACL-denied, proxy, or other operational errors as Lua unavailability.
+        message = str(exc).lower()
+        unknown_command = "unknown command" in message or "unknown redis command" in message or "err unknown command" in message
+        mentions_script_command = "eval" in message or "evalsha" in message
+        return "lupa" in message or (unknown_command and mentions_script_command)
+
+    def _compute_ttl(self, updates: dict) -> int:
+        if updates.get("state") == "open":
+            open_until = float(updates.get("open_until", 0))
+            remaining = int(open_until - time.monotonic())
+            return max(1, self._ttl, remaining + 60)
+        return max(1, self._ttl)
+
+    def _cas_state_without_lua(
+        self,
+        backend: str,
+        expected_state: str,
+        updates: dict,
+    ) -> bool:
+        key = self._key(backend)
+        for attempt in range(3):
+            pipe = self._client.pipeline(True)
+            try:
+                pipe.watch(key)
+                current = self._client.hget(key, "state")
+                if current is not None:
+                    current = self._decode(current)
+                else:
+                    current = "closed"
+                if current != expected_state:
+                    pipe.reset()
+                    return False
+                pipe.multi()
+                for field, value in updates.items():
+                    pipe.hset(key, field, self._to_redis_value(value))
+                effective_ttl = self._compute_ttl(updates)
+                pipe.expire(key, effective_ttl)
+                pipe.execute()
+                return True
+            except Exception as exc:
+                err_msg = str(exc).lower()
+                if "watch" in err_msg or "multi" in err_msg or "wrongtype" in err_msg or "execabort" in err_msg:
+                    time.sleep(0.001 * (2**attempt))
+                    continue
+                raise
+        return False
+
+    def _increment_failure_without_lua(self, backend: str) -> int:
+        key = self._key(backend)
+        for attempt in range(3):
+            pipe = self._client.pipeline(True)
+            try:
+                pipe.watch(key)
+                state = self.get_state(backend)
+                state["failure_count"] = int(state["failure_count"]) + 1
+                pipe.multi()
+                mapping = {field: self._to_redis_value(state[field]) for field in DEFAULT_CIRCUIT_BREAKER_STATE}
+                pipe.hset(key, mapping=mapping)
+                pipe.expire(key, self._compute_ttl(state))
+                pipe.execute()
+                return int(state["failure_count"])
+            except Exception as exc:
+                err_msg = str(exc).lower()
+                if "watch" in err_msg or "execabort" in err_msg:
+                    time.sleep(0.001 * (2**attempt))
+                    continue
+                raise
+        raise RuntimeError(
+            f"Failed to atomically increment failure count for {backend!r} after 3 retries",
+        )
+
+
+def make_store(backend: str = "memory", **kwargs: Any) -> CircuitBreakerStore:
+    """Create a circuit breaker state store."""
+    if backend == "memory":
+        return InMemoryStore()
+    if backend == "redis":
+        return RedisStore(
+            kwargs["redis_client"],
+            ttl=kwargs.get("ttl", 3600),
+        )
+    raise ValueError(f"Unknown circuit breaker store backend: {backend}")

--- a/massgen/backend/cb_store.py
+++ b/massgen/backend/cb_store.py
@@ -826,6 +826,8 @@ return {
                     time.sleep(0.001 * (2**attempt))
                     continue
                 raise
+            finally:
+                pipe.reset()
         return False
 
     def _increment_failure_without_lua(self, backend: str) -> int:
@@ -848,6 +850,8 @@ return {
                     time.sleep(0.001 * (2**attempt))
                     continue
                 raise
+            finally:
+                pipe.reset()
         raise RuntimeError(
             f"Failed to atomically increment failure count for {backend!r} " "after 3 retries",
         )

--- a/massgen/backend/cb_store.py
+++ b/massgen/backend/cb_store.py
@@ -533,6 +533,7 @@ if now == nil then
     now = tonumber(redis_time[1]) + (tonumber(redis_time[2]) / 1000000)
 end
 local ttl = tonumber(ARGV[2])
+local probe_ttl = tonumber(ARGV[3])
 local transition = ""
 
 if state["state"] == "open" and now >= tonumber(state["open_until"]) then
@@ -553,7 +554,11 @@ if transition ~= "" then
         "open_until", state["open_until"],
         "half_open_probe_active", state["half_open_probe_active"]
     )
-    redis.call("EXPIRE", KEYS[1], ttl)
+    local effective_ttl = ttl
+    if state["half_open_probe_active"] == "True" then
+        effective_ttl = probe_ttl
+    end
+    redis.call("EXPIRE", KEYS[1], effective_ttl)
 end
 
 return {
@@ -571,10 +576,17 @@ return {
         redis_client: Any,
         ttl: int = 3600,
         key_prefix: str = "massgen:cb",
+        half_open_probe_ttl: int | None = None,
     ) -> None:
+        if redis_client is None:
+            raise ValueError("redis_client is required for RedisStore")
         self._client = redis_client
         self._ttl = ttl
         self._key_prefix = key_prefix
+        # Probe TTL must be at least as long as the base TTL so the
+        # half_open state survives a long probe request even when callers
+        # configure a small base TTL.
+        self._half_open_probe_ttl = max(ttl, half_open_probe_ttl) if half_open_probe_ttl is not None else ttl
         self._fallback_lock = threading.Lock()
 
     def get_state(self, backend: str) -> dict:
@@ -680,6 +692,7 @@ return {
                 self._key(backend),
                 str(now),
                 str(max(1, self._ttl)),
+                str(max(1, self._half_open_probe_ttl)),
             )
         except Exception as exc:
             if not self._script_unavailable(exc):
@@ -792,6 +805,8 @@ return {
             open_until = float(updates.get("open_until", 0))
             remaining = int(open_until - time.time())
             return max(1, self._ttl, remaining + 60)
+        if updates.get("state") == "half_open" and updates.get("half_open_probe_active"):
+            return max(1, self._half_open_probe_ttl)
         return max(1, self._ttl)
 
     @staticmethod
@@ -968,8 +983,10 @@ def make_store(backend: str = "memory", **kwargs: Any) -> CircuitBreakerStore:
         backend: ``"memory"`` for the in-process store or ``"redis"`` for the
             Redis-backed store.
         **kwargs: For ``"redis"``, ``redis_client`` is required; ``ttl``
-            (default 3600) and ``key_prefix`` (default ``"massgen:cb"``)
-            are forwarded to ``RedisStore``.
+            (default 3600), ``key_prefix`` (default ``"massgen:cb"``), and
+            ``half_open_probe_ttl`` (default equals ``ttl``) are forwarded
+            to ``RedisStore``. Use ``half_open_probe_ttl`` to keep the
+            half_open probe entry alive longer than the base TTL.
 
     Raises:
         ValueError: If ``backend`` is unknown, or if ``backend=="redis"`` but
@@ -986,5 +1003,7 @@ def make_store(backend: str = "memory", **kwargs: Any) -> CircuitBreakerStore:
         redis_kwargs: dict[str, Any] = {"ttl": kwargs.get("ttl", 3600)}
         if "key_prefix" in kwargs:
             redis_kwargs["key_prefix"] = kwargs["key_prefix"]
+        if "half_open_probe_ttl" in kwargs:
+            redis_kwargs["half_open_probe_ttl"] = kwargs["half_open_probe_ttl"]
         return RedisStore(redis_client, **redis_kwargs)
     raise ValueError(f"Unknown circuit breaker store backend: {backend}")

--- a/massgen/backend/cb_store.py
+++ b/massgen/backend/cb_store.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import copy
 import threading
 import time
+from collections.abc import Iterable
 from typing import Any, Protocol, runtime_checkable
 
 DEFAULT_CIRCUIT_BREAKER_STATE: dict[str, Any] = {
@@ -35,6 +36,31 @@ class CircuitBreakerStore(Protocol):
 
     def increment_failure(self, backend: str) -> int:
         """Atomically increment and return the backend failure count."""
+
+    def atomic_record_failure(
+        self,
+        backend: str,
+        failure_threshold: int,
+        recovery_timeout: float,
+    ) -> dict:
+        """Atomically record a failed call and return the new full state.
+
+        The operation increments failure_count, records the current failure
+        time, and applies the CLOSED/HALF_OPEN -> OPEN transition rules in one
+        store-level critical section.
+        """
+
+    def atomic_record_success(
+        self,
+        backend: str,
+        expected_state: str | None = None,
+    ) -> dict:
+        """Atomically record a successful call and return the new full state.
+
+        When expected_state is provided, the update is constrained to that
+        current state. Without an expected state, OPEN is treated as a forced
+        open guard and is returned unchanged.
+        """
 
     def clear(self, backend: str) -> None:
         """Remove persisted state for a backend."""
@@ -74,6 +100,64 @@ class InMemoryStore:
             state["failure_count"] = int(state["failure_count"]) + 1
             self.set_state(backend, state)
             return int(state["failure_count"])
+
+    def atomic_record_failure(
+        self,
+        backend: str,
+        failure_threshold: int,
+        recovery_timeout: float,
+    ) -> dict:
+        with self._lock:
+            if backend not in self._storage:
+                self._storage[backend] = _default_state()
+
+            state = copy.deepcopy(self._storage[backend])
+            now = time.monotonic()
+            failure_count = int(state["failure_count"]) + 1
+            state["failure_count"] = failure_count
+            state["last_failure_time"] = now
+
+            if state["state"] == "half_open":
+                state["state"] = "open"
+                state["open_until"] = now + recovery_timeout
+                state["half_open_probe_active"] = False
+            elif state["state"] == "closed" and failure_count >= failure_threshold:
+                state["state"] = "open"
+                state["open_until"] = now + recovery_timeout
+                state["half_open_probe_active"] = False
+
+            self._storage[backend] = state
+            return copy.deepcopy(state)
+
+    def atomic_record_success(
+        self,
+        backend: str,
+        expected_state: str | None = None,
+    ) -> dict:
+        with self._lock:
+            if backend not in self._storage:
+                self._storage[backend] = _default_state()
+
+            state = copy.deepcopy(self._storage[backend])
+            current_state = str(state["state"])
+
+            if expected_state is not None and current_state != expected_state:
+                return copy.deepcopy(state)
+
+            if expected_state is None and current_state == "open":
+                return copy.deepcopy(state)
+
+            if current_state == "closed":
+                state["failure_count"] = 0
+                state["half_open_probe_active"] = False
+                self._storage[backend] = state
+            elif current_state == "half_open":
+                state["state"] = "closed"
+                state["failure_count"] = 0
+                state["half_open_probe_active"] = False
+                self._storage[backend] = state
+
+            return copy.deepcopy(state)
 
     def clear(self, backend: str) -> None:
         with self._lock:
@@ -122,6 +206,168 @@ redis.call("EXPIRE", KEYS[1], new_ttl)
 return count
 """
 
+    _RECORD_FAILURE_SCRIPT = """
+local raw = redis.call("HGETALL", KEYS[1])
+local state = {
+    state = "closed",
+    failure_count = "0",
+    last_failure_time = "0.0",
+    open_until = "0.0",
+    half_open_probe_active = "False"
+}
+for i = 1, #raw, 2 do
+    state[raw[i]] = raw[i + 1]
+end
+
+local failure_threshold = tonumber(ARGV[1])
+local recovery_timeout = tonumber(ARGV[2])
+local ttl = tonumber(ARGV[3])
+local now = tonumber(ARGV[4])
+if now == nil then
+    local redis_time = redis.call("TIME")
+    now = tonumber(redis_time[1]) + (tonumber(redis_time[2]) / 1000000)
+end
+
+local failure_count = tonumber(state["failure_count"]) or 0
+failure_count = failure_count + 1
+state["failure_count"] = tostring(failure_count)
+state["last_failure_time"] = tostring(now)
+
+if state["state"] == "half_open" then
+    state["state"] = "open"
+    state["open_until"] = tostring(now + recovery_timeout)
+    state["half_open_probe_active"] = "False"
+elseif state["state"] == "closed" and failure_count >= failure_threshold then
+    state["state"] = "open"
+    state["open_until"] = tostring(now + recovery_timeout)
+    state["half_open_probe_active"] = "False"
+end
+
+redis.call(
+    "HSET",
+    KEYS[1],
+    "state",
+    state["state"],
+    "failure_count",
+    state["failure_count"],
+    "last_failure_time",
+    state["last_failure_time"],
+    "open_until",
+    state["open_until"],
+    "half_open_probe_active",
+    state["half_open_probe_active"]
+)
+local effective_ttl = ttl
+if state["state"] == "open" then
+    local remaining = tonumber(state["open_until"]) - now
+    if remaining ~= nil and remaining > 0 then
+        local open_ttl = math.floor(remaining) + 60
+        if open_ttl > effective_ttl then
+            effective_ttl = open_ttl
+        end
+    end
+end
+redis.call("EXPIRE", KEYS[1], effective_ttl)
+return {
+    "state",
+    state["state"],
+    "failure_count",
+    state["failure_count"],
+    "last_failure_time",
+    state["last_failure_time"],
+    "open_until",
+    state["open_until"],
+    "half_open_probe_active",
+    state["half_open_probe_active"]
+}
+"""
+
+    _RECORD_SUCCESS_SCRIPT = """
+local raw = redis.call("HGETALL", KEYS[1])
+local state = {
+    state = "closed",
+    failure_count = "0",
+    last_failure_time = "0.0",
+    open_until = "0.0",
+    half_open_probe_active = "False"
+}
+for i = 1, #raw, 2 do
+    state[raw[i]] = raw[i + 1]
+end
+
+local expected_state = ARGV[1]
+local ttl = tonumber(ARGV[2])
+local should_write = 0
+
+if expected_state ~= "" and state["state"] ~= expected_state then
+    return {
+        "state",
+        state["state"],
+        "failure_count",
+        state["failure_count"],
+        "last_failure_time",
+        state["last_failure_time"],
+        "open_until",
+        state["open_until"],
+        "half_open_probe_active",
+        state["half_open_probe_active"]
+    }
+end
+
+if state["state"] == "open" and expected_state == "" then
+    return {
+        "state",
+        state["state"],
+        "failure_count",
+        state["failure_count"],
+        "last_failure_time",
+        state["last_failure_time"],
+        "open_until",
+        state["open_until"],
+        "half_open_probe_active",
+        state["half_open_probe_active"]
+    }
+end
+
+if state["state"] == "closed" or state["state"] == "half_open" then
+    state["state"] = "closed"
+    state["failure_count"] = "0"
+    state["half_open_probe_active"] = "False"
+    should_write = 1
+end
+
+if should_write == 1 then
+    redis.call(
+        "HSET",
+        KEYS[1],
+        "state",
+        state["state"],
+        "failure_count",
+        state["failure_count"],
+        "last_failure_time",
+        state["last_failure_time"],
+        "open_until",
+        state["open_until"],
+        "half_open_probe_active",
+        state["half_open_probe_active"]
+    )
+    redis.call("EXPIRE", KEYS[1], ttl)
+end
+
+return {
+    "state",
+    state["state"],
+    "failure_count",
+    state["failure_count"],
+    "last_failure_time",
+    state["last_failure_time"],
+    "open_until",
+    state["open_until"],
+    "half_open_probe_active",
+    state["half_open_probe_active"]
+}
+"""
+
     def __init__(
         self,
         redis_client: Any,
@@ -131,28 +377,22 @@ return count
         self._client = redis_client
         self._ttl = ttl
         self._key_prefix = key_prefix
+        self._fallback_lock = threading.Lock()
 
     def get_state(self, backend: str) -> dict:
         raw_state = self._client.hgetall(self._key(backend))
-        state = _default_state()
-        for raw_key, raw_value in raw_state.items():
-            key = self._decode(raw_key)
-            value = self._decode(raw_value)
-            if key == "failure_count":
-                state[key] = int(value)
-            elif key in {"last_failure_time", "open_until"}:
-                state[key] = float(value)
-            elif key == "half_open_probe_active":
-                state[key] = value == "True"
-            elif key == "state":
-                state[key] = value
-        return state
+        return self._state_from_items(raw_state.items())
 
     def set_state(self, backend: str, state: dict) -> None:
         key = self._key(backend)
-        mapping = {field: self._to_redis_value(state[field]) for field in DEFAULT_CIRCUIT_BREAKER_STATE}
+        complete_state = _default_state()
+        complete_state.update(copy.deepcopy(state))
+        mapping = {
+            field: self._to_redis_value(complete_state[field])
+            for field in DEFAULT_CIRCUIT_BREAKER_STATE
+        }
         self._client.hset(key, mapping=mapping)
-        self._client.expire(key, self._compute_ttl(state))
+        self._client.expire(key, self._compute_ttl(complete_state))
 
     def cas_state(self, backend: str, expected_state: str, updates: dict) -> bool:
         args: list[Any] = [expected_state, str(self._compute_ttl(updates))]
@@ -180,6 +420,51 @@ return count
             return self._increment_failure_without_lua(backend)
         return int(result)
 
+    def atomic_record_failure(
+        self,
+        backend: str,
+        failure_threshold: int,
+        recovery_timeout: float,
+    ) -> dict:
+        try:
+            result = self._client.eval(
+                self._RECORD_FAILURE_SCRIPT,
+                1,
+                self._key(backend),
+                str(int(failure_threshold)),
+                str(float(recovery_timeout)),
+                str(self._ttl),
+                str(time.monotonic()),
+            )
+        except Exception as exc:
+            if not self._script_unavailable(exc):
+                raise
+            return self._atomic_record_failure_without_lua(
+                backend,
+                failure_threshold,
+                recovery_timeout,
+            )
+        return self._state_from_flat_pairs(result)
+
+    def atomic_record_success(
+        self,
+        backend: str,
+        expected_state: str | None = None,
+    ) -> dict:
+        try:
+            result = self._client.eval(
+                self._RECORD_SUCCESS_SCRIPT,
+                1,
+                self._key(backend),
+                expected_state or "",
+                str(self._ttl),
+            )
+        except Exception as exc:
+            if not self._script_unavailable(exc):
+                raise
+            return self._atomic_record_success_without_lua(backend, expected_state)
+        return self._state_from_flat_pairs(result)
+
     def clear(self, backend: str) -> None:
         self._client.delete(self._key(backend))
 
@@ -198,13 +483,44 @@ return count
             return "True" if value else "False"
         return str(value)
 
+    def _state_from_items(self, items: Iterable[tuple[Any, Any]]) -> dict:
+        state = _default_state()
+        for raw_key, raw_value in items:
+            key = self._decode(raw_key)
+            value = self._decode(raw_value)
+            if key == "failure_count":
+                state[key] = int(value)
+            elif key in {"last_failure_time", "open_until"}:
+                state[key] = float(value)
+            elif key == "half_open_probe_active":
+                state[key] = value == "True"
+            elif key == "state":
+                state[key] = value
+        return state
+
+    def _state_from_flat_pairs(self, raw_pairs: Any) -> dict:
+        pairs = list(raw_pairs)
+        if len(pairs) % 2 != 0:
+            raise ValueError("Redis circuit breaker script returned uneven field pairs")
+        return self._state_from_items(zip(pairs[0::2], pairs[1::2]))
+
+    def _state_to_mapping(self, state: dict) -> dict:
+        return {
+            field: self._to_redis_value(state[field])
+            for field in DEFAULT_CIRCUIT_BREAKER_STATE
+        }
+
     @staticmethod
     def _script_unavailable(exc: Exception) -> bool:
         # Match only known Lua/EVAL unavailability signatures.
         # Require "unknown command" context to avoid classifying READONLY,
         # ACL-denied, proxy, or other operational errors as Lua unavailability.
         message = str(exc).lower()
-        unknown_command = "unknown command" in message or "unknown redis command" in message or "err unknown command" in message
+        unknown_command = (
+            "unknown command" in message
+            or "unknown redis command" in message
+            or "err unknown command" in message
+        )
         mentions_script_command = "eval" in message or "evalsha" in message
         return "lupa" in message or (unknown_command and mentions_script_command)
 
@@ -214,6 +530,18 @@ return count
             remaining = int(open_until - time.monotonic())
             return max(1, self._ttl, remaining + 60)
         return max(1, self._ttl)
+
+    @staticmethod
+    def _watch_retryable(exc: Exception) -> bool:
+        err_msg = str(exc).lower()
+        class_name = exc.__class__.__name__.lower()
+        return (
+            "watch" in err_msg
+            or "execabort" in err_msg
+            or "multi" in err_msg
+            or "wrongtype" in err_msg
+            or class_name == "watcherror"
+        )
 
     def _cas_state_without_lua(
         self,
@@ -243,7 +571,12 @@ return count
                 return True
             except Exception as exc:
                 err_msg = str(exc).lower()
-                if "watch" in err_msg or "multi" in err_msg or "wrongtype" in err_msg or "execabort" in err_msg:
+                if (
+                    "watch" in err_msg
+                    or "multi" in err_msg
+                    or "wrongtype" in err_msg
+                    or "execabort" in err_msg
+                ):
                     time.sleep(0.001 * (2**attempt))
                     continue
                 raise
@@ -258,7 +591,10 @@ return count
                 state = self.get_state(backend)
                 state["failure_count"] = int(state["failure_count"]) + 1
                 pipe.multi()
-                mapping = {field: self._to_redis_value(state[field]) for field in DEFAULT_CIRCUIT_BREAKER_STATE}
+                mapping = {
+                    field: self._to_redis_value(state[field])
+                    for field in DEFAULT_CIRCUIT_BREAKER_STATE
+                }
                 pipe.hset(key, mapping=mapping)
                 pipe.expire(key, self._compute_ttl(state))
                 pipe.execute()
@@ -270,7 +606,97 @@ return count
                     continue
                 raise
         raise RuntimeError(
-            f"Failed to atomically increment failure count for {backend!r} after 3 retries",
+            f"Failed to atomically increment failure count for {backend!r} "
+            "after 3 retries",
+        )
+
+    def _atomic_record_failure_without_lua(
+        self,
+        backend: str,
+        failure_threshold: int,
+        recovery_timeout: float,
+    ) -> dict:
+        key = self._key(backend)
+        with self._fallback_lock:
+            for attempt in range(3):
+                pipe = self._client.pipeline(True)
+                try:
+                    pipe.watch(key)
+                    raw_state = pipe.hgetall(key)
+                    state = self._state_from_items(raw_state.items())
+                    now = time.monotonic()
+                    failure_count = int(state["failure_count"]) + 1
+                    state["failure_count"] = failure_count
+                    state["last_failure_time"] = now
+
+                    if state["state"] == "half_open":
+                        state["state"] = "open"
+                        state["open_until"] = now + recovery_timeout
+                        state["half_open_probe_active"] = False
+                    elif (
+                        state["state"] == "closed"
+                        and failure_count >= failure_threshold
+                    ):
+                        state["state"] = "open"
+                        state["open_until"] = now + recovery_timeout
+                        state["half_open_probe_active"] = False
+
+                    pipe.multi()
+                    pipe.hset(key, mapping=self._state_to_mapping(state))
+                    pipe.expire(key, self._compute_ttl(state))
+                    pipe.execute()
+                    return state
+                except Exception as exc:
+                    if self._watch_retryable(exc):
+                        time.sleep(0.001 * (2**attempt))
+                        continue
+                    raise
+                finally:
+                    pipe.reset()
+        raise RuntimeError(
+            f"Failed to atomically record failure for {backend!r} after 3 retries",
+        )
+
+    def _atomic_record_success_without_lua(
+        self,
+        backend: str,
+        expected_state: str | None = None,
+    ) -> dict:
+        key = self._key(backend)
+        with self._fallback_lock:
+            for attempt in range(3):
+                pipe = self._client.pipeline(True)
+                try:
+                    pipe.watch(key)
+                    raw_state = pipe.hgetall(key)
+                    state = self._state_from_items(raw_state.items())
+                    current_state = str(state["state"])
+
+                    if expected_state is not None and current_state != expected_state:
+                        return state
+
+                    if expected_state is None and current_state == "open":
+                        return state
+
+                    if current_state in {"closed", "half_open"}:
+                        state["state"] = "closed"
+                        state["failure_count"] = 0
+                        state["half_open_probe_active"] = False
+                        pipe.multi()
+                        pipe.hset(key, mapping=self._state_to_mapping(state))
+                        pipe.expire(key, self._compute_ttl(state))
+                        pipe.execute()
+
+                    return state
+                except Exception as exc:
+                    if self._watch_retryable(exc):
+                        time.sleep(0.001 * (2**attempt))
+                        continue
+                    raise
+                finally:
+                    pipe.reset()
+        raise RuntimeError(
+            f"Failed to atomically record success for {backend!r} after 3 retries",
         )
 
 

--- a/massgen/backend/cb_store.py
+++ b/massgen/backend/cb_store.py
@@ -294,10 +294,28 @@ end
 if current_state ~= ARGV[1] then
     return 0
 end
-for i = 3, #ARGV, 2 do
+for i = 4, #ARGV, 2 do
 redis.call("HSET", KEYS[1], ARGV[i], ARGV[i + 1])
 end
-redis.call("EXPIRE", KEYS[1], ARGV[2])
+local base_ttl = tonumber(ARGV[2])
+local half_open_probe_ttl = tonumber(ARGV[3])
+local final_state = redis.call("HGET", KEYS[1], "state")
+if final_state == false then final_state = "closed" end
+local effective_ttl = base_ttl
+if final_state == "open" then
+    local open_until = tonumber(redis.call("HGET", KEYS[1], "open_until") or "0")
+    local t = redis.call("TIME")
+    local now = tonumber(t[1])
+    local remaining = open_until - now
+    if remaining + 60 > effective_ttl then effective_ttl = math.ceil(remaining + 60) end
+elseif final_state == "half_open" then
+    local probe_active = redis.call("HGET", KEYS[1], "half_open_probe_active")
+    if probe_active == "True" then
+        if half_open_probe_ttl > effective_ttl then effective_ttl = half_open_probe_ttl end
+    end
+end
+if effective_ttl < 1 then effective_ttl = 1 end
+redis.call("EXPIRE", KEYS[1], effective_ttl)
 return 1
 """
 
@@ -586,7 +604,9 @@ return {
         # Probe TTL must be at least as long as the base TTL so the
         # half_open state survives a long probe request even when callers
         # configure a small base TTL.
-        self._half_open_probe_ttl = max(ttl, half_open_probe_ttl) if half_open_probe_ttl is not None else ttl
+        self._half_open_probe_ttl = (
+            max(ttl, half_open_probe_ttl) if half_open_probe_ttl is not None else ttl
+        )
         self._fallback_lock = threading.Lock()
 
     def get_state(self, backend: str) -> dict:
@@ -597,12 +617,19 @@ return {
         key = self._key(backend)
         complete_state = _default_state()
         complete_state.update(copy.deepcopy(state))
-        mapping = {field: self._to_redis_value(complete_state[field]) for field in DEFAULT_CIRCUIT_BREAKER_STATE}
+        mapping = {
+            field: self._to_redis_value(complete_state[field])
+            for field in DEFAULT_CIRCUIT_BREAKER_STATE
+        }
         self._client.hset(key, mapping=mapping)
         self._client.expire(key, self._compute_ttl(complete_state))
 
     def cas_state(self, backend: str, expected_state: str, updates: dict) -> bool:
-        args: list[Any] = [expected_state, str(self._compute_ttl(updates))]
+        args: list[Any] = [
+            expected_state,
+            str(self._ttl),
+            str(self._half_open_probe_ttl),
+        ]
         for field, value in updates.items():
             args.extend([field, self._to_redis_value(value)])
         try:
@@ -788,7 +815,10 @@ return {
         return self._state_from_items(zip(pairs[0::2], pairs[1::2], strict=True))
 
     def _state_to_mapping(self, state: dict) -> dict:
-        return {field: self._to_redis_value(state[field]) for field in DEFAULT_CIRCUIT_BREAKER_STATE}
+        return {
+            field: self._to_redis_value(state[field])
+            for field in DEFAULT_CIRCUIT_BREAKER_STATE
+        }
 
     @staticmethod
     def _script_unavailable(exc: Exception) -> bool:
@@ -796,7 +826,11 @@ return {
         # Require "unknown command" context to avoid classifying READONLY,
         # ACL-denied, proxy, or other operational errors as Lua unavailability.
         message = str(exc).lower()
-        unknown_command = "unknown command" in message or "unknown redis command" in message or "err unknown command" in message
+        unknown_command = (
+            "unknown command" in message
+            or "unknown redis command" in message
+            or "err unknown command" in message
+        )
         mentions_script_command = "eval" in message or "evalsha" in message
         return "lupa" in message or (unknown_command and mentions_script_command)
 
@@ -805,7 +839,9 @@ return {
             open_until = float(updates.get("open_until", 0))
             remaining = int(open_until - time.time())
             return max(1, self._ttl, remaining + 60)
-        if updates.get("state") == "half_open" and updates.get("half_open_probe_active"):
+        if updates.get("state") == "half_open" and updates.get(
+            "half_open_probe_active"
+        ):
             return max(1, self._half_open_probe_ttl)
         return max(1, self._ttl)
 
@@ -813,7 +849,13 @@ return {
     def _watch_retryable(exc: Exception) -> bool:
         err_msg = str(exc).lower()
         class_name = exc.__class__.__name__.lower()
-        return "watch" in err_msg or "execabort" in err_msg or "multi" in err_msg or "wrongtype" in err_msg or class_name == "watcherror"
+        return (
+            "watch" in err_msg
+            or "execabort" in err_msg
+            or "multi" in err_msg
+            or "wrongtype" in err_msg
+            or class_name == "watcherror"
+        )
 
     def _cas_state_without_lua(
         self,
@@ -834,16 +876,23 @@ return {
                 if current != expected_state:
                     pipe.reset()
                     return False
+                existing = self._state_from_items(self._client.hgetall(key).items())
+                existing.update(updates)
                 pipe.multi()
                 for field, value in updates.items():
                     pipe.hset(key, field, self._to_redis_value(value))
-                effective_ttl = self._compute_ttl(updates)
+                effective_ttl = self._compute_ttl(existing)
                 pipe.expire(key, effective_ttl)
                 pipe.execute()
                 return True
             except Exception as exc:
                 err_msg = str(exc).lower()
-                if "watch" in err_msg or "multi" in err_msg or "wrongtype" in err_msg or "execabort" in err_msg:
+                if (
+                    "watch" in err_msg
+                    or "multi" in err_msg
+                    or "wrongtype" in err_msg
+                    or "execabort" in err_msg
+                ):
                     time.sleep(0.001 * (2**attempt))
                     continue
                 raise
@@ -860,7 +909,10 @@ return {
                 state = self.get_state(backend)
                 state["failure_count"] = int(state["failure_count"]) + 1
                 pipe.multi()
-                mapping = {field: self._to_redis_value(state[field]) for field in DEFAULT_CIRCUIT_BREAKER_STATE}
+                mapping = {
+                    field: self._to_redis_value(state[field])
+                    for field in DEFAULT_CIRCUIT_BREAKER_STATE
+                }
                 pipe.hset(key, mapping=mapping)
                 pipe.expire(key, self._compute_ttl(state))
                 pipe.execute()
@@ -874,7 +926,8 @@ return {
             finally:
                 pipe.reset()
         raise RuntimeError(
-            f"Failed to atomically increment failure count for {backend!r} " "after 3 retries",
+            f"Failed to atomically increment failure count for {backend!r} "
+            "after 3 retries",
         )
 
     def _atomic_record_failure_without_lua(
@@ -901,13 +954,18 @@ return {
                         state["state"] = "open"
                         state["open_until"] = now + recovery_timeout
                         state["half_open_probe_active"] = False
-                    elif state["state"] == "closed" and failure_count >= failure_threshold:
+                    elif (
+                        state["state"] == "closed"
+                        and failure_count >= failure_threshold
+                    ):
                         state["state"] = "open"
                         state["open_until"] = now + recovery_timeout
                         state["half_open_probe_active"] = False
                     elif state["state"] == "open":
                         current_open_until = float(state.get("open_until", 0))
-                        state["open_until"] = max(current_open_until, now + recovery_timeout)
+                        state["open_until"] = max(
+                            current_open_until, now + recovery_timeout
+                        )
 
                     pipe.multi()
                     pipe.hset(key, mapping=self._state_to_mapping(state))

--- a/massgen/backend/llm_circuit_breaker.py
+++ b/massgen/backend/llm_circuit_breaker.py
@@ -500,20 +500,12 @@ class LLMCircuitBreaker:
                     break
                 # CAS conflict -- retry with refreshed state
             else:
-                # All CAS attempts failed; fall back to unconditional set to
-                # avoid leaving the CB in a non-open state under quota exhaustion.
-                current = self._store.get_state(self.backend_name)
-                merged_open_until = max(computed_open_until, float(current.get("open_until", 0)))
-                merged_last_failure = max(now, float(current.get("last_failure_time", 0)))
-                self._store.set_state(
-                    self.backend_name,
-                    {
-                        **current,
-                        "state": CircuitState.OPEN.value,
-                        "last_failure_time": merged_last_failure,
-                        "open_until": merged_open_until,
-                        "half_open_probe_active": False,
-                    },
+                # All CAS attempts exhausted. Blind set_state risks overwriting a
+                # fresher open_until written by a concurrent writer. Log a warning
+                # and rely on the circuit to self-heal via the next record_failure.
+                self._log(
+                    "force_open: CAS exhausted after 5 attempts; skipping fallback set_state",
+                    open_for_seconds=duration,
                 )
             self._log(
                 f"Circuit breaker force-opened: {reason}",

--- a/massgen/backend/llm_circuit_breaker.py
+++ b/massgen/backend/llm_circuit_breaker.py
@@ -91,8 +91,7 @@ class LLMCircuitBreakerConfig:
             )
         if self.retry_after_threshold_seconds < 0:
             raise ValueError(
-                "retry_after_threshold_seconds must be >= 0, "
-                f"got {self.retry_after_threshold_seconds}",
+                "retry_after_threshold_seconds must be >= 0, " f"got {self.retry_after_threshold_seconds}",
             )
 
 
@@ -522,7 +521,8 @@ class LLMCircuitBreaker:
         """Reset circuit breaker to initial CLOSED state."""
         if self._store is not None:
             prev_state_value = self._store.get_state(self.backend_name).get(
-                "state", CircuitState.CLOSED.value
+                "state",
+                CircuitState.CLOSED.value,
             )
             self._store.set_state(
                 self.backend_name,
@@ -613,8 +613,7 @@ class LLMCircuitBreaker:
                     if self._metrics is not None:
                         self._safe_emit(self._metrics.record_request, self.backend_name, outcome, 0.0)
                     raise CircuitBreakerOpenError(
-                        f"Circuit breaker became {state_label} during retries "
-                        f"for {self.backend_name}",
+                        f"Circuit breaker became {state_label} during retries " f"for {self.backend_name}",
                     )
 
                 if attempt > 1 and not _owns_probe:
@@ -647,9 +646,7 @@ class LLMCircuitBreaker:
                         if action == RateLimitAction.STOP:
                             # Quota exhaustion -- open CB for full Retry-After window
                             self.force_open(
-                                f"429 STOP: Retry-After={retry_after}s > "
-                                "threshold="
-                                f"{self.config.retry_after_threshold_seconds}s",
+                                f"429 STOP: Retry-After={retry_after}s > " "threshold=" f"{self.config.retry_after_threshold_seconds}s",
                                 open_for_seconds=retry_after or 0,
                             )
                             if self._metrics is not None:
@@ -662,9 +659,7 @@ class LLMCircuitBreaker:
                                 self._safe_emit(self._metrics.record_request, self.backend_name, "failure", _latency)
                             if attempt >= max_retries:
                                 raise
-                            wait_seconds = (
-                                retry_after if retry_after is not None else 1.0
-                            )
+                            wait_seconds = retry_after if retry_after is not None else 1.0
                             self._log(
                                 "429 WAIT: retrying after Retry-After",
                                 retry_after=wait_seconds,
@@ -744,15 +739,11 @@ class LLMCircuitBreaker:
             if _owns_probe:
                 if self._store is not None:
                     state = self._store.get_state(self.backend_name)
-                    if (
-                        CircuitState(state["state"]) == CircuitState.HALF_OPEN
-                        and state["half_open_probe_active"]
-                    ):
+                    if CircuitState(state["state"]) == CircuitState.HALF_OPEN and state["half_open_probe_active"]:
                         state.update(
                             {
                                 "state": CircuitState.OPEN.value,
-                                "open_until": time.monotonic()
-                                + self.config.reset_time_seconds,
+                                "open_until": time.monotonic() + self.config.reset_time_seconds,
                                 "half_open_probe_active": False,
                             },
                         )
@@ -798,9 +789,7 @@ class LLMCircuitBreaker:
 
     def _log(self, message: str, **details: Any) -> None:
         """Log via structured backend activity logger."""
-        log_details: dict[str, Any] = {
-            k: v for k, v in details.items() if v is not None
-        }
+        log_details: dict[str, Any] = {k: v for k, v in details.items() if v is not None}
         log_backend_activity(
             self.backend_name,
             message,
@@ -812,19 +801,11 @@ class LLMCircuitBreaker:
         if self._store is not None:
             state = self.state.value
             failures = self.failure_count
-            return (
-                f"LLMCircuitBreaker(state={state}, "
-                f"failures={failures}/{self.config.max_failures}, "
-                f"backend={self.backend_name!r})"
-            )
+            return f"LLMCircuitBreaker(state={state}, " f"failures={failures}/{self.config.max_failures}, " f"backend={self.backend_name!r})"
         with self._lock:
             state = self._state.value
             failures = self._failure_count
-        return (
-            f"LLMCircuitBreaker(state={state}, "
-            f"failures={failures}/{self.config.max_failures}, "
-            f"backend={self.backend_name!r})"
-        )
+        return f"LLMCircuitBreaker(state={state}, " f"failures={failures}/{self.config.max_failures}, " f"backend={self.backend_name!r})"
 
 
 # ---------------------------------------------------------------------------

--- a/massgen/backend/llm_circuit_breaker.py
+++ b/massgen/backend/llm_circuit_breaker.py
@@ -233,53 +233,55 @@ class LLMCircuitBreaker:
             True if the circuit is OPEN and reset time has not elapsed.
             In HALF_OPEN, allows exactly one probe request.
         """
+        blocked, _ = self._should_block_with_claim()
+        return blocked
+
+    def _should_block_with_claim(self) -> tuple[bool, bool]:
+        """Internal variant of should_block that also reports probe ownership.
+
+        Returns:
+            (should_block, claimed_probe). ``claimed_probe`` is True iff this
+            call transitioned OPEN->HALF_OPEN or claimed the HALF_OPEN probe
+            slot. Always False when should_block is True.
+        """
         if not self.config.enabled:
-            return False
+            return False, False
 
         if self._store is not None:
-            for _ in range(2):
-                state = self._store.get_state(self.backend_name)
-                circuit_state = CircuitState(state["state"])
+            state = self._store.get_state(self.backend_name)
+            circuit_state = CircuitState(state["state"])
 
-                if circuit_state == CircuitState.CLOSED:
-                    return False
+            if circuit_state == CircuitState.CLOSED:
+                return False, False
 
-                if circuit_state == CircuitState.OPEN:
-                    now = time.monotonic()
-                    if now >= float(state["open_until"]):
-                        transitioned = self._store.cas_state(
-                            self.backend_name,
-                            CircuitState.OPEN.value,
-                            {
-                                "state": CircuitState.HALF_OPEN.value,
-                                "half_open_probe_active": True,
-                            },
-                        )
-                        if transitioned:
-                            self._log(
-                                "Circuit breaker half-open, allowing probe request",
-                            )
-                            if self._metrics is not None:
-                                self._safe_emit(
-                                    self._metrics.record_state_transition,
-                                    self.backend_name,
-                                    "open",
-                                    "half_open",
-                                )
-                            return False
-                        continue
-                    return True
+            if circuit_state == CircuitState.OPEN and time.time() < float(state["open_until"]):
+                return True, False
 
-                if state["half_open_probe_active"]:
-                    return True
-                return not self._store.cas_state(
-                    self.backend_name,
-                    CircuitState.HALF_OPEN.value,
-                    {"half_open_probe_active": True},
-                )
-            return True
+            if circuit_state == CircuitState.HALF_OPEN and state["half_open_probe_active"]:
+                return True, False
+
+            # OPEN (elapsed) or HALF_OPEN (probe not claimed): single atomic op
+            won, _new_state, transition = self._store.try_transition_and_claim_probe(
+                self.backend_name,
+                time.time(),
+                float(self.config.reset_time_seconds),
+            )
+            if not won:
+                return True, False
+
+            if transition == "open->half_open":
+                self._log("Circuit breaker half-open, allowing probe request")
+                if self._metrics is not None:
+                    self._safe_emit(
+                        self._metrics.record_state_transition,
+                        self.backend_name,
+                        "open",
+                        "half_open",
+                    )
+            return False, True
 
         _emit_transition: tuple[str, str] | None = None
+        claimed_probe_local = False
         with self._lock:
             if self._state == CircuitState.CLOSED:
                 should_block = False
@@ -293,6 +295,7 @@ class LLMCircuitBreaker:
                     self._log("Circuit breaker half-open, allowing probe request")
                     _emit_transition = ("open", "half_open")
                     should_block = False
+                    claimed_probe_local = True
                 else:
                     should_block = True
 
@@ -305,6 +308,7 @@ class LLMCircuitBreaker:
                     # No probe active -- allow one
                     self._half_open_probe_active = True
                     should_block = False
+                    claimed_probe_local = True
 
         if _emit_transition and self._metrics is not None:
             self._safe_emit(
@@ -312,7 +316,7 @@ class LLMCircuitBreaker:
                 self.backend_name,
                 *_emit_transition,
             )
-        return should_block
+        return should_block, claimed_probe_local
 
     def record_failure(
         self,
@@ -337,8 +341,9 @@ class LLMCircuitBreaker:
             new_state_str = new_state["state"]
 
             if new_state_str == CircuitState.OPEN.value:
-                prev_label = "half_open" if new_state.get("_prev_was_half_open") else new_state.get("_prev_state", "closed")
-                if new_state.get("_prev_was_half_open"):
+                prev_was_half_open = bool(new_state.get("_prev_was_half_open", False))
+                prev_label = str(new_state.get("_prev_state", "closed"))
+                if prev_was_half_open:
                     self._log(
                         "Probe failed, circuit breaker re-opened",
                         failure_count=failure_count,
@@ -361,7 +366,7 @@ class LLMCircuitBreaker:
                         self._safe_emit(
                             self._metrics.record_state_transition,
                             self.backend_name,
-                            prev_label,
+                            prev_label,  # now from _prev_state, never stale
                             "open",
                         )
             else:
@@ -422,10 +427,10 @@ class LLMCircuitBreaker:
             return
 
         if self._store is not None:
-            prev_state_str = self._store.get_state(self.backend_name)["state"]
-            self._store.atomic_record_success(self.backend_name)
+            new_state = self._store.atomic_record_success(self.backend_name)
+            prev_state_str = str(new_state.get("_prev_state", new_state["state"]))
 
-            if prev_state_str != CircuitState.CLOSED.value:
+            if prev_state_str != CircuitState.CLOSED.value and new_state["state"] == CircuitState.CLOSED.value:
                 self._log(
                     "Circuit breaker closed after success",
                     previous_state=prev_state_str,
@@ -472,7 +477,7 @@ class LLMCircuitBreaker:
             return
 
         if self._store is not None:
-            now = time.monotonic()
+            now = time.time()
             duration = max(self.config.reset_time_seconds, open_for_seconds)
             state = self._store.get_state(self.backend_name)
             prev_state_value = state.get("state", CircuitState.CLOSED.value)
@@ -579,11 +584,12 @@ class LLMCircuitBreaker:
         if not self.config.enabled:
             return await coro_factory()
 
-        if self.should_block():
-            # Note: state is read after should_block() for the error message
-            # and metric label. Under high concurrency, the state may transition between
-            # should_block() and the re-acquisition (e.g. OPEN->HALF_OPEN). The
-            # outcome label is best-effort; the rejection decision itself is authoritative.
+        _initial_blocked, _initial_claimed = self._should_block_with_claim()
+        if _initial_blocked:
+            # Note: state is read after the gate check for the error message
+            # and metric label. Under high concurrency, the state may transition
+            # between the gate and this read (e.g. OPEN->HALF_OPEN). The outcome
+            # label is best-effort; the rejection decision itself is authoritative.
             if self._store is not None:
                 state_label = self.state.value
             else:
@@ -598,28 +604,27 @@ class LLMCircuitBreaker:
 
         last_exc: Exception | None = None
         delay = 1.0  # initial backoff for CAP / retryable errors
-        _owns_probe = self.state == CircuitState.HALF_OPEN
+        _owns_probe = _initial_claimed
 
         try:
             for attempt in range(1, max_retries + 1):
                 # Re-check CB state at start of each attempt
-                if attempt > 1 and self.should_block():
-                    if self._store is not None:
-                        state_label = self.state.value
-                    else:
-                        with self._lock:
-                            state_label = self._state.value
-                    outcome = "rejected_open" if state_label == "open" else "rejected_half_open"
-                    if self._metrics is not None:
-                        self._safe_emit(self._metrics.record_request, self.backend_name, outcome, 0.0)
-                    raise CircuitBreakerOpenError(
-                        f"Circuit breaker became {state_label} during retries " f"for {self.backend_name}",
-                    )
-
-                if attempt > 1 and not _owns_probe:
-                    with self._lock:
-                        if self._state == CircuitState.HALF_OPEN:
-                            _owns_probe = True
+                if attempt > 1:
+                    _retry_blocked, _retry_claimed = self._should_block_with_claim()
+                    if _retry_claimed:
+                        _owns_probe = True
+                    if _retry_blocked:
+                        if self._store is not None:
+                            state_label = self.state.value
+                        else:
+                            with self._lock:
+                                state_label = self._state.value
+                        outcome = "rejected_open" if state_label == "open" else "rejected_half_open"
+                        if self._metrics is not None:
+                            self._safe_emit(self._metrics.record_request, self.backend_name, outcome, 0.0)
+                        raise CircuitBreakerOpenError(
+                            f"Circuit breaker became {state_label} during retries " f"for {self.backend_name}",
+                        )
 
                 _t0 = time.perf_counter()
                 try:
@@ -743,7 +748,7 @@ class LLMCircuitBreaker:
                         state.update(
                             {
                                 "state": CircuitState.OPEN.value,
-                                "open_until": time.monotonic() + self.config.reset_time_seconds,
+                                "open_until": time.time() + self.config.reset_time_seconds,
                                 "half_open_probe_active": False,
                             },
                         )

--- a/massgen/backend/llm_circuit_breaker.py
+++ b/massgen/backend/llm_circuit_breaker.py
@@ -479,17 +479,42 @@ class LLMCircuitBreaker:
         if self._store is not None:
             now = time.time()
             duration = max(self.config.reset_time_seconds, open_for_seconds)
-            state = self._store.get_state(self.backend_name)
-            prev_state_value = state.get("state", CircuitState.CLOSED.value)
-            state.update(
-                {
+            computed_open_until = now + duration
+            prev_state_value = CircuitState.CLOSED.value
+            _MAX_CAS_ATTEMPTS = 5
+            for _attempt in range(_MAX_CAS_ATTEMPTS):
+                current = self._store.get_state(self.backend_name)
+                prev_state_value = current.get("state", CircuitState.CLOSED.value)
+                # Preserve longer open_until and more recent failure time
+                # if a concurrent force_open has already written a later value.
+                merged_open_until = max(computed_open_until, float(current.get("open_until", 0)))
+                merged_last_failure = max(now, float(current.get("last_failure_time", 0)))
+                updates = {
                     "state": CircuitState.OPEN.value,
-                    "last_failure_time": now,
-                    "open_until": now + duration,
+                    "last_failure_time": merged_last_failure,
+                    "open_until": merged_open_until,
                     "half_open_probe_active": False,
-                },
-            )
-            self._store.set_state(self.backend_name, state)
+                }
+                applied = self._store.cas_state(self.backend_name, prev_state_value, updates)
+                if applied:
+                    break
+                # CAS conflict -- retry with refreshed state
+            else:
+                # All CAS attempts failed; fall back to unconditional set to
+                # avoid leaving the CB in a non-open state under quota exhaustion.
+                current = self._store.get_state(self.backend_name)
+                merged_open_until = max(computed_open_until, float(current.get("open_until", 0)))
+                merged_last_failure = max(now, float(current.get("last_failure_time", 0)))
+                self._store.set_state(
+                    self.backend_name,
+                    {
+                        **current,
+                        "state": CircuitState.OPEN.value,
+                        "last_failure_time": merged_last_failure,
+                        "open_until": merged_open_until,
+                        "half_open_probe_active": False,
+                    },
+                )
             self._log(
                 f"Circuit breaker force-opened: {reason}",
                 open_for_seconds=duration,
@@ -706,7 +731,10 @@ class LLMCircuitBreaker:
                             error_type=f"http_{status_code}",
                             error_message=str(exc)[:200],
                         )
-                        if attempt < max_retries and not self.should_block():
+                        _retry_blocked2, _retry_claimed2 = self._should_block_with_claim()
+                        if _retry_claimed2:
+                            _owns_probe = True
+                        if attempt < max_retries and not _retry_blocked2:
                             jittered = delay * random.uniform(0.8, 1.2)  # noqa: S311
                             self._log(
                                 f"Retryable error (HTTP {status_code}), backing off",
@@ -743,16 +771,20 @@ class LLMCircuitBreaker:
             _transition_args: tuple[str, str, str] | None = None
             if _owns_probe:
                 if self._store is not None:
-                    state = self._store.get_state(self.backend_name)
-                    if CircuitState(state["state"]) == CircuitState.HALF_OPEN and state["half_open_probe_active"]:
-                        state.update(
-                            {
-                                "state": CircuitState.OPEN.value,
-                                "open_until": time.time() + self.config.reset_time_seconds,
-                                "half_open_probe_active": False,
-                            },
-                        )
-                        self._store.set_state(self.backend_name, state)
+                    # Use CAS to avoid overwriting a longer open_until written
+                    # concurrently (e.g. force_open from another coroutine).
+                    _probe_now = time.time()
+                    _probe_open_until = _probe_now + self.config.reset_time_seconds
+                    _probe_applied = self._store.cas_state(
+                        self.backend_name,
+                        CircuitState.HALF_OPEN.value,
+                        {
+                            "state": CircuitState.OPEN.value,
+                            "open_until": _probe_open_until,
+                            "half_open_probe_active": False,
+                        },
+                    )
+                    if _probe_applied:
                         self._log(
                             "Probe terminated abnormally, circuit breaker re-opened",
                         )

--- a/massgen/backend/llm_circuit_breaker.py
+++ b/massgen/backend/llm_circuit_breaker.py
@@ -91,7 +91,8 @@ class LLMCircuitBreakerConfig:
             )
         if self.retry_after_threshold_seconds < 0:
             raise ValueError(
-                f"retry_after_threshold_seconds must be >= 0, " f"got {self.retry_after_threshold_seconds}",
+                "retry_after_threshold_seconds must be >= 0, "
+                f"got {self.retry_after_threshold_seconds}",
             )
 
 
@@ -328,65 +329,43 @@ class LLMCircuitBreaker:
             return
 
         if self._store is not None:
-            previous = self._store.get_state(self.backend_name)
-            previous_state = CircuitState(previous["state"])
-            failure_count = self._store.increment_failure(self.backend_name)
-            now = time.monotonic()
+            new_state = self._store.atomic_record_failure(
+                self.backend_name,
+                self.config.max_failures,
+                float(self.config.reset_time_seconds),
+            )
+            failure_count = int(new_state["failure_count"])
+            new_state_str = new_state["state"]
 
-            if previous_state == CircuitState.HALF_OPEN:
-                self._store.cas_state(
-                    self.backend_name,
-                    CircuitState.HALF_OPEN.value,
-                    {
-                        "state": CircuitState.OPEN.value,
-                        "last_failure_time": now,
-                        "open_until": now + self.config.reset_time_seconds,
-                        "half_open_probe_active": False,
-                    },
-                )
-                self._log(
-                    "Probe failed, circuit breaker re-opened",
-                    failure_count=failure_count,
-                    error_type=error_type,
-                )
-                if self._metrics is not None:
-                    self._safe_emit(
-                        self._metrics.record_state_transition,
-                        self.backend_name,
-                        "half_open",
-                        "open",
+            if new_state_str == CircuitState.OPEN.value:
+                prev_label = "half_open" if new_state.get("_prev_was_half_open") else new_state.get("_prev_state", "closed")
+                if new_state.get("_prev_was_half_open"):
+                    self._log(
+                        "Probe failed, circuit breaker re-opened",
+                        failure_count=failure_count,
+                        error_type=error_type,
                     )
-                return
-
-            if failure_count >= self.config.max_failures:
-                self._store.cas_state(
-                    self.backend_name,
-                    previous_state.value,
-                    {
-                        "state": CircuitState.OPEN.value,
-                        "last_failure_time": now,
-                        "open_until": now + self.config.reset_time_seconds,
-                        "half_open_probe_active": False,
-                    },
-                )
-                self._log(
-                    "Circuit breaker opened",
-                    failure_count=failure_count,
-                    error_type=error_type,
-                )
-                if self._metrics is not None:
-                    self._safe_emit(
-                        self._metrics.record_state_transition,
-                        self.backend_name,
-                        previous_state.value,
-                        "open",
+                    if self._metrics is not None:
+                        self._safe_emit(
+                            self._metrics.record_state_transition,
+                            self.backend_name,
+                            "half_open",
+                            "open",
+                        )
+                else:
+                    self._log(
+                        "Circuit breaker opened",
+                        failure_count=failure_count,
+                        error_type=error_type,
                     )
+                    if self._metrics is not None:
+                        self._safe_emit(
+                            self._metrics.record_state_transition,
+                            self.backend_name,
+                            prev_label,
+                            "open",
+                        )
             else:
-                self._store.cas_state(
-                    self.backend_name,
-                    previous_state.value,
-                    {"last_failure_time": now},
-                )
                 self._log(
                     "Failure recorded",
                     failure_count=failure_count,
@@ -444,24 +423,19 @@ class LLMCircuitBreaker:
             return
 
         if self._store is not None:
-            prev_state = CircuitState(
-                self._store.get_state(self.backend_name)["state"],
-            )
-            self._store.set_state(
-                self.backend_name,
-                dict(DEFAULT_CIRCUIT_BREAKER_STATE),
-            )
+            prev_state_str = self._store.get_state(self.backend_name)["state"]
+            self._store.atomic_record_success(self.backend_name)
 
-            if prev_state != CircuitState.CLOSED:
+            if prev_state_str != CircuitState.CLOSED.value:
                 self._log(
                     "Circuit breaker closed after success",
-                    previous_state=prev_state.value,
+                    previous_state=prev_state_str,
                 )
                 if self._metrics is not None:
                     self._safe_emit(
                         self._metrics.record_state_transition,
                         self.backend_name,
-                        prev_state.value,
+                        prev_state_str,
                         "closed",
                     )
             return
@@ -639,7 +613,8 @@ class LLMCircuitBreaker:
                     if self._metrics is not None:
                         self._safe_emit(self._metrics.record_request, self.backend_name, outcome, 0.0)
                     raise CircuitBreakerOpenError(
-                        f"Circuit breaker became {state_label} during retries for {self.backend_name}",
+                        f"Circuit breaker became {state_label} during retries "
+                        f"for {self.backend_name}",
                     )
 
                 if attempt > 1 and not _owns_probe:
@@ -672,7 +647,9 @@ class LLMCircuitBreaker:
                         if action == RateLimitAction.STOP:
                             # Quota exhaustion -- open CB for full Retry-After window
                             self.force_open(
-                                f"429 STOP: Retry-After={retry_after}s > " f"threshold={self.config.retry_after_threshold_seconds}s",
+                                f"429 STOP: Retry-After={retry_after}s > "
+                                "threshold="
+                                f"{self.config.retry_after_threshold_seconds}s",
                                 open_for_seconds=retry_after or 0,
                             )
                             if self._metrics is not None:
@@ -685,7 +662,9 @@ class LLMCircuitBreaker:
                                 self._safe_emit(self._metrics.record_request, self.backend_name, "failure", _latency)
                             if attempt >= max_retries:
                                 raise
-                            wait_seconds = retry_after if retry_after is not None else 1.0
+                            wait_seconds = (
+                                retry_after if retry_after is not None else 1.0
+                            )
                             self._log(
                                 "429 WAIT: retrying after Retry-After",
                                 retry_after=wait_seconds,
@@ -765,11 +744,15 @@ class LLMCircuitBreaker:
             if _owns_probe:
                 if self._store is not None:
                     state = self._store.get_state(self.backend_name)
-                    if CircuitState(state["state"]) == CircuitState.HALF_OPEN and state["half_open_probe_active"]:
+                    if (
+                        CircuitState(state["state"]) == CircuitState.HALF_OPEN
+                        and state["half_open_probe_active"]
+                    ):
                         state.update(
                             {
                                 "state": CircuitState.OPEN.value,
-                                "open_until": time.monotonic() + self.config.reset_time_seconds,
+                                "open_until": time.monotonic()
+                                + self.config.reset_time_seconds,
                                 "half_open_probe_active": False,
                             },
                         )
@@ -815,7 +798,9 @@ class LLMCircuitBreaker:
 
     def _log(self, message: str, **details: Any) -> None:
         """Log via structured backend activity logger."""
-        log_details: dict[str, Any] = {k: v for k, v in details.items() if v is not None}
+        log_details: dict[str, Any] = {
+            k: v for k, v in details.items() if v is not None
+        }
         log_backend_activity(
             self.backend_name,
             message,
@@ -827,11 +812,19 @@ class LLMCircuitBreaker:
         if self._store is not None:
             state = self.state.value
             failures = self.failure_count
-            return f"LLMCircuitBreaker(state={state}, " f"failures={failures}/{self.config.max_failures}, " f"backend={self.backend_name!r})"
+            return (
+                f"LLMCircuitBreaker(state={state}, "
+                f"failures={failures}/{self.config.max_failures}, "
+                f"backend={self.backend_name!r})"
+            )
         with self._lock:
             state = self._state.value
             failures = self._failure_count
-        return f"LLMCircuitBreaker(state={state}, " f"failures={failures}/{self.config.max_failures}, " f"backend={self.backend_name!r})"
+        return (
+            f"LLMCircuitBreaker(state={state}, "
+            f"failures={failures}/{self.config.max_failures}, "
+            f"backend={self.backend_name!r})"
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/massgen/backend/llm_circuit_breaker.py
+++ b/massgen/backend/llm_circuit_breaker.py
@@ -23,6 +23,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
 from ..logger_config import log_backend_activity
+from .cb_store import DEFAULT_CIRCUIT_BREAKER_STATE
 
 if TYPE_CHECKING:
     from massgen.observability.prometheus import CircuitBreakerMetrics
@@ -192,10 +193,12 @@ class LLMCircuitBreaker:
         config: LLMCircuitBreakerConfig | None = None,
         backend_name: str = "claude",
         metrics: CircuitBreakerMetrics | None = None,
+        store: Any = None,
     ) -> None:
         self.config = config or LLMCircuitBreakerConfig()
         self.backend_name = backend_name
         self._metrics = metrics
+        self._store: Any = store
         self._lock = threading.Lock()
 
         # State
@@ -210,12 +213,16 @@ class LLMCircuitBreaker:
     @property
     def state(self) -> CircuitState:
         """Current circuit state (read-only snapshot)."""
+        if self._store is not None:
+            return CircuitState(self._store.get_state(self.backend_name)["state"])
         with self._lock:
             return self._state
 
     @property
     def failure_count(self) -> int:
         """Current failure count (read-only snapshot)."""
+        if self._store is not None:
+            return int(self._store.get_state(self.backend_name)["failure_count"])
         with self._lock:
             return self._failure_count
 
@@ -228,6 +235,49 @@ class LLMCircuitBreaker:
         """
         if not self.config.enabled:
             return False
+
+        if self._store is not None:
+            for _ in range(2):
+                state = self._store.get_state(self.backend_name)
+                circuit_state = CircuitState(state["state"])
+
+                if circuit_state == CircuitState.CLOSED:
+                    return False
+
+                if circuit_state == CircuitState.OPEN:
+                    now = time.monotonic()
+                    if now >= float(state["open_until"]):
+                        transitioned = self._store.cas_state(
+                            self.backend_name,
+                            CircuitState.OPEN.value,
+                            {
+                                "state": CircuitState.HALF_OPEN.value,
+                                "half_open_probe_active": True,
+                            },
+                        )
+                        if transitioned:
+                            self._log(
+                                "Circuit breaker half-open, allowing probe request",
+                            )
+                            if self._metrics is not None:
+                                self._safe_emit(
+                                    self._metrics.record_state_transition,
+                                    self.backend_name,
+                                    "open",
+                                    "half_open",
+                                )
+                            return False
+                        continue
+                    return True
+
+                if state["half_open_probe_active"]:
+                    return True
+                return not self._store.cas_state(
+                    self.backend_name,
+                    CircuitState.HALF_OPEN.value,
+                    {"half_open_probe_active": True},
+                )
+            return True
 
         _emit_transition: tuple[str, str] | None = None
         with self._lock:
@@ -275,6 +325,74 @@ class LLMCircuitBreaker:
         In HALF_OPEN, any failure transitions back to OPEN.
         """
         if not self.config.enabled:
+            return
+
+        if self._store is not None:
+            previous = self._store.get_state(self.backend_name)
+            previous_state = CircuitState(previous["state"])
+            failure_count = self._store.increment_failure(self.backend_name)
+            now = time.monotonic()
+
+            if previous_state == CircuitState.HALF_OPEN:
+                self._store.cas_state(
+                    self.backend_name,
+                    CircuitState.HALF_OPEN.value,
+                    {
+                        "state": CircuitState.OPEN.value,
+                        "last_failure_time": now,
+                        "open_until": now + self.config.reset_time_seconds,
+                        "half_open_probe_active": False,
+                    },
+                )
+                self._log(
+                    "Probe failed, circuit breaker re-opened",
+                    failure_count=failure_count,
+                    error_type=error_type,
+                )
+                if self._metrics is not None:
+                    self._safe_emit(
+                        self._metrics.record_state_transition,
+                        self.backend_name,
+                        "half_open",
+                        "open",
+                    )
+                return
+
+            if failure_count >= self.config.max_failures:
+                self._store.cas_state(
+                    self.backend_name,
+                    previous_state.value,
+                    {
+                        "state": CircuitState.OPEN.value,
+                        "last_failure_time": now,
+                        "open_until": now + self.config.reset_time_seconds,
+                        "half_open_probe_active": False,
+                    },
+                )
+                self._log(
+                    "Circuit breaker opened",
+                    failure_count=failure_count,
+                    error_type=error_type,
+                )
+                if self._metrics is not None:
+                    self._safe_emit(
+                        self._metrics.record_state_transition,
+                        self.backend_name,
+                        previous_state.value,
+                        "open",
+                    )
+            else:
+                self._store.cas_state(
+                    self.backend_name,
+                    previous_state.value,
+                    {"last_failure_time": now},
+                )
+                self._log(
+                    "Failure recorded",
+                    failure_count=failure_count,
+                    max_failures=self.config.max_failures,
+                    error_type=error_type,
+                )
             return
 
         _transition_args: tuple[str, str, str] | None = None
@@ -325,6 +443,29 @@ class LLMCircuitBreaker:
         if not self.config.enabled:
             return
 
+        if self._store is not None:
+            prev_state = CircuitState(
+                self._store.get_state(self.backend_name)["state"],
+            )
+            self._store.set_state(
+                self.backend_name,
+                dict(DEFAULT_CIRCUIT_BREAKER_STATE),
+            )
+
+            if prev_state != CircuitState.CLOSED:
+                self._log(
+                    "Circuit breaker closed after success",
+                    previous_state=prev_state.value,
+                )
+                if self._metrics is not None:
+                    self._safe_emit(
+                        self._metrics.record_state_transition,
+                        self.backend_name,
+                        prev_state.value,
+                        "closed",
+                    )
+            return
+
         _transition_args: tuple[str, str, str] | None = None
         with self._lock:
             prev_state = self._state
@@ -357,6 +498,33 @@ class LLMCircuitBreaker:
         if not self.config.enabled:
             return
 
+        if self._store is not None:
+            now = time.monotonic()
+            duration = max(self.config.reset_time_seconds, open_for_seconds)
+            state = self._store.get_state(self.backend_name)
+            prev_state_value = state.get("state", CircuitState.CLOSED.value)
+            state.update(
+                {
+                    "state": CircuitState.OPEN.value,
+                    "last_failure_time": now,
+                    "open_until": now + duration,
+                    "half_open_probe_active": False,
+                },
+            )
+            self._store.set_state(self.backend_name, state)
+            self._log(
+                f"Circuit breaker force-opened: {reason}",
+                open_for_seconds=duration,
+            )
+            if self._metrics is not None:
+                self._safe_emit(
+                    self._metrics.record_state_transition,
+                    self.backend_name,
+                    prev_state_value,
+                    "open",
+                )
+            return
+
         _transition_args: tuple[str, str, str] | None = None
         with self._lock:
             now = time.monotonic()
@@ -378,6 +546,23 @@ class LLMCircuitBreaker:
 
     def reset(self) -> None:
         """Reset circuit breaker to initial CLOSED state."""
+        if self._store is not None:
+            prev_state_value = self._store.get_state(self.backend_name).get(
+                "state", CircuitState.CLOSED.value
+            )
+            self._store.set_state(
+                self.backend_name,
+                dict(DEFAULT_CIRCUIT_BREAKER_STATE),
+            )
+            if self._metrics is not None and prev_state_value != CircuitState.CLOSED.value:
+                self._safe_emit(
+                    self._metrics.record_state_transition,
+                    self.backend_name,
+                    prev_state_value,
+                    "closed",
+                )
+            return
+
         _transition_args: tuple[str, str, str] | None = None
         with self._lock:
             prev_state = self._state
@@ -421,12 +606,15 @@ class LLMCircuitBreaker:
             return await coro_factory()
 
         if self.should_block():
-            # Note: state is read under lock after should_block() for the error message
+            # Note: state is read after should_block() for the error message
             # and metric label. Under high concurrency, the state may transition between
-            # should_block() and the lock re-acquisition (e.g. OPEN->HALF_OPEN). The
+            # should_block() and the re-acquisition (e.g. OPEN->HALF_OPEN). The
             # outcome label is best-effort; the rejection decision itself is authoritative.
-            with self._lock:
-                state_label = self._state.value
+            if self._store is not None:
+                state_label = self.state.value
+            else:
+                with self._lock:
+                    state_label = self._state.value
             outcome = "rejected_open" if state_label == "open" else "rejected_half_open"
             if self._metrics is not None:
                 self._safe_emit(self._metrics.record_request, self.backend_name, outcome, 0.0)
@@ -442,8 +630,11 @@ class LLMCircuitBreaker:
             for attempt in range(1, max_retries + 1):
                 # Re-check CB state at start of each attempt
                 if attempt > 1 and self.should_block():
-                    with self._lock:
-                        state_label = self._state.value
+                    if self._store is not None:
+                        state_label = self.state.value
+                    else:
+                        with self._lock:
+                            state_label = self._state.value
                     outcome = "rejected_open" if state_label == "open" else "rejected_half_open"
                     if self._metrics is not None:
                         self._safe_emit(self._metrics.record_request, self.backend_name, outcome, 0.0)
@@ -572,19 +763,41 @@ class LLMCircuitBreaker:
             # to prevent wedging the CB in a permanently blocked state.
             _transition_args: tuple[str, str, str] | None = None
             if _owns_probe:
-                with self._lock:
-                    if self._state == CircuitState.HALF_OPEN and self._half_open_probe_active:
-                        self._state = CircuitState.OPEN
-                        self._open_until = time.monotonic() + self.config.reset_time_seconds
-                        self._half_open_probe_active = False
-                        self._log("Probe terminated abnormally, circuit breaker re-opened")
+                if self._store is not None:
+                    state = self._store.get_state(self.backend_name)
+                    if CircuitState(state["state"]) == CircuitState.HALF_OPEN and state["half_open_probe_active"]:
+                        state.update(
+                            {
+                                "state": CircuitState.OPEN.value,
+                                "open_until": time.monotonic() + self.config.reset_time_seconds,
+                                "half_open_probe_active": False,
+                            },
+                        )
+                        self._store.set_state(self.backend_name, state)
+                        self._log(
+                            "Probe terminated abnormally, circuit breaker re-opened",
+                        )
                         if self._metrics is not None:
-                            _transition_args = (self.backend_name, "half_open", "open")
-                if _transition_args is not None and self._metrics is not None:
-                    self._safe_emit(
-                        self._metrics.record_state_transition,
-                        *_transition_args,
-                    )
+                            self._safe_emit(
+                                self._metrics.record_state_transition,
+                                self.backend_name,
+                                "half_open",
+                                "open",
+                            )
+                else:
+                    with self._lock:
+                        if self._state == CircuitState.HALF_OPEN and self._half_open_probe_active:
+                            self._state = CircuitState.OPEN
+                            self._open_until = time.monotonic() + self.config.reset_time_seconds
+                            self._half_open_probe_active = False
+                            self._log("Probe terminated abnormally, circuit breaker re-opened")
+                            if self._metrics is not None:
+                                _transition_args = (self.backend_name, "half_open", "open")
+                    if _transition_args is not None and self._metrics is not None:
+                        self._safe_emit(
+                            self._metrics.record_state_transition,
+                            *_transition_args,
+                        )
             raise
 
     # -- Internal helpers ---------------------------------------------------
@@ -611,6 +824,10 @@ class LLMCircuitBreaker:
         )
 
     def __repr__(self) -> str:
+        if self._store is not None:
+            state = self.state.value
+            failures = self.failure_count
+            return f"LLMCircuitBreaker(state={state}, " f"failures={failures}/{self.config.max_failures}, " f"backend={self.backend_name!r})"
         with self._lock:
             state = self._state.value
             failures = self._failure_count

--- a/massgen/tests/test_cb_store.py
+++ b/massgen/tests/test_cb_store.py
@@ -123,10 +123,7 @@ class TestInMemoryStoreThreadSafety:
     def test_concurrent_increment_failure_100_threads(self):
         store = InMemoryStore()
 
-        threads = [
-            threading.Thread(target=store.increment_failure, args=("claude",))
-            for _ in range(100)
-        ]
+        threads = [threading.Thread(target=store.increment_failure, args=("claude",)) for _ in range(100)]
         for thread in threads:
             thread.start()
         for thread in threads:

--- a/massgen/tests/test_cb_store.py
+++ b/massgen/tests/test_cb_store.py
@@ -261,7 +261,11 @@ class TestInMemoryStoreAtomicRecordSuccess:
 
         state = store.atomic_record_success("claude")
 
-        assert state == expected
+        # state includes _prev_state / _prev_was_half_open metadata -- compare core fields only
+        core_keys = set(expected.keys())
+        assert {k: state[k] for k in core_keys} == expected
+        assert state["_prev_state"] == "open"
+        assert state["_prev_was_half_open"] is False
         assert store.get_state("claude") == expected
 
     def test_expected_state_mismatch_is_noop(self):
@@ -440,7 +444,11 @@ class TestRedisStoreAtomicRecordSuccess:
 
         state = store.atomic_record_success("claude")
 
-        assert state == expected
+        # state includes _prev_state / _prev_was_half_open metadata -- compare core fields only
+        core_keys = set(expected.keys())
+        assert {k: state[k] for k in core_keys} == expected
+        assert state["_prev_state"] == "open"
+        assert state["_prev_was_half_open"] is False
         assert store.get_state("claude") == expected
 
     def test_expected_state_mismatch_is_noop(self):

--- a/massgen/tests/test_cb_store.py
+++ b/massgen/tests/test_cb_store.py
@@ -1,0 +1,276 @@
+"""Tests for distributed circuit breaker state stores."""
+
+from __future__ import annotations
+
+import threading
+
+import pytest
+
+from massgen.backend.cb_store import (
+    DEFAULT_CIRCUIT_BREAKER_STATE,
+    InMemoryStore,
+    RedisStore,
+    make_store,
+)
+from massgen.backend.llm_circuit_breaker import (
+    CircuitState,
+    LLMCircuitBreaker,
+    LLMCircuitBreakerConfig,
+)
+
+
+def _enabled_config(**overrides) -> LLMCircuitBreakerConfig:
+    defaults = {"enabled": True, "max_failures": 3, "reset_time_seconds": 1}
+    defaults.update(overrides)
+    return LLMCircuitBreakerConfig(**defaults)
+
+
+def _open_state(**overrides) -> dict:
+    state = {
+        "state": "open",
+        "failure_count": 2,
+        "last_failure_time": 10.5,
+        "open_until": 20.5,
+        "half_open_probe_active": True,
+    }
+    state.update(overrides)
+    return state
+
+
+def _fake_redis():
+    fakeredis = pytest.importorskip("fakeredis")
+    return fakeredis.FakeRedis()
+
+
+class TestInMemoryStoreHappyPath:
+    def test_get_state_returns_defaults_for_new_backend(self):
+        store = InMemoryStore()
+
+        assert store.get_state("claude") == DEFAULT_CIRCUIT_BREAKER_STATE
+
+    def test_set_state_persists_values(self):
+        store = InMemoryStore()
+        expected = _open_state()
+
+        store.set_state("claude", expected)
+
+        assert store.get_state("claude") == expected
+
+    def test_get_state_returns_copy_not_reference(self):
+        store = InMemoryStore()
+        state = store.get_state("claude")
+
+        state["state"] = "open"
+
+        assert store.get_state("claude")["state"] == "closed"
+
+    def test_cas_state_succeeds_when_state_matches(self):
+        store = InMemoryStore()
+
+        result = store.cas_state("claude", "closed", {"state": "open"})
+
+        assert result is True
+        assert store.get_state("claude")["state"] == "open"
+
+    def test_cas_state_fails_when_state_mismatches(self):
+        store = InMemoryStore()
+
+        result = store.cas_state("claude", "open", {"state": "half_open"})
+
+        assert result is False
+        assert store.get_state("claude")["state"] == "closed"
+
+    def test_increment_failure_returns_new_count(self):
+        store = InMemoryStore()
+
+        assert store.increment_failure("claude") == 1
+
+    def test_increment_failure_is_sequential(self):
+        store = InMemoryStore()
+
+        assert [store.increment_failure("claude") for _ in range(3)] == [1, 2, 3]
+
+    def test_clear_resets_to_defaults(self):
+        store = InMemoryStore()
+        store.set_state("claude", _open_state())
+
+        store.clear("claude")
+
+        assert store.get_state("claude") == DEFAULT_CIRCUIT_BREAKER_STATE
+
+    def test_multiple_backends_isolated(self):
+        store = InMemoryStore()
+
+        store.set_state("claude", _open_state())
+
+        assert store.get_state("openai") == DEFAULT_CIRCUIT_BREAKER_STATE
+        assert store.get_state("claude")["state"] == "open"
+
+    def test_set_state_full_dict_roundtrip(self):
+        store = InMemoryStore()
+        expected = _open_state(
+            state="half_open",
+            failure_count=7,
+            half_open_probe_active=False,
+        )
+
+        store.set_state("claude", expected)
+
+        assert store.get_state("claude") == expected
+
+
+class TestInMemoryStoreThreadSafety:
+    def test_concurrent_increment_failure_100_threads(self):
+        store = InMemoryStore()
+
+        threads = [threading.Thread(target=store.increment_failure, args=("claude",)) for _ in range(100)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+
+        assert store.get_state("claude")["failure_count"] == 100
+
+    def test_concurrent_cas_state_only_one_wins(self):
+        store = InMemoryStore()
+        results: list[bool] = []
+        lock = threading.Lock()
+
+        def attempt_cas() -> None:
+            result = store.cas_state("claude", "closed", {"state": "open"})
+            with lock:
+                results.append(result)
+
+        threads = [threading.Thread(target=attempt_cas) for _ in range(100)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+
+        assert results.count(True) == 1
+        assert results.count(False) == 99
+
+
+class TestRedisStoreHappyPath:
+    def test_get_state_returns_defaults_for_new_backend(self):
+        store = RedisStore(_fake_redis())
+
+        assert store.get_state("claude") == DEFAULT_CIRCUIT_BREAKER_STATE
+
+    def test_set_and_get_state_roundtrip(self):
+        store = RedisStore(_fake_redis())
+        expected = _open_state()
+
+        store.set_state("claude", expected)
+
+        assert store.get_state("claude") == expected
+
+    def test_cas_state_succeeds_when_matches(self):
+        store = RedisStore(_fake_redis())
+        store.set_state("claude", DEFAULT_CIRCUIT_BREAKER_STATE)
+
+        result = store.cas_state("claude", "closed", {"state": "open"})
+
+        assert result is True
+        assert store.get_state("claude")["state"] == "open"
+
+    def test_cas_state_fails_when_mismatches(self):
+        store = RedisStore(_fake_redis())
+        store.set_state("claude", DEFAULT_CIRCUIT_BREAKER_STATE)
+
+        result = store.cas_state("claude", "open", {"state": "half_open"})
+
+        assert result is False
+        assert store.get_state("claude")["state"] == "closed"
+
+    def test_increment_failure_atomic(self):
+        store = RedisStore(_fake_redis())
+
+        assert [store.increment_failure("claude") for _ in range(3)] == [1, 2, 3]
+        assert store.get_state("claude")["failure_count"] == 3
+
+    def test_clear_removes_key(self):
+        store = RedisStore(_fake_redis())
+        store.set_state("claude", _open_state())
+
+        store.clear("claude")
+
+        assert store.get_state("claude") == DEFAULT_CIRCUIT_BREAKER_STATE
+
+    def test_ttl_set_on_set_state(self):
+        client = _fake_redis()
+        store = RedisStore(client, ttl=123)
+
+        store.set_state("claude", DEFAULT_CIRCUIT_BREAKER_STATE)
+
+        assert client.ttl("massgen:cb:claude") == 123
+
+
+class TestMakeStore:
+    def test_make_store_memory_returns_in_memory_store(self):
+        assert isinstance(make_store("memory"), InMemoryStore)
+
+    def test_make_store_redis_returns_redis_store(self):
+        store = make_store("redis", redis_client=_fake_redis())
+
+        assert isinstance(store, RedisStore)
+
+    def test_make_store_unknown_raises_value_error(self):
+        with pytest.raises(ValueError, match="Unknown circuit breaker store backend"):
+            make_store("unknown")
+
+
+class TestCBIntegration:
+    def test_cb_with_store_starts_closed(self):
+        cb = LLMCircuitBreaker(config=_enabled_config(), store=InMemoryStore())
+
+        assert cb.state == CircuitState.CLOSED
+
+    def test_cb_with_store_opens_after_max_failures(self):
+        cb = LLMCircuitBreaker(
+            config=_enabled_config(max_failures=2),
+            store=InMemoryStore(),
+        )
+
+        cb.record_failure()
+        cb.record_failure()
+
+        assert cb.state == CircuitState.OPEN
+
+    def test_cb_with_store_reset_returns_to_closed(self):
+        cb = LLMCircuitBreaker(
+            config=_enabled_config(max_failures=1),
+            store=InMemoryStore(),
+        )
+        cb.record_failure()
+
+        cb.reset()
+
+        assert cb.state == CircuitState.CLOSED
+        assert cb.failure_count == 0
+
+    def test_cb_store_none_preserves_behavior(self):
+        cb = LLMCircuitBreaker(config=_enabled_config(max_failures=1), store=None)
+
+        cb.record_failure()
+
+        assert cb.state == CircuitState.OPEN
+        assert cb.failure_count == 1
+
+    def test_cb_store_persisted_across_instances(self):
+        store = InMemoryStore()
+        first = LLMCircuitBreaker(
+            config=_enabled_config(max_failures=1),
+            backend_name="claude",
+            store=store,
+        )
+        second = LLMCircuitBreaker(
+            config=_enabled_config(max_failures=1),
+            backend_name="claude",
+            store=store,
+        )
+
+        first.record_failure()
+
+        assert second.state == CircuitState.OPEN
+        assert second.should_block() is True

--- a/massgen/tests/test_cb_store.py
+++ b/massgen/tests/test_cb_store.py
@@ -123,7 +123,10 @@ class TestInMemoryStoreThreadSafety:
     def test_concurrent_increment_failure_100_threads(self):
         store = InMemoryStore()
 
-        threads = [threading.Thread(target=store.increment_failure, args=("claude",)) for _ in range(100)]
+        threads = [
+            threading.Thread(target=store.increment_failure, args=("claude",))
+            for _ in range(100)
+        ]
         for thread in threads:
             thread.start()
         for thread in threads:
@@ -149,6 +152,130 @@ class TestInMemoryStoreThreadSafety:
 
         assert results.count(True) == 1
         assert results.count(False) == 99
+
+
+class TestInMemoryStoreAtomicRecordFailure:
+    def test_basic_increment_increments_count(self):
+        store = InMemoryStore()
+
+        state = store.atomic_record_failure(
+            "claude",
+            failure_threshold=3,
+            recovery_timeout=1.0,
+        )
+
+        assert state["failure_count"] == 1
+        assert store.get_state("claude")["failure_count"] == 1
+
+    def test_closed_to_open_transition_at_threshold(self):
+        store = InMemoryStore()
+
+        for _ in range(3):
+            state = store.atomic_record_failure(
+                "claude",
+                failure_threshold=3,
+                recovery_timeout=1.0,
+            )
+
+        assert state["state"] == "open"
+        assert state["failure_count"] == 3
+        assert state["open_until"] > state["last_failure_time"]
+
+    def test_half_open_to_open_on_any_failure(self):
+        store = InMemoryStore()
+        store.set_state(
+            "claude",
+            {"state": "half_open", "half_open_probe_active": True},
+        )
+
+        state = store.atomic_record_failure(
+            "claude",
+            failure_threshold=5,
+            recovery_timeout=1.0,
+        )
+
+        assert state["state"] == "open"
+        assert state["half_open_probe_active"] is False
+        assert state["failure_count"] == 1
+
+    def test_below_threshold_stays_closed(self):
+        store = InMemoryStore()
+
+        for _ in range(3):
+            state = store.atomic_record_failure(
+                "claude",
+                failure_threshold=5,
+                recovery_timeout=1.0,
+            )
+
+        assert state["state"] == "closed"
+        assert state["failure_count"] == 3
+
+    def test_concurrent_100_threads_exact_count(self):
+        store = InMemoryStore()
+
+        threads = [
+            threading.Thread(
+                target=store.atomic_record_failure,
+                args=("claude", 200, 1.0),
+            )
+            for _ in range(100)
+        ]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+
+        assert store.get_state("claude")["failure_count"] == 100
+
+
+class TestInMemoryStoreAtomicRecordSuccess:
+    def test_closed_resets_failure_count(self):
+        store = InMemoryStore()
+        store.set_state("claude", {"state": "closed", "failure_count": 5})
+
+        state = store.atomic_record_success("claude")
+
+        assert state["state"] == "closed"
+        assert state["failure_count"] == 0
+        assert state["half_open_probe_active"] is False
+
+    def test_half_open_transitions_to_closed(self):
+        store = InMemoryStore()
+        store.set_state(
+            "claude",
+            {
+                "state": "half_open",
+                "failure_count": 5,
+                "half_open_probe_active": True,
+            },
+        )
+
+        state = store.atomic_record_success("claude")
+
+        assert state["state"] == "closed"
+        assert state["failure_count"] == 0
+        assert state["half_open_probe_active"] is False
+
+    def test_open_with_no_expected_state_is_noop(self):
+        store = InMemoryStore()
+        expected = _open_state(failure_count=5, half_open_probe_active=False)
+        store.set_state("claude", expected)
+
+        state = store.atomic_record_success("claude")
+
+        assert state == expected
+        assert store.get_state("claude") == expected
+
+    def test_expected_state_mismatch_is_noop(self):
+        store = InMemoryStore()
+        expected = {"state": "closed", "failure_count": 5}
+        store.set_state("claude", expected)
+
+        state = store.atomic_record_success("claude", expected_state="half_open")
+
+        assert state["state"] == "closed"
+        assert state["failure_count"] == 5
 
 
 class TestRedisStoreHappyPath:
@@ -204,6 +331,130 @@ class TestRedisStoreHappyPath:
         store.set_state("claude", DEFAULT_CIRCUIT_BREAKER_STATE)
 
         assert client.ttl("massgen:cb:claude") == 123
+
+
+class TestRedisStoreAtomicRecordFailure:
+    def test_basic_increment_increments_count(self):
+        store = RedisStore(_fake_redis())
+
+        state = store.atomic_record_failure(
+            "claude",
+            failure_threshold=3,
+            recovery_timeout=1.0,
+        )
+
+        assert state["failure_count"] == 1
+        assert store.get_state("claude")["failure_count"] == 1
+
+    def test_closed_to_open_transition_at_threshold(self):
+        store = RedisStore(_fake_redis())
+
+        for _ in range(3):
+            state = store.atomic_record_failure(
+                "claude",
+                failure_threshold=3,
+                recovery_timeout=1.0,
+            )
+
+        assert state["state"] == "open"
+        assert state["failure_count"] == 3
+        assert state["open_until"] > state["last_failure_time"]
+
+    def test_half_open_to_open_on_any_failure(self):
+        store = RedisStore(_fake_redis())
+        store.set_state(
+            "claude",
+            {"state": "half_open", "half_open_probe_active": True},
+        )
+
+        state = store.atomic_record_failure(
+            "claude",
+            failure_threshold=5,
+            recovery_timeout=1.0,
+        )
+
+        assert state["state"] == "open"
+        assert state["half_open_probe_active"] is False
+        assert state["failure_count"] == 1
+
+    def test_below_threshold_stays_closed(self):
+        store = RedisStore(_fake_redis())
+
+        for _ in range(3):
+            state = store.atomic_record_failure(
+                "claude",
+                failure_threshold=5,
+                recovery_timeout=1.0,
+            )
+
+        assert state["state"] == "closed"
+        assert state["failure_count"] == 3
+
+    def test_concurrent_100_threads_exact_count(self):
+        store = RedisStore(_fake_redis())
+
+        threads = [
+            threading.Thread(
+                target=store.atomic_record_failure,
+                args=("claude", 200, 1.0),
+            )
+            for _ in range(100)
+        ]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+
+        assert store.get_state("claude")["failure_count"] == 100
+
+
+class TestRedisStoreAtomicRecordSuccess:
+    def test_closed_resets_failure_count(self):
+        store = RedisStore(_fake_redis())
+        store.set_state("claude", {"state": "closed", "failure_count": 5})
+
+        state = store.atomic_record_success("claude")
+
+        assert state["state"] == "closed"
+        assert state["failure_count"] == 0
+        assert state["half_open_probe_active"] is False
+
+    def test_half_open_transitions_to_closed(self):
+        store = RedisStore(_fake_redis())
+        store.set_state(
+            "claude",
+            {
+                "state": "half_open",
+                "failure_count": 5,
+                "half_open_probe_active": True,
+            },
+        )
+
+        state = store.atomic_record_success("claude")
+
+        assert state["state"] == "closed"
+        assert state["failure_count"] == 0
+        assert state["half_open_probe_active"] is False
+
+    def test_open_with_no_expected_state_is_noop(self):
+        store = RedisStore(_fake_redis())
+        expected = _open_state(failure_count=5, half_open_probe_active=False)
+        store.set_state("claude", expected)
+
+        state = store.atomic_record_success("claude")
+
+        assert state == expected
+        assert store.get_state("claude") == expected
+
+    def test_expected_state_mismatch_is_noop(self):
+        store = RedisStore(_fake_redis())
+        expected = {"state": "closed", "failure_count": 5}
+        store.set_state("claude", expected)
+
+        state = store.atomic_record_success("claude", expected_state="half_open")
+
+        assert state["state"] == "closed"
+        assert state["failure_count"] == 5
 
 
 class TestMakeStore:

--- a/massgen/tests/test_cb_store_adversarial.py
+++ b/massgen/tests/test_cb_store_adversarial.py
@@ -250,7 +250,7 @@ class TestAdversarialRedisStore:
     def test_redis_store_increment_preserves_open_state_ttl(self) -> None:
         client = _fake_redis()
         store = RedisStore(client, ttl=1)
-        open_until = time.monotonic() + 120
+        open_until = time.time() + 120
         store.set_state(
             "backend",
             _complete_state(state="open", open_until=open_until),
@@ -267,7 +267,7 @@ class TestAdversarialRedisStore:
     ) -> None:
         client = _fake_redis()
         store = RedisStore(client, ttl=1)
-        open_until = time.monotonic() + 120
+        open_until = time.time() + 120
         store.set_state(
             "backend",
             _complete_state(state="open", open_until=open_until),
@@ -312,7 +312,7 @@ class TestAdversarialRedisStore:
     def test_redis_store_open_state_ttl_covers_open_until(self) -> None:
         client = _fake_redis()
         store = RedisStore(client, ttl=1)
-        open_until = time.monotonic() + 120
+        open_until = time.time() + 120
 
         store.set_state(
             "backend",
@@ -324,7 +324,7 @@ class TestAdversarialRedisStore:
     def test_redis_store_cas_open_state_ttl_covers_open_until(self) -> None:
         client = _fake_redis()
         store = RedisStore(client, ttl=1)
-        open_until = time.monotonic() + 120
+        open_until = time.time() + 120
 
         result = store.cas_state(
             "backend",
@@ -386,7 +386,7 @@ class TestAdversarialRedisStore:
             res = store.cas_state(
                 "backend",
                 "closed",
-                {"state": "open", "open_until": time.monotonic() + 60},
+                {"state": "open", "open_until": time.time() + 60},
             )
             with lock:
                 results.append(res)
@@ -608,7 +608,7 @@ class TestAdversarialCBIntegration:
 
         cb.force_open()
         state = store.get_state("backend")
-        state["open_until"] = time.monotonic() - 1
+        state["open_until"] = time.time() - 1
         store.set_state("backend", state)
 
         assert cb.should_block() is False
@@ -619,7 +619,7 @@ class TestAdversarialCBIntegration:
 
         cb.force_open()
         state = store.get_state("backend")
-        state["open_until"] = time.monotonic() - 1
+        state["open_until"] = time.time() - 1
         store.set_state("backend", state)
         assert cb.should_block() is False
         assert cb.state == CircuitState.HALF_OPEN
@@ -782,16 +782,21 @@ class TestConcurrentLinearizability:
 
 class TestForceOpenRace:
     def test_force_open_wins_over_concurrent_record_success(self) -> None:
-        success_read = threading.Event()
+        # record_success() now calls atomic_record_success() directly (no prior
+        # get_state() read). The old TOCTOU window -- where force_open() could
+        # slip between get_state() and atomic_record_success() -- no longer
+        # exists. This test verifies that when force_open() completes BEFORE
+        # atomic_record_success() acquires the lock, the OPEN state is preserved
+        # because atomic_record_success() guards against open with no
+        # expected_state.
         force_open_done = threading.Event()
+        success_start = threading.Event()
 
         class CoordinatedStore(InMemoryStore):
-            def get_state(self, backend: str) -> dict:
-                state = super().get_state(backend)
-                if threading.current_thread().name == "record-success":
-                    success_read.set()
-                    assert force_open_done.wait(timeout=5)
-                return state
+            def atomic_record_success(self, backend: str, expected_state: str | None = None) -> dict:
+                success_start.set()
+                assert force_open_done.wait(timeout=5)
+                return super().atomic_record_success(backend, expected_state)
 
         store = CoordinatedStore()
         cb = LLMCircuitBreaker(
@@ -801,7 +806,7 @@ class TestForceOpenRace:
         )
 
         def force_open() -> None:
-            assert success_read.wait(timeout=5)
+            assert success_start.wait(timeout=5)
             cb.force_open("quota", open_for_seconds=30)
             force_open_done.set()
 
@@ -817,6 +822,7 @@ class TestForceOpenRace:
         for thread in threads:
             thread.join()
 
+        # force_open() ran before atomic_record_success() -- OPEN must survive
         assert cb.state == CircuitState.OPEN
         assert store.get_state("claude")["state"] == "open"
 
@@ -841,3 +847,213 @@ class TestAtomicFailureOrdering:
         state = store.get_state("claude")
         assert state["failure_count"] == thread_count
         assert state["failure_count"] <= thread_count
+
+
+class TestTryTransitionAndClaimProbe:
+    """Adversarial tests for the atomic OPEN->HALF_OPEN / probe-claim op."""
+
+    def test_inmemory_open_elapsed_transitions_exactly_one(self) -> None:
+        store = InMemoryStore()
+        store.set_state(
+            "claude",
+            _complete_state(state="open", open_until=time.time() - 0.01),
+        )
+
+        results: list[tuple[bool, str | None]] = []
+        lock = threading.Lock()
+
+        def claim() -> None:
+            won, _state, label = store.try_transition_and_claim_probe(
+                "claude",
+                time.time(),
+                30.0,
+            )
+            with lock:
+                results.append((won, label))
+
+        threads = [threading.Thread(target=claim) for _ in range(50)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        winners = [r for r in results if r[0]]
+        assert len(winners) == 1, f"exactly one winner expected, got {len(winners)}"
+        assert winners[0][1] == "open->half_open"
+        assert store.get_state("claude")["half_open_probe_active"] is True
+        assert store.get_state("claude")["state"] == "half_open"
+
+    def test_inmemory_half_open_probe_claim_exactly_one(self) -> None:
+        store = InMemoryStore()
+        store.set_state(
+            "claude",
+            _complete_state(state="half_open", half_open_probe_active=False),
+        )
+
+        results: list[bool] = []
+        lock = threading.Lock()
+
+        def claim() -> None:
+            won, _state, _label = store.try_transition_and_claim_probe(
+                "claude",
+                time.time(),
+                30.0,
+            )
+            with lock:
+                results.append(won)
+
+        threads = [threading.Thread(target=claim) for _ in range(50)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert sum(results) == 1, f"exactly one probe winner, got {sum(results)}"
+
+    def test_inmemory_open_not_yet_elapsed_blocks(self) -> None:
+        store = InMemoryStore()
+        store.set_state(
+            "claude",
+            _complete_state(state="open", open_until=time.time() + 100),
+        )
+
+        won, state, label = store.try_transition_and_claim_probe(
+            "claude",
+            time.time(),
+            30.0,
+        )
+        assert won is False
+        assert label is None
+        assert state["state"] == "open"
+
+    def test_inmemory_force_open_during_transition_no_phantom_half_open(self) -> None:
+        """force_open extending open_until must not be undone by a stale CAS."""
+        store = InMemoryStore()
+        # Initially OPEN with elapsed open_until -- ripe for transition
+        store.set_state(
+            "claude",
+            _complete_state(state="open", open_until=time.time() - 0.01),
+        )
+
+        # Simulate force_open extending open_until before our claim
+        store.set_state(
+            "claude",
+            _complete_state(state="open", open_until=time.time() + 100),
+        )
+
+        won, state, _label = store.try_transition_and_claim_probe(
+            "claude",
+            time.time(),
+            30.0,
+        )
+        # New open_until is in the future -- must NOT transition
+        assert won is False
+        assert state["state"] == "open"
+
+    def test_redis_open_elapsed_transitions_exactly_one(self) -> None:
+        client = _fake_redis()
+        store = RedisStore(client, ttl=60)
+        store.set_state(
+            "claude",
+            _complete_state(state="open", open_until=time.time() - 0.01),
+        )
+
+        results: list[tuple[bool, str | None]] = []
+        lock = threading.Lock()
+
+        def claim() -> None:
+            won, _state, label = store.try_transition_and_claim_probe(
+                "claude",
+                time.time(),
+                30.0,
+            )
+            with lock:
+                results.append((won, label))
+
+        threads = [threading.Thread(target=claim) for _ in range(20)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        winners = [r for r in results if r[0]]
+        assert len(winners) == 1
+        assert winners[0][1] == "open->half_open"
+
+    def test_redis_open_not_elapsed_blocks(self) -> None:
+        client = _fake_redis()
+        store = RedisStore(client, ttl=60)
+        store.set_state(
+            "claude",
+            _complete_state(state="open", open_until=time.time() + 100),
+        )
+
+        won, state, label = store.try_transition_and_claim_probe(
+            "claude",
+            time.time(),
+            30.0,
+        )
+        assert won is False
+        assert label is None
+        assert state["state"] == "open"
+
+
+class TestMakeStoreFactory:
+    """Adversarial tests for the make_store factory function."""
+
+    def test_make_store_redis_missing_client_raises_valueerror(self) -> None:
+        from massgen.backend.cb_store import make_store
+
+        with pytest.raises(ValueError, match="redis_client is required"):
+            make_store("redis")
+
+    def test_make_store_redis_forwards_key_prefix(self) -> None:
+        from massgen.backend.cb_store import make_store
+
+        client = _fake_redis()
+        store = make_store(
+            "redis",
+            redis_client=client,
+            ttl=42,
+            key_prefix="custom:ns",
+        )
+        assert isinstance(store, RedisStore)
+        assert store._key_prefix == "custom:ns"
+        assert store._ttl == 42
+
+    def test_make_store_memory_default(self) -> None:
+        from massgen.backend.cb_store import make_store
+
+        store = make_store()
+        assert isinstance(store, InMemoryStore)
+
+    def test_make_store_unknown_backend_raises(self) -> None:
+        from massgen.backend.cb_store import make_store
+
+        with pytest.raises(ValueError, match="Unknown circuit breaker store"):
+            make_store("postgres")
+
+
+class TestProbeOwnershipInRetries:
+    """Adversarial: store-mode probe ownership tracking through retries."""
+
+    def test_store_mode_probe_owner_tracked_via_should_block_with_claim(self) -> None:
+        """Verify _should_block_with_claim returns claim flag in store mode."""
+        store = InMemoryStore()
+        store.set_state(
+            "claude",
+            _complete_state(state="open", open_until=time.time() - 1),
+        )
+        cb = LLMCircuitBreaker(
+            backend_name="claude",
+            config=_enabled_config(reset_time_seconds=30),
+            store=store,
+        )
+
+        blocked, claimed = cb._should_block_with_claim()
+        assert blocked is False
+        assert claimed is True
+        # Subsequent caller must NOT also claim (probe already taken)
+        blocked2, claimed2 = cb._should_block_with_claim()
+        assert blocked2 is True
+        assert claimed2 is False

--- a/massgen/tests/test_cb_store_adversarial.py
+++ b/massgen/tests/test_cb_store_adversarial.py
@@ -124,10 +124,7 @@ class TestAdversarialInMemoryStoreConcurrency:
     def test_concurrent_increment_failure_100_threads(self) -> None:
         store = InMemoryStore()
 
-        threads = [
-            threading.Thread(target=store.increment_failure, args=("backend",))
-            for _ in range(100)
-        ]
+        threads = [threading.Thread(target=store.increment_failure, args=("backend",)) for _ in range(100)]
         for thread in threads:
             thread.start()
         for thread in threads:
@@ -171,14 +168,8 @@ class TestAdversarialInMemoryStoreConcurrency:
                 with exception_lock:
                     exceptions.append(exc)
 
-        threads = [
-            threading.Thread(target=run_safely, args=(store.increment_failure,))
-            for _ in range(50)
-        ]
-        threads.extend(
-            threading.Thread(target=run_safely, args=(store.clear,))
-            for _ in range(50)
-        )
+        threads = [threading.Thread(target=run_safely, args=(store.increment_failure,)) for _ in range(50)]
+        threads.extend(threading.Thread(target=run_safely, args=(store.clear,)) for _ in range(50))
         for thread in threads:
             thread.start()
         for thread in threads:
@@ -314,10 +305,7 @@ class TestAdversarialRedisStore:
 
         with pytest.raises(
             RuntimeError,
-            match=(
-                "Failed to atomically increment failure count for 'backend' "
-                "after 3 retries"
-            ),
+            match=("Failed to atomically increment failure count for 'backend' " "after 3 retries"),
         ):
             store.increment_failure("backend")
 
@@ -779,10 +767,7 @@ class TestConcurrentLinearizability:
             )
             for _ in range(failure_count)
         ]
-        threads.extend(
-            threading.Thread(target=store.atomic_record_success, args=("claude",))
-            for _ in range(success_count)
-        )
+        threads.extend(threading.Thread(target=store.atomic_record_success, args=("claude",)) for _ in range(success_count))
 
         for thread in threads:
             thread.start()

--- a/massgen/tests/test_cb_store_adversarial.py
+++ b/massgen/tests/test_cb_store_adversarial.py
@@ -164,7 +164,7 @@ class TestAdversarialInMemoryStoreConcurrency:
         def run_safely(action: Any) -> None:
             try:
                 action("backend")
-            except BaseException as exc:
+            except Exception as exc:
                 with exception_lock:
                     exceptions.append(exc)
 
@@ -188,7 +188,7 @@ class TestAdversarialInMemoryStoreConcurrency:
         def set_open_state() -> None:
             try:
                 store.set_state("backend", _complete_state(state="open"))
-            except BaseException as exc:
+            except Exception as exc:
                 with lock:
                     exceptions.append(exc)
 
@@ -197,7 +197,7 @@ class TestAdversarialInMemoryStoreConcurrency:
                 state = store.get_state("backend")
                 with lock:
                     observed_states.append(state)
-            except BaseException as exc:
+            except Exception as exc:
                 with lock:
                     exceptions.append(exc)
 
@@ -729,13 +729,9 @@ class TestAdversarialCBIntegration:
         # After partial write: HSET succeeded (data readable), EXPIRE failed (no TTL).
         # State is defined -- either full data if HSET was atomic, or empty if HSET
         # also failed. Both are acceptable; no crash and no corrupted type errors.
-        try:
-            state = store.get_state("backend")
-            # If data was written, it should be structurally valid.
-            assert isinstance(state["failure_count"], int)
-            assert state["state"] in ("closed", "open", "half_open")
-        except Exception as exc:
-            pytest.fail(f"get_state raised after partial write: {exc}")
+        state = store.get_state("backend")
+        assert isinstance(state["failure_count"], int)
+        assert state["state"] in ("closed", "open", "half_open")
 
     def test_two_cb_same_store_different_backends(self) -> None:
         store = InMemoryStore()

--- a/massgen/tests/test_cb_store_adversarial.py
+++ b/massgen/tests/test_cb_store_adversarial.py
@@ -1,0 +1,729 @@
+"""Adversarial tests for circuit breaker state stores."""
+
+from __future__ import annotations
+
+import threading
+import time
+from typing import Any
+
+import pytest
+
+from massgen.backend.cb_store import (
+    DEFAULT_CIRCUIT_BREAKER_STATE,
+    InMemoryStore,
+    RedisStore,
+)
+from massgen.backend.llm_circuit_breaker import (
+    CircuitState,
+    LLMCircuitBreaker,
+    LLMCircuitBreakerConfig,
+)
+
+
+def _enabled_config(**overrides: Any) -> LLMCircuitBreakerConfig:
+    defaults = {"enabled": True, "max_failures": 3, "reset_time_seconds": 1}
+    defaults.update(overrides)
+    return LLMCircuitBreakerConfig(**defaults)
+
+
+def _complete_state(**overrides: Any) -> dict[str, Any]:
+    state = dict(DEFAULT_CIRCUIT_BREAKER_STATE)
+    state.update(overrides)
+    return state
+
+
+def _assert_complete_state(state: dict[str, Any]) -> None:
+    assert set(DEFAULT_CIRCUIT_BREAKER_STATE).issubset(state)
+
+
+def _fake_redis():
+    fakeredis = pytest.importorskip("fakeredis")
+    return fakeredis.FakeRedis()
+
+
+class TestAdversarialInMemoryStore:
+    def test_backend_name_empty_string(self) -> None:
+        store = InMemoryStore()
+
+        assert store.get_state("") == DEFAULT_CIRCUIT_BREAKER_STATE
+
+    def test_backend_name_very_long(self) -> None:
+        store = InMemoryStore()
+        long_backend = "x" * 10000
+
+        store.set_state(long_backend, _complete_state(state="open"))
+
+        assert store.get_state(long_backend)["state"] == "open"
+        assert store.get_state("normal") == DEFAULT_CIRCUIT_BREAKER_STATE
+
+    def test_backend_name_unicode(self) -> None:
+        store = InMemoryStore()
+
+        state = store.get_state("\u4e2d\u6587backend")
+
+        assert state == DEFAULT_CIRCUIT_BREAKER_STATE
+
+    def test_set_state_missing_keys(self) -> None:
+        store = InMemoryStore()
+
+        store.set_state("backend", {"state": "open"})
+
+        assert store.get_state("backend") == _complete_state(state="open")
+
+    def test_set_state_extra_keys(self) -> None:
+        store = InMemoryStore()
+
+        store.set_state("backend", _complete_state(extra_unknown_key="ignored_or_kept"))
+
+        state = store.get_state("backend")
+        _assert_complete_state(state)
+
+    def test_cas_state_same_state_no_op(self) -> None:
+        store = InMemoryStore()
+
+        result = store.cas_state("backend", "closed", {"failure_count": 5})
+
+        assert result is True
+        assert store.get_state("backend")["state"] == "closed"
+        assert store.get_state("backend")["failure_count"] == 5
+
+    def test_cas_state_invalid_expected_state(self) -> None:
+        store = InMemoryStore()
+
+        result = store.cas_state(
+            "backend",
+            "nonexistent_state",
+            {"state": "open"},
+        )
+
+        assert result is False
+
+    def test_increment_failure_many_times(self) -> None:
+        store = InMemoryStore()
+
+        for _ in range(1000):
+            store.increment_failure("backend")
+
+        assert store.get_state("backend")["failure_count"] == 1000
+
+    def test_clear_nonexistent_backend_no_crash(self) -> None:
+        store = InMemoryStore()
+
+        store.clear("never_existed")
+
+    def test_clear_then_get_returns_defaults(self) -> None:
+        store = InMemoryStore()
+        store.set_state("backend", _complete_state(state="open", failure_count=10))
+
+        store.clear("backend")
+
+        assert store.get_state("backend") == DEFAULT_CIRCUIT_BREAKER_STATE
+
+
+class TestAdversarialInMemoryStoreConcurrency:
+    def test_concurrent_increment_failure_100_threads(self) -> None:
+        store = InMemoryStore()
+
+        threads = [threading.Thread(target=store.increment_failure, args=("backend",)) for _ in range(100)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+
+        assert store.get_state("backend")["failure_count"] == 100
+
+    def test_concurrent_cas_state_race(self) -> None:
+        store = InMemoryStore()
+        results: list[bool] = []
+        result_lock = threading.Lock()
+
+        def attempt_cas() -> None:
+            result = store.cas_state(
+                "backend",
+                "closed",
+                {"state": "open", "failure_count": 1},
+            )
+            with result_lock:
+                results.append(result)
+
+        threads = [threading.Thread(target=attempt_cas) for _ in range(100)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+
+        assert results.count(True) == 1
+        assert results.count(False) == 99
+        assert store.get_state("backend")["state"] == "open"
+
+    def test_concurrent_clear_and_increment(self) -> None:
+        store = InMemoryStore()
+        exceptions: list[BaseException] = []
+        exception_lock = threading.Lock()
+
+        def run_safely(action: Any) -> None:
+            try:
+                action("backend")
+            except BaseException as exc:
+                with exception_lock:
+                    exceptions.append(exc)
+
+        threads = [threading.Thread(target=run_safely, args=(store.increment_failure,)) for _ in range(50)] + [threading.Thread(target=run_safely, args=(store.clear,)) for _ in range(50)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+
+        assert exceptions == []
+        final_count = store.get_state("backend")["failure_count"]
+        assert 0 <= final_count <= 50
+
+    def test_concurrent_set_and_get_state(self) -> None:
+        store = InMemoryStore()
+        exceptions: list[BaseException] = []
+        observed_states: list[dict[str, Any]] = []
+        lock = threading.Lock()
+
+        def set_open_state() -> None:
+            try:
+                store.set_state("backend", _complete_state(state="open"))
+            except BaseException as exc:
+                with lock:
+                    exceptions.append(exc)
+
+        def get_state() -> None:
+            try:
+                state = store.get_state("backend")
+                with lock:
+                    observed_states.append(state)
+            except BaseException as exc:
+                with lock:
+                    exceptions.append(exc)
+
+        threads = [threading.Thread(target=set_open_state) for _ in range(50)] + [threading.Thread(target=get_state) for _ in range(50)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+
+        assert exceptions == []
+        assert observed_states
+        for state in observed_states:
+            _assert_complete_state(state)
+
+
+class TestAdversarialRedisStore:
+    def test_redis_store_missing_key_returns_defaults(self) -> None:
+        store = RedisStore(_fake_redis())
+
+        assert store.get_state("backend") == DEFAULT_CIRCUIT_BREAKER_STATE
+
+    def test_redis_store_cas_when_key_missing(self) -> None:
+        store = RedisStore(_fake_redis())
+
+        result = store.cas_state("backend", "closed", {"state": "open"})
+
+        assert result is True
+        assert store.get_state("backend")["state"] == "open"
+
+    def test_redis_store_increment_on_missing_key(self) -> None:
+        store = RedisStore(_fake_redis())
+
+        assert store.increment_failure("backend") == 1
+        assert store.get_state("backend")["failure_count"] == 1
+
+    def test_redis_store_clear_missing_key_no_crash(self) -> None:
+        store = RedisStore(_fake_redis())
+
+        store.clear("backend")
+
+    def test_redis_store_ttl_refreshed_on_increment(self) -> None:
+        client = _fake_redis()
+        store = RedisStore(client, ttl=123)
+
+        store.increment_failure("backend")
+
+        assert client.ttl("massgen:cb:backend") > 0
+
+    def test_redis_store_increment_preserves_open_state_ttl(self) -> None:
+        client = _fake_redis()
+        store = RedisStore(client, ttl=1)
+        open_until = time.monotonic() + 120
+        store.set_state(
+            "backend",
+            _complete_state(state="open", open_until=open_until),
+        )
+        ttl_before = client.ttl("massgen:cb:backend")
+
+        store.increment_failure("backend")
+
+        assert client.ttl("massgen:cb:backend") >= ttl_before - 1
+
+    def test_redis_store_increment_without_lua_preserves_open_state_ttl(self, monkeypatch) -> None:
+        client = _fake_redis()
+        store = RedisStore(client, ttl=1)
+        open_until = time.monotonic() + 120
+        store.set_state(
+            "backend",
+            _complete_state(state="open", open_until=open_until),
+        )
+        ttl_before = client.ttl("massgen:cb:backend")
+
+        def raise_unknown_command(*args: Any, **kwargs: Any) -> None:
+            raise RuntimeError("unknown command 'eval'")
+
+        monkeypatch.setattr(client, "eval", raise_unknown_command)
+
+        store.increment_failure("backend")
+
+        assert client.ttl("massgen:cb:backend") >= ttl_before - 1
+
+    def test_redis_store_increment_without_lua_retry_exhaustion_raises(self, monkeypatch) -> None:
+        store = RedisStore(_fake_redis())
+
+        def raise_unknown_command(*args: Any, **kwargs: Any) -> None:
+            raise RuntimeError("unknown command 'eval'")
+
+        class FailingWatchPipeline:
+            def watch(self, key: str) -> None:
+                raise RuntimeError("watch conflict")
+
+        monkeypatch.setattr(store._client, "eval", raise_unknown_command)
+        monkeypatch.setattr(store._client, "pipeline", lambda transaction=True: FailingWatchPipeline())
+
+        with pytest.raises(
+            RuntimeError,
+            match="Failed to atomically increment failure count for 'backend' after 3 retries",
+        ):
+            store.increment_failure("backend")
+
+    def test_redis_store_open_state_ttl_covers_open_until(self) -> None:
+        client = _fake_redis()
+        store = RedisStore(client, ttl=1)
+        open_until = time.monotonic() + 120
+
+        store.set_state(
+            "backend",
+            _complete_state(state="open", open_until=open_until),
+        )
+
+        assert client.ttl("massgen:cb:backend") >= 170
+
+    def test_redis_store_cas_open_state_ttl_covers_open_until(self) -> None:
+        client = _fake_redis()
+        store = RedisStore(client, ttl=1)
+        open_until = time.monotonic() + 120
+
+        result = store.cas_state(
+            "backend",
+            "closed",
+            {"state": "open", "open_until": open_until},
+        )
+
+        assert result is True
+        assert client.ttl("massgen:cb:backend") >= 170
+
+    def test_redis_store_cas_missing_state_preserves_partial_hash(self) -> None:
+        client = _fake_redis()
+        store = RedisStore(client)
+        client.hset("massgen:cb:backend", "failure_count", "7")
+
+        result = store.cas_state("backend", "closed", {"state": "open"})
+
+        assert result is True
+        assert store.get_state("backend")["failure_count"] == 7
+
+    def test_redis_store_state_dict_wrong_types(self) -> None:
+        client = _fake_redis()
+        store = RedisStore(client)
+        client.hset(
+            "massgen:cb:backend",
+            mapping={
+                "state": "open",
+                "failure_count": "not_a_number",
+                "last_failure_time": "also_not_a_float",
+                "open_until": "still_not_a_float",
+                "half_open_probe_active": "not_a_bool",
+            },
+        )
+
+        # Current behavior raises ValueError for corrupted numeric fields.
+        # Graceful defaulting would also be acceptable for this boundary case.
+        try:
+            state = store.get_state("backend")
+        except ValueError:
+            return
+
+        assert state == DEFAULT_CIRCUIT_BREAKER_STATE
+
+    def test_redis_store_cas_without_lua_only_one_winner(self, monkeypatch) -> None:
+        """Concurrent CAS through non-Lua fallback: exactly 1 thread wins closed->open."""
+        client = _fake_redis()
+        store = RedisStore(client)
+
+        # Disable Lua scripting to force _cas_state_without_lua path.
+        def raise_eval(*args: Any, **kwargs: Any) -> None:
+            raise RuntimeError("unknown command 'eval'")
+
+        monkeypatch.setattr(client, "eval", raise_eval)
+
+        results: list[bool] = []
+        lock = threading.Lock()
+
+        def attempt() -> None:
+            res = store.cas_state(
+                "backend",
+                "closed",
+                {"state": "open", "open_until": time.monotonic() + 60},
+            )
+            with lock:
+                results.append(res)
+
+        threads = [threading.Thread(target=attempt) for _ in range(20)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert results.count(True) == 1
+        assert results.count(False) == 19
+        assert store.get_state("backend")["state"] == "open"
+
+    def test_redis_store_script_unavailable_does_not_match_readonly(
+        self,
+        monkeypatch,
+    ) -> None:
+        """READONLY errors are not classified as Lua unavailability."""
+        client = _fake_redis()
+        store = RedisStore(client)
+
+        def raise_readonly(*args: Any, **kwargs: Any) -> None:
+            raise RuntimeError("READONLY You can't write against a read only replica")
+
+        monkeypatch.setattr(client, "eval", raise_readonly)
+
+        with pytest.raises(RuntimeError, match="READONLY"):
+            store.cas_state("backend", "closed", {"state": "open"})
+
+
+class TestAdversarialCBIntegration:
+    def test_closed_should_block_returns_false(self) -> None:
+        config = LLMCircuitBreakerConfig(enabled=True)
+        store = InMemoryStore()
+        cb = LLMCircuitBreaker(config, backend_name="test", store=store)
+
+        assert cb.should_block() is False
+        assert cb.state == CircuitState.CLOSED
+        assert store.get_state("test")["state"] == "closed"
+
+    def test_half_open_should_block_active_probe_blocks(self) -> None:
+        config = LLMCircuitBreakerConfig(
+            enabled=True,
+            max_failures=1,
+            reset_time_seconds=60,
+        )
+        store = InMemoryStore()
+        cb = LLMCircuitBreaker(config, backend_name="test", store=store)
+        store.set_state(
+            "test",
+            {
+                "state": "half_open",
+                "failure_count": 1,
+                "last_failure_time": 0.0,
+                "open_until": 0.0,
+                "half_open_probe_active": True,
+            },
+        )
+
+        assert cb.should_block() is True
+
+    def test_half_open_should_block_inactive_probe_allows_one(self) -> None:
+        config = LLMCircuitBreakerConfig(
+            enabled=True,
+            max_failures=1,
+            reset_time_seconds=60,
+        )
+        store = InMemoryStore()
+        cb = LLMCircuitBreaker(config, backend_name="test", store=store)
+        store.set_state(
+            "test",
+            {
+                "state": "half_open",
+                "failure_count": 1,
+                "last_failure_time": 0.0,
+                "open_until": 0.0,
+                "half_open_probe_active": False,
+            },
+        )
+
+        assert cb.should_block() is False
+        assert store.get_state("test")["half_open_probe_active"] is True
+        assert cb.should_block() is True
+
+    def test_record_success_resets_failure_count_in_store(self) -> None:
+        config = LLMCircuitBreakerConfig(enabled=True, max_failures=3)
+        store = InMemoryStore()
+        cb = LLMCircuitBreaker(config, backend_name="test", store=store)
+
+        cb.record_failure()
+        cb.record_failure()
+        assert store.get_state("test")["failure_count"] == 2
+
+        cb.record_success()
+
+        assert store.get_state("test")["failure_count"] == 0
+        assert store.get_state("test")["state"] == "closed"
+
+    def test_closed_reset_is_noop(self) -> None:
+        config = LLMCircuitBreakerConfig(enabled=True)
+        store = InMemoryStore()
+        cb = LLMCircuitBreaker(config, backend_name="test", store=store)
+
+        cb.reset()
+
+        assert cb.state == CircuitState.CLOSED
+        assert store.get_state("test")["failure_count"] == 0
+
+    def test_half_open_force_open_transitions_to_open(self) -> None:
+        config = LLMCircuitBreakerConfig(
+            enabled=True,
+            max_failures=1,
+            reset_time_seconds=60,
+        )
+        store = InMemoryStore()
+        cb = LLMCircuitBreaker(config, backend_name="test", store=store)
+
+        cb.force_open("test")
+        store.set_state(
+            "test",
+            {
+                "state": "half_open",
+                "failure_count": 1,
+                "last_failure_time": 0.0,
+                "open_until": 0.0,
+                "half_open_probe_active": True,
+            },
+        )
+        assert cb.state == CircuitState.HALF_OPEN
+
+        cb.force_open("force from half_open")
+
+        assert cb.state == CircuitState.OPEN
+
+    def test_half_open_reset_returns_to_closed(self) -> None:
+        config = LLMCircuitBreakerConfig(enabled=True, max_failures=1)
+        store = InMemoryStore()
+        cb = LLMCircuitBreaker(config, backend_name="test", store=store)
+        store.set_state(
+            "test",
+            {
+                "state": "half_open",
+                "failure_count": 1,
+                "last_failure_time": 0.0,
+                "open_until": 0.0,
+                "half_open_probe_active": True,
+            },
+        )
+
+        cb.reset()
+
+        assert cb.state == CircuitState.CLOSED
+        assert store.get_state("test")["failure_count"] == 0
+
+    def test_open_record_success_closes_circuit(self) -> None:
+        config = LLMCircuitBreakerConfig(enabled=True, max_failures=1)
+        store = InMemoryStore()
+        cb = LLMCircuitBreaker(config, backend_name="test", store=store)
+
+        cb.force_open("test")
+        assert cb.state == CircuitState.OPEN
+
+        cb.record_success()
+
+        assert cb.state == CircuitState.CLOSED
+        assert store.get_state("test")["failure_count"] == 0
+
+    def test_state_machine_all_closed_transitions(self) -> None:
+        store = InMemoryStore()
+        cb = LLMCircuitBreaker(
+            config=_enabled_config(max_failures=2),
+            backend_name="backend",
+            store=store,
+        )
+
+        cb.record_success()
+        assert cb.state == CircuitState.CLOSED
+
+        cb.record_failure()
+        assert cb.state == CircuitState.CLOSED
+
+        cb.force_open()
+        assert cb.state == CircuitState.OPEN
+
+        cb.reset()
+        assert cb.state == CircuitState.CLOSED
+
+    def test_state_machine_all_open_transitions(self) -> None:
+        store = InMemoryStore()
+        cb = LLMCircuitBreaker(
+            config=_enabled_config(max_failures=1),
+            backend_name="backend",
+            store=store,
+        )
+
+        cb.force_open()
+        assert cb.should_block() is True
+
+        cb.record_failure()
+        assert cb.state == CircuitState.OPEN
+
+        first_open_until = store.get_state("backend")["open_until"]
+        time.sleep(0.001)
+        cb.force_open()
+        assert cb.state == CircuitState.OPEN
+        assert store.get_state("backend")["open_until"] >= first_open_until
+
+        cb.reset()
+        assert cb.state == CircuitState.CLOSED
+
+    def test_state_machine_half_open_transitions(self) -> None:
+        store = InMemoryStore()
+        cb = LLMCircuitBreaker(
+            config=_enabled_config(max_failures=1),
+            backend_name="backend",
+            store=store,
+        )
+
+        cb.force_open()
+        state = store.get_state("backend")
+        state["open_until"] = time.monotonic() - 1
+        store.set_state("backend", state)
+
+        assert cb.should_block() is False
+        assert cb.state == CircuitState.HALF_OPEN
+
+        cb.record_success()
+        assert cb.state == CircuitState.CLOSED
+
+        cb.force_open()
+        state = store.get_state("backend")
+        state["open_until"] = time.monotonic() - 1
+        store.set_state("backend", state)
+        assert cb.should_block() is False
+        assert cb.state == CircuitState.HALF_OPEN
+
+        cb.record_failure()
+        assert cb.state == CircuitState.OPEN
+
+    def test_contradictory_state_dict(self) -> None:
+        store = InMemoryStore()
+        cb = LLMCircuitBreaker(
+            config=_enabled_config(),
+            backend_name="backend",
+            store=store,
+        )
+        store.set_state("backend", _complete_state(state="open", open_until=0.0))
+
+        assert cb.should_block() is False
+        assert cb.state == CircuitState.HALF_OPEN
+
+    def test_exception_during_store_raises_propagates(self) -> None:
+        class RaisingSetStateStore(InMemoryStore):
+            def set_state(self, backend: str, state: dict) -> None:
+                raise RuntimeError("set_state failed")
+
+        cb = LLMCircuitBreaker(
+            config=_enabled_config(max_failures=1),
+            backend_name="backend",
+            store=RaisingSetStateStore(),
+        )
+
+        with pytest.raises(RuntimeError, match="set_state failed"):
+            cb.record_failure()
+
+    def test_rule_45_no_mutation_before_validation(self) -> None:
+        store = InMemoryStore()
+        before = store.get_state("backend")
+
+        result = store.cas_state(
+            "backend",
+            "nonexistent_state",
+            {"state": "open", "failure_count": 100},
+        )
+
+        assert result is False
+        assert store.get_state("backend") == before
+
+    def test_rule_27_error_recovery_store_write_failure(self, monkeypatch) -> None:
+        store = InMemoryStore()
+        store.set_state("backend", _complete_state(state="closed", failure_count=2))
+        before = store.get_state("backend")
+        cb = LLMCircuitBreaker(
+            config=_enabled_config(),
+            backend_name="backend",
+            store=store,
+        )
+
+        def fail_set_state(self: InMemoryStore, backend: str, state: dict) -> None:
+            raise RuntimeError("write failed")
+
+        monkeypatch.setattr(InMemoryStore, "set_state", fail_set_state)
+
+        with pytest.raises(RuntimeError, match="write failed"):
+            cb.record_success()
+
+        assert store.get_state("backend") == before
+
+    def test_rule_27_redis_hset_succeeds_expire_fails_state_readable(self) -> None:
+        """RedisStore partial-write: HSET succeeds but EXPIRE fails.
+
+        When EXPIRE fails, the key has no TTL but the state data is still
+        readable. This is an acceptable degradation -- state is correct,
+        key just won't auto-expire. Document the behavior rather than hide it.
+        """
+        client = _fake_redis()
+        store = RedisStore(client, ttl=60)
+        original_expire = client.expire
+
+        expire_call_count = [0]
+
+        def fail_on_second_expire(key: str, seconds: int) -> bool:
+            expire_call_count[0] += 1
+            if expire_call_count[0] == 1:
+                raise RuntimeError("expire failed")
+            return original_expire(key, seconds)
+
+        client.expire = fail_on_second_expire
+
+        with pytest.raises(RuntimeError, match="expire failed"):
+            store.set_state("backend", _complete_state(state="open", failure_count=3))
+
+        # After partial write: HSET succeeded (data readable), EXPIRE failed (no TTL).
+        # State is defined -- either full data if HSET was atomic, or empty if HSET
+        # also failed. Both are acceptable; no crash and no corrupted type errors.
+        try:
+            state = store.get_state("backend")
+            # If data was written, it should be structurally valid.
+            assert isinstance(state["failure_count"], int)
+            assert state["state"] in ("closed", "open", "half_open")
+        except Exception as exc:
+            pytest.fail(f"get_state raised after partial write: {exc}")
+
+    def test_two_cb_same_store_different_backends(self) -> None:
+        store = InMemoryStore()
+        backend_a = LLMCircuitBreaker(
+            config=_enabled_config(max_failures=1),
+            backend_name="backend_a",
+            store=store,
+        )
+        backend_b = LLMCircuitBreaker(
+            config=_enabled_config(max_failures=1),
+            backend_name="backend_b",
+            store=store,
+        )
+
+        backend_a.record_failure()
+
+        assert backend_a.state == CircuitState.OPEN
+        assert backend_b.state == CircuitState.CLOSED
+        assert backend_b.failure_count == 0

--- a/massgen/tests/test_cb_store_adversarial.py
+++ b/massgen/tests/test_cb_store_adversarial.py
@@ -296,6 +296,9 @@ class TestAdversarialRedisStore:
             def watch(self, key: str) -> None:
                 raise RuntimeError("watch conflict")
 
+            def reset(self) -> None:
+                pass
+
         monkeypatch.setattr(store._client, "eval", raise_unknown_command)
         monkeypatch.setattr(
             store._client,

--- a/massgen/tests/test_cb_store_adversarial.py
+++ b/massgen/tests/test_cb_store_adversarial.py
@@ -124,7 +124,10 @@ class TestAdversarialInMemoryStoreConcurrency:
     def test_concurrent_increment_failure_100_threads(self) -> None:
         store = InMemoryStore()
 
-        threads = [threading.Thread(target=store.increment_failure, args=("backend",)) for _ in range(100)]
+        threads = [
+            threading.Thread(target=store.increment_failure, args=("backend",))
+            for _ in range(100)
+        ]
         for thread in threads:
             thread.start()
         for thread in threads:
@@ -168,7 +171,14 @@ class TestAdversarialInMemoryStoreConcurrency:
                 with exception_lock:
                     exceptions.append(exc)
 
-        threads = [threading.Thread(target=run_safely, args=(store.increment_failure,)) for _ in range(50)] + [threading.Thread(target=run_safely, args=(store.clear,)) for _ in range(50)]
+        threads = [
+            threading.Thread(target=run_safely, args=(store.increment_failure,))
+            for _ in range(50)
+        ]
+        threads.extend(
+            threading.Thread(target=run_safely, args=(store.clear,))
+            for _ in range(50)
+        )
         for thread in threads:
             thread.start()
         for thread in threads:
@@ -200,7 +210,8 @@ class TestAdversarialInMemoryStoreConcurrency:
                 with lock:
                     exceptions.append(exc)
 
-        threads = [threading.Thread(target=set_open_state) for _ in range(50)] + [threading.Thread(target=get_state) for _ in range(50)]
+        threads = [threading.Thread(target=set_open_state) for _ in range(50)]
+        threads.extend(threading.Thread(target=get_state) for _ in range(50))
         for thread in threads:
             thread.start()
         for thread in threads:
@@ -259,7 +270,10 @@ class TestAdversarialRedisStore:
 
         assert client.ttl("massgen:cb:backend") >= ttl_before - 1
 
-    def test_redis_store_increment_without_lua_preserves_open_state_ttl(self, monkeypatch) -> None:
+    def test_redis_store_increment_without_lua_preserves_open_state_ttl(
+        self,
+        monkeypatch,
+    ) -> None:
         client = _fake_redis()
         store = RedisStore(client, ttl=1)
         open_until = time.monotonic() + 120
@@ -278,7 +292,10 @@ class TestAdversarialRedisStore:
 
         assert client.ttl("massgen:cb:backend") >= ttl_before - 1
 
-    def test_redis_store_increment_without_lua_retry_exhaustion_raises(self, monkeypatch) -> None:
+    def test_redis_store_increment_without_lua_retry_exhaustion_raises(
+        self,
+        monkeypatch,
+    ) -> None:
         store = RedisStore(_fake_redis())
 
         def raise_unknown_command(*args: Any, **kwargs: Any) -> None:
@@ -289,11 +306,18 @@ class TestAdversarialRedisStore:
                 raise RuntimeError("watch conflict")
 
         monkeypatch.setattr(store._client, "eval", raise_unknown_command)
-        monkeypatch.setattr(store._client, "pipeline", lambda transaction=True: FailingWatchPipeline())
+        monkeypatch.setattr(
+            store._client,
+            "pipeline",
+            lambda transaction=True: FailingWatchPipeline(),
+        )
 
         with pytest.raises(
             RuntimeError,
-            match="Failed to atomically increment failure count for 'backend' after 3 retries",
+            match=(
+                "Failed to atomically increment failure count for 'backend' "
+                "after 3 retries"
+            ),
         ):
             store.increment_failure("backend")
 
@@ -357,7 +381,7 @@ class TestAdversarialRedisStore:
         assert state == DEFAULT_CIRCUIT_BREAKER_STATE
 
     def test_redis_store_cas_without_lua_only_one_winner(self, monkeypatch) -> None:
-        """Concurrent CAS through non-Lua fallback: exactly 1 thread wins closed->open."""
+        """Concurrent CAS fallback allows exactly one closed-to-open winner."""
         client = _fake_redis()
         store = RedisStore(client)
 
@@ -380,10 +404,10 @@ class TestAdversarialRedisStore:
                 results.append(res)
 
         threads = [threading.Thread(target=attempt) for _ in range(20)]
-        for t in threads:
-            t.start()
-        for t in threads:
-            t.join()
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
 
         assert results.count(True) == 1
         assert results.count(False) == 19
@@ -530,7 +554,7 @@ class TestAdversarialCBIntegration:
         assert cb.state == CircuitState.CLOSED
         assert store.get_state("test")["failure_count"] == 0
 
-    def test_open_record_success_closes_circuit(self) -> None:
+    def test_open_record_success_does_not_close_forced_open_circuit(self) -> None:
         config = LLMCircuitBreakerConfig(enabled=True, max_failures=1)
         store = InMemoryStore()
         cb = LLMCircuitBreaker(config, backend_name="test", store=store)
@@ -540,8 +564,8 @@ class TestAdversarialCBIntegration:
 
         cb.record_success()
 
-        assert cb.state == CircuitState.CLOSED
-        assert store.get_state("test")["failure_count"] == 0
+        assert cb.state == CircuitState.OPEN
+        assert store.get_state("test")["state"] == "open"
 
     def test_state_machine_all_closed_transitions(self) -> None:
         store = InMemoryStore()
@@ -628,17 +652,22 @@ class TestAdversarialCBIntegration:
         assert cb.state == CircuitState.HALF_OPEN
 
     def test_exception_during_store_raises_propagates(self) -> None:
-        class RaisingSetStateStore(InMemoryStore):
-            def set_state(self, backend: str, state: dict) -> None:
-                raise RuntimeError("set_state failed")
+        class RaisingAtomicFailureStore(InMemoryStore):
+            def atomic_record_failure(
+                self,
+                backend: str,
+                failure_threshold: int,
+                recovery_timeout: float,
+            ) -> dict:
+                raise RuntimeError("atomic_record_failure failed")
 
         cb = LLMCircuitBreaker(
             config=_enabled_config(max_failures=1),
             backend_name="backend",
-            store=RaisingSetStateStore(),
+            store=RaisingAtomicFailureStore(),
         )
 
-        with pytest.raises(RuntimeError, match="set_state failed"):
+        with pytest.raises(RuntimeError, match="atomic_record_failure failed"):
             cb.record_failure()
 
     def test_rule_45_no_mutation_before_validation(self) -> None:
@@ -664,10 +693,18 @@ class TestAdversarialCBIntegration:
             store=store,
         )
 
-        def fail_set_state(self: InMemoryStore, backend: str, state: dict) -> None:
+        def fail_atomic_record_success(
+            self: InMemoryStore,
+            backend: str,
+            expected_state: str | None = None,
+        ) -> dict:
             raise RuntimeError("write failed")
 
-        monkeypatch.setattr(InMemoryStore, "set_state", fail_set_state)
+        monkeypatch.setattr(
+            InMemoryStore,
+            "atomic_record_success",
+            fail_atomic_record_success,
+        )
 
         with pytest.raises(RuntimeError, match="write failed"):
             cb.record_success()
@@ -727,3 +764,95 @@ class TestAdversarialCBIntegration:
         assert backend_a.state == CircuitState.OPEN
         assert backend_b.state == CircuitState.CLOSED
         assert backend_b.failure_count == 0
+
+
+class TestConcurrentLinearizability:
+    def test_100_threads_mixed_failure_success_linearizable(self) -> None:
+        store = InMemoryStore()
+        failure_count = 50
+        success_count = 50
+
+        threads = [
+            threading.Thread(
+                target=store.atomic_record_failure,
+                args=("claude", 200, 30.0),
+            )
+            for _ in range(failure_count)
+        ]
+        threads.extend(
+            threading.Thread(target=store.atomic_record_success, args=("claude",))
+            for _ in range(success_count)
+        )
+
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+
+        state = store.get_state("claude")
+        assert state["state"] == "closed"
+        assert 0 <= state["failure_count"] <= failure_count
+        assert state["half_open_probe_active"] is False
+
+
+class TestForceOpenRace:
+    def test_force_open_wins_over_concurrent_record_success(self) -> None:
+        success_read = threading.Event()
+        force_open_done = threading.Event()
+
+        class CoordinatedStore(InMemoryStore):
+            def get_state(self, backend: str) -> dict:
+                state = super().get_state(backend)
+                if threading.current_thread().name == "record-success":
+                    success_read.set()
+                    assert force_open_done.wait(timeout=5)
+                return state
+
+        store = CoordinatedStore()
+        cb = LLMCircuitBreaker(
+            config=_enabled_config(max_failures=10, reset_time_seconds=30),
+            backend_name="claude",
+            store=store,
+        )
+
+        def force_open() -> None:
+            assert success_read.wait(timeout=5)
+            cb.force_open("quota", open_for_seconds=30)
+            force_open_done.set()
+
+        def record_success() -> None:
+            cb.record_success()
+
+        threads = [
+            threading.Thread(target=force_open),
+            threading.Thread(target=record_success, name="record-success"),
+        ]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+
+        assert cb.state == CircuitState.OPEN
+        assert store.get_state("claude")["state"] == "open"
+
+
+class TestAtomicFailureOrdering:
+    def test_failure_count_never_exceeds_thread_count(self) -> None:
+        store = InMemoryStore()
+        thread_count = 100
+
+        threads = [
+            threading.Thread(
+                target=store.atomic_record_failure,
+                args=("claude", 200, 30.0),
+            )
+            for _ in range(thread_count)
+        ]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+
+        state = store.get_state("claude")
+        assert state["failure_count"] == thread_count
+        assert state["failure_count"] <= thread_count

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,9 @@ observability = [
     "logfire>=3.0.0",
     "prometheus-client>=0.20",
 ]
+redis-store = [
+    "redis>=4.0",
+]
 
 dev = [
     "pytest>=7.0.0",
@@ -128,6 +131,7 @@ all = [
     "litellm>=1.0.0,<=1.82.6",
     "logfire>=3.0.0",
     "prometheus-client>=0.20",
+    "redis>=4.0",
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Summary

Phase 4: pluggable store backend for the LLM circuit breaker, so state can be shared across workers / processes. Default (`store=None`) keeps the existing single-process path unchanged.

Rebased on top of #1038 (Phase 2) and #1056 (Phase 3).

## What's in

- `CircuitBreakerStore` Protocol (sync, to match the existing CB code path)
- `InMemoryStore` -- RLock, zero deps
- `RedisStore` -- requires `redis>=4.0`, lazy-imported
- `atomic_record_failure` / `atomic_record_success` on the Protocol. Needed for linearizability when multiple workers race on the same backend; found this the hard way in review and had to extend the Protocol mid-way.
- Metrics hooks from #1056 fire on every store code path too.

## Tests

159 tests passing locally: store unit, adversarial (TOCTOU, Redis eviction, corrupted state, Protocol contract), plus regression on the existing CB tests.

Unrelated `test_subagent_docker_logs.py` etc. fail on Windows with cp932 encoding, but they fail on `origin/main` too -- pre-existing, not touched here.

## Install

Redis backend is optional:
```
pip install massgen[redis-store]
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Persistent circuit-breaker stores (in-memory and Redis) and a factory; circuit breakers can be configured to use shared store-based state and coordinated probe ownership.

* **Bug Fixes / Reliability**
  * Atomic updates, CAS semantics, probe-claiming, TTL handling, and retry/fallback paths to prevent races and stale reopen timing.

* **Tests**
  * Extensive unit and adversarial tests for store behavior, concurrency, and end-to-end integration.

* **Chores**
  * Added optional Redis dependency group.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->