### PR TITLE
feat: add multi-region failover for circuit breaker (Phase 6)

### DIFF
--- a/massgen/backend/cb_failover.py
+++ b/massgen/backend/cb_failover.py
@@ -48,21 +48,18 @@ class FailoverConfig:
         """Validate all configuration fields."""
         if self.health_check_timeout_seconds <= 0:
             raise ValueError(
-                f"health_check_timeout_seconds must be > 0, "
-                f"got {self.health_check_timeout_seconds}",
+                f"health_check_timeout_seconds must be > 0, " f"got {self.health_check_timeout_seconds}",
             )
         if self.min_failover_duration_seconds < 0:
             raise ValueError(
-                f"min_failover_duration_seconds must be >= 0, "
-                f"got {self.min_failover_duration_seconds}",
+                f"min_failover_duration_seconds must be >= 0, " f"got {self.min_failover_duration_seconds}",
             )
         if self.recovery_check_interval_seconds <= 0:
             raise ValueError(
-                f"recovery_check_interval_seconds must be > 0, "
-                f"got {self.recovery_check_interval_seconds}",
+                f"recovery_check_interval_seconds must be > 0, " f"got {self.recovery_check_interval_seconds}",
             )
         for backend, region_list in self.regions.items():
-            if not isinstance(backend, str) or not backend:
+            if not isinstance(backend, str) or not backend.strip():
                 raise ValueError(
                     f"regions keys must be non-empty strings, got {backend!r}",
                 )
@@ -71,7 +68,7 @@ class FailoverConfig:
                     f"regions[{backend!r}] must be a non-empty list, got {region_list!r}",
                 )
             for region in region_list:
-                if not isinstance(region, str) or not region:
+                if not isinstance(region, str) or not region.strip():
                     raise ValueError(
                         f"regions[{backend!r}] contains invalid region: {region!r}",
                     )
@@ -125,9 +122,38 @@ class FailoverRouter:
         #   _failover_at[backend] = float | None (clock value when failover committed, None if not failed over)
         #   _failover_pending[backend] = bool (True while a probe is in-flight for this backend)
         #     Prevents concurrent threads from all probing and committing independently.
+        #   _closed_during_probe[backend] = bool (True when CLOSED arrived while a probe was pending)
+        #     Prevents stale OPEN probes from committing after the CB has already recovered.
         self._active_region: dict[str, str] = {}
         self._failover_at: dict[str, float | None] = {}
         self._failover_pending: dict[str, bool] = {}
+        self._closed_during_probe: dict[str, bool] = {}
+
+    def _try_lazy_recovery_unlocked(self, backend: str, region_list: list[str]) -> None:
+        """Restore primary if min_failover_duration has elapsed since failover.
+
+        Caller must hold self._lock. Mutates _active_region and _failover_at
+        when eligible. No-op when not failed over or duration not elapsed.
+        Used by get_active_region, is_failed_over, and snapshot to keep router
+        observation methods consistent.
+        """
+        failover_at = self._failover_at.get(backend)
+        if failover_at is None:
+            return
+        elapsed = self._clock() - failover_at
+        min_duration = self._config.min_failover_duration_seconds
+        if elapsed < min_duration:
+            return
+        primary = region_list[0]
+        self._active_region.pop(backend, None)
+        self._failover_at[backend] = None
+        logger.info(
+            "Lazy recovery for %r: restored primary %r (elapsed=%.1fs >= min_duration=%.1fs).",
+            backend,
+            primary,
+            elapsed,
+            min_duration,
+        )
 
     def get_active_region(self, backend: str) -> str | None:
         """Return the active region for a backend, or None if not configured.
@@ -135,6 +161,12 @@ class FailoverRouter:
         Returns None when config.enabled is False or the backend has no
         regions configured. Returns the primary (regions[backend][0]) when
         not failed over, or the secondary when failed over.
+
+        Side effect: applies lazy recovery -- if the backend is currently
+        failed over and min_failover_duration_seconds has elapsed since the
+        failover, restores the primary inline (mutates router state). This
+        keeps observation methods (get_active_region, is_failed_over,
+        snapshot) consistent without requiring a background recovery thread.
 
         Args:
             backend: Logical backend name matching a key in config.regions.
@@ -148,6 +180,7 @@ class FailoverRouter:
         if not region_list:
             return None
         with self._lock:
+            self._try_lazy_recovery_unlocked(backend, region_list)
             return self._active_region.get(backend, region_list[0])
 
     def on_cb_state_change(self, backend: str, old_state: str, new_state: str) -> None:
@@ -204,13 +237,13 @@ class FailoverRouter:
             if len(region_list) < 2:
                 # No secondary configured for this backend.
                 logger.warning(
-                    "Failover triggered for %r but no secondary region configured "
-                    "(regions list has only one entry).",
+                    "Failover triggered for %r but no secondary region configured " "(regions list has only one entry).",
                     backend,
                 )
                 return
             # Claim the probe slot before releasing the lock.
             self._failover_pending[backend] = True
+            self._closed_during_probe.pop(backend, None)
 
         # Probe runs outside the lock so it cannot block concurrent reads.
         primary = region_list[0]
@@ -229,8 +262,26 @@ class FailoverRouter:
                     continue
                 if probe_result:
                     with self._lock:
+                        if not self._failover_pending.get(backend, False):
+                            logger.info(
+                                "Failover probe for %r succeeded but commit was aborted because pending failover state was cleared before commit.",
+                                backend,
+                            )
+                            return
+                        if self._closed_during_probe.get(backend, False):
+                            logger.info(
+                                "Failover probe for %r succeeded but commit was aborted because the circuit breaker closed during the probe.",
+                                backend,
+                            )
+                            return
                         self._active_region[backend] = candidate
                         self._failover_at[backend] = self._clock()
+                        # Atomically clear pending+latch so observers don't see
+                        # a transient (failed_over=True, pending=True) state
+                        # that could cause a subsequent OPEN event to be
+                        # wrongly suppressed if recovery races with this commit.
+                        self._failover_pending[backend] = False
+                        self._closed_during_probe.pop(backend, None)
                     logger.info(
                         "Failover committed for %r: %r -> %r (CB transitioned %s -> open).",
                         backend,
@@ -254,9 +305,15 @@ class FailoverRouter:
                     primary,
                 )
         finally:
-            # Always clear the pending flag so future OPEN events can retry.
-            with self._lock:
-                self._failover_pending[backend] = False
+            # Only clear pending if the commit block did not already clear it.
+            # On a committed probe, pending+latch were cleared atomically with
+            # the commit (see line ~285). Clearing again here would race with
+            # a subsequent probe that has already claimed _failover_pending,
+            # silently dropping its commit when the new probe checks the flag.
+            if not committed:
+                with self._lock:
+                    self._failover_pending[backend] = False
+                    self._closed_during_probe.pop(backend, None)
 
     def _handle_closed(
         self,
@@ -267,40 +324,46 @@ class FailoverRouter:
         """Internal: evaluate recovery when CB returns to CLOSED."""
         with self._lock:
             failover_at = self._failover_at.get(backend)
-            if failover_at is None:
-                # Not failed over -- nothing to restore.
+            if failover_at is not None:
+                now = self._clock()
+                elapsed = now - failover_at
+                min_duration = self._config.min_failover_duration_seconds
+                if elapsed >= min_duration:
+                    primary = region_list[0]
+                    self._active_region.pop(backend, None)
+                    self._failover_at[backend] = None
+                    logger.info(
+                        "Recovery complete for %r: restored primary %r " "(elapsed=%.1fs >= min_duration=%.1fs, CB transitioned %s -> closed).",
+                        backend,
+                        primary,
+                        elapsed,
+                        min_duration,
+                        old_state,
+                    )
+                else:
+                    remaining = min_duration - elapsed
+                    active = self._active_region.get(backend, region_list[0])
+                    logger.info(
+                        "Recovery deferred for %r: staying on %r for %.1f more seconds " "(elapsed=%.1fs < min_duration=%.1fs).",
+                        backend,
+                        active,
+                        remaining,
+                        elapsed,
+                        min_duration,
+                    )
                 return
-            now = self._clock()
-            elapsed = now - failover_at
-            min_duration = self._config.min_failover_duration_seconds
-            if elapsed >= min_duration:
-                primary = region_list[0]
-                self._active_region.pop(backend, None)
-                self._failover_at[backend] = None
-                logger.info(
-                    "Recovery complete for %r: restored primary %r "
-                    "(elapsed=%.1fs >= min_duration=%.1fs, CB transitioned %s -> closed).",
+            if self._failover_pending.get(backend, False):
+                self._closed_during_probe[backend] = True
+                logger.debug(
+                    "CLOSED notification for %r arrived during an in-flight failover probe; " "marking probe for abort.",
                     backend,
-                    primary,
-                    elapsed,
-                    min_duration,
-                    old_state,
-                )
-            else:
-                remaining = min_duration - elapsed
-                active = self._active_region.get(backend, region_list[0])
-                logger.info(
-                    "Recovery deferred for %r: staying on %r for %.1f more seconds "
-                    "(elapsed=%.1fs < min_duration=%.1fs).",
-                    backend,
-                    active,
-                    remaining,
-                    elapsed,
-                    min_duration,
                 )
 
     def is_failed_over(self, backend: str) -> bool:
         """Return True iff the backend is currently routing to a secondary region.
+
+        Side effect: applies lazy recovery (see get_active_region) so that
+        is_failed_over and get_active_region report consistent state.
 
         Args:
             backend: Logical backend name.
@@ -311,13 +374,19 @@ class FailoverRouter:
         """
         if not self._config.enabled:
             return False
+        region_list = self._config.regions.get(backend)
+        if not region_list:
+            return False
         with self._lock:
+            self._try_lazy_recovery_unlocked(backend, region_list)
             return self._failover_at.get(backend) is not None
 
     def snapshot(self) -> dict[str, Any]:
         """Return an observable point-in-time snapshot of all backends.
 
         All live fields are captured under a single lock acquisition.
+        Side effect: applies lazy recovery for each configured backend so
+        snapshot agrees with get_active_region/is_failed_over.
 
         Returns:
             Dict with key "backends" mapping each configured backend name to
@@ -329,6 +398,7 @@ class FailoverRouter:
         with self._lock:
             result: dict[str, Any] = {}
             for backend, region_list in self._config.regions.items():
+                self._try_lazy_recovery_unlocked(backend, region_list)
                 primary = region_list[0]
                 active = self._active_region.get(backend, primary)
                 failover_at = self._failover_at.get(backend)
@@ -348,10 +418,13 @@ class FailoverRouter:
         Args:
             backend: Logical backend name.
         """
+        if backend not in self._config.regions:
+            return
         region_list = self._config.regions.get(backend)
         with self._lock:
             self._active_region.pop(backend, None)
             self._failover_at[backend] = None
             self._failover_pending[backend] = False
+            self._closed_during_probe.pop(backend, None)
         if region_list:
             logger.info("Administrative reset for %r: restored primary %r.", backend, region_list[0])

--- a/massgen/backend/cb_failover.py
+++ b/massgen/backend/cb_failover.py
@@ -92,7 +92,6 @@ class FailoverRouter:
     def __init__(
         self,
         config: FailoverConfig,
-        cb_registry: dict[str, Any] | None = None,
         *,
         clock: Callable[[], float] | None = None,
         health_probe: Callable[[str], bool] | None = None,
@@ -101,19 +100,17 @@ class FailoverRouter:
 
         Args:
             config: Failover configuration including enabled flag and region map.
-            cb_registry: Optional mapping of backend names to LLMCircuitBreaker
-                instances, used only for snapshot() enrichment. Does not affect
-                routing decisions.
             clock: Monotonic clock for measuring failover duration. Defaults to
                 time.monotonic. Injectable for tests.
             health_probe: Callable that accepts a region string and returns True
                 if the region is healthy. Defaults to a function that always
                 returns True (assume healthy). Injectable for tests to simulate
                 failures. Any exception raised by the probe is caught and treated
-                as a probe failure -- no failover is committed.
+                as a probe failure -- no failover is committed. Each probe call
+                runs under a `health_check_timeout_seconds` deadline; on timeout
+                the probe is treated as a failure and the next region is tried.
         """
         self._config = config
-        self._cb_registry = cb_registry
         self._clock: Callable[[], float] = clock or time.monotonic
         self._health_probe: Callable[[str], bool] = health_probe or (lambda _region: True)
         self._lock = threading.Lock()
@@ -228,38 +225,79 @@ class FailoverRouter:
         first thread to set the flag wins the probe; all subsequent callers
         see either the pending flag or the committed failover and return early.
         """
-        with self._lock:
-            already_failed_over = self._failover_at.get(backend) is not None
-            pending = self._failover_pending.get(backend, False)
-            if already_failed_over or pending:
-                # Idempotent: already on secondary, or another thread is probing.
-                return
-            if len(region_list) < 2:
-                # No secondary configured for this backend.
-                logger.warning(
-                    "Failover triggered for %r but no secondary region configured " "(regions list has only one entry).",
-                    backend,
-                )
-                return
-            # Claim the probe slot before releasing the lock.
-            self._failover_pending[backend] = True
-            self._closed_during_probe.pop(backend, None)
-
-        # Probe runs outside the lock so it cannot block concurrent reads.
+        # The whole probe (lock-claim + probe loop + commit) runs under one
+        # try/finally so a BaseException (KeyboardInterrupt, SystemExit,
+        # asyncio.CancelledError) arriving anywhere during probe slot claim
+        # cannot leave _failover_pending stuck True. The pending_claimed
+        # flag is set BEFORE _failover_pending so the finally cleanup is
+        # always reachable when the actual flag is set.
+        pending_claimed = False
         primary = region_list[0]
         committed = False
+        timeout = self._config.health_check_timeout_seconds
         try:
+            with self._lock:
+                already_failed_over = self._failover_at.get(backend) is not None
+                pending = self._failover_pending.get(backend, False)
+                if already_failed_over or pending:
+                    # Idempotent: already on secondary, or another thread is probing.
+                    return
+                if len(region_list) < 2:
+                    # No secondary configured for this backend.
+                    logger.warning(
+                        "Failover triggered for %r but no secondary region configured (regions list has only one entry).",
+                        backend,
+                    )
+                    return
+                # Set the cleanup-reachability marker before mutating the
+                # actual pending flag. If BaseException fires between these
+                # two assignments, the finally still runs (pending_claimed
+                # is True) and clears the (False) pending flag harmlessly.
+                pending_claimed = True
+                self._failover_pending[backend] = True
+                self._closed_during_probe.pop(backend, None)
+
             for candidate in region_list[1:]:
                 probe_result = False
-                try:
-                    probe_result = bool(self._health_probe(candidate))
-                except Exception:  # noqa: BLE001 -- probe failures must never propagate
+                # Enforce health_check_timeout_seconds via a daemon thread +
+                # join(timeout). A hanging probe must not block the calling
+                # thread (and through it the LLMCircuitBreaker) indefinitely;
+                # without this, _failover_pending would also stick True and
+                # silently disable all subsequent OPEN events.
+                #
+                # Python cannot cancel a running thread, so a hanging probe
+                # leaks until process exit. The thread is daemon so it does
+                # not delay shutdown. Probe authors should use timeouts in
+                # their HTTP clients to avoid the leak in practice.
+                probe_outcome: list[bool | BaseException] = [False]
+
+                def _probe_runner(region: str = candidate, sink: list[bool | BaseException] = probe_outcome) -> None:
+                    try:
+                        sink[0] = bool(self._health_probe(region))
+                    except BaseException as exc:  # noqa: BLE001 -- never let probe break router
+                        sink[0] = exc
+
+                probe_thread = threading.Thread(target=_probe_runner, name=f"failover-probe-{candidate}", daemon=True)
+                probe_thread.start()
+                probe_thread.join(timeout=timeout)
+                if probe_thread.is_alive():
                     logger.warning(
-                        "Health probe for %r raised an exception; skipping region %r.",
+                        "Health probe for %r region %r timed out after %.1fs; treating as failure (thread abandoned).",
                         backend,
+                        candidate,
+                        timeout,
+                    )
+                    probe_result = False
+                elif isinstance(probe_outcome[0], BaseException):
+                    logger.warning(
+                        "Health probe for %r raised %s; skipping region %r.",
+                        backend,
+                        type(probe_outcome[0]).__name__,
                         candidate,
                     )
                     continue
+                else:
+                    probe_result = bool(probe_outcome[0])
                 if probe_result:
                     with self._lock:
                         if not self._failover_pending.get(backend, False):
@@ -305,12 +343,13 @@ class FailoverRouter:
                     primary,
                 )
         finally:
-            # Only clear pending if the commit block did not already clear it.
-            # On a committed probe, pending+latch were cleared atomically with
-            # the commit (see line ~285). Clearing again here would race with
-            # a subsequent probe that has already claimed _failover_pending,
-            # silently dropping its commit when the new probe checks the flag.
-            if not committed:
+            # Clean up only when:
+            # - we actually claimed the probe slot (pending_claimed=True), AND
+            # - the probe did not commit (commit clears pending atomically).
+            # This prevents (a) wiping a subsequent concurrent probe's claim
+            # after a successful commit, and (b) leaving _failover_pending stuck
+            # True if a BaseException fires between slot claim and probe start.
+            if pending_claimed and not committed:
                 with self._lock:
                     self._failover_pending[backend] = False
                     self._closed_during_probe.pop(backend, None)
@@ -420,11 +459,11 @@ class FailoverRouter:
         """
         if backend not in self._config.regions:
             return
-        region_list = self._config.regions.get(backend)
+        # Guard above + FailoverConfig validation guarantee a non-empty list.
+        region_list = self._config.regions[backend]
         with self._lock:
             self._active_region.pop(backend, None)
             self._failover_at[backend] = None
             self._failover_pending[backend] = False
             self._closed_during_probe.pop(backend, None)
-        if region_list:
-            logger.info("Administrative reset for %r: restored primary %r.", backend, region_list[0])
+        logger.info("Administrative reset for %r: restored primary %r.", backend, region_list[0])

--- a/massgen/backend/cb_failover.py
+++ b/massgen/backend/cb_failover.py
@@ -15,28 +15,40 @@ from __future__ import annotations
 import logging
 import threading
 import time
-from collections.abc import Callable
+import types
+from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass, field
 from typing import Any
 
 logger = logging.getLogger(__name__)
 
 
-@dataclass
+@dataclass(frozen=True)
 class FailoverConfig:
     """Configuration for the multi-region failover router.
 
     All fields have safe defaults so existing CB configs need no changes.
-    Set enabled=True and populate regions to activate failover.
+    Set enabled=True and populate regions to activate failover. The dataclass
+    is frozen and `regions` is normalized to an immutable mapping in
+    __post_init__ so callers cannot mutate the config after construction
+    and bypass validation.
     """
 
     enabled: bool = False
-    # Map backend name to ordered list of region strings.
-    # First element is the primary; subsequent elements are secondaries
-    # tried in order. Example: {"gpt-5.4": ["us-east", "eu-west"]}
-    regions: dict[str, list[str]] = field(default_factory=dict)
+    # Map backend name to ordered sequence of region strings. First element
+    # is the primary; subsequent elements are secondaries tried in order.
+    # Example input: {"gpt-5.4": ["us-east", "eu-west"]}. Annotated as a
+    # read-only Mapping[str, Sequence[str]] so type checkers reject
+    # mutation attempts (e.g. cfg.regions["x"].append("y") or
+    # cfg.regions["x"] = (...)). __post_init__ normalizes the validated
+    # input to MappingProxyType[str, tuple[str, ...]] so the runtime form
+    # also rejects mutation.
+    regions: Mapping[str, Sequence[str]] = field(default_factory=dict)
     # Seconds to wait for health probe before committing failover.
-    # Must be > 0.
+    # Must be > 0. Probe authors MUST also apply a client-level timeout
+    # (e.g. requests.get(..., timeout=...)) so the underlying socket
+    # actually closes; the daemon-thread timeout here only unblocks the
+    # caller and abandons the probe thread.
     health_check_timeout_seconds: float = 5.0
     # Minimum seconds to stay on secondary after a failover before
     # restoring primary on CB recovery. Prevents flapping. >= 0.
@@ -58,25 +70,39 @@ class FailoverConfig:
             raise ValueError(
                 f"recovery_check_interval_seconds must be > 0, " f"got {self.recovery_check_interval_seconds}",
             )
+        # Materialize each region sequence into a tuple BEFORE iterating so
+        # iterator inputs (which would otherwise be consumed by the first
+        # for-loop and report a misleading "non-empty list" error from the
+        # subsequent len() check) are handled correctly.
+        materialized: dict[str, tuple[str, ...]] = {}
         for backend, region_list in self.regions.items():
             if not isinstance(backend, str) or not backend.strip():
                 raise ValueError(
                     f"regions keys must be non-empty strings, got {backend!r}",
                 )
-            if not region_list:
+            regions_tuple = tuple(region_list)
+            if not regions_tuple:
                 raise ValueError(
                     f"regions[{backend!r}] must be a non-empty list, got {region_list!r}",
                 )
-            for region in region_list:
+            for region in regions_tuple:
                 if not isinstance(region, str) or not region.strip():
                     raise ValueError(
                         f"regions[{backend!r}] contains invalid region: {region!r}",
                     )
-            if len(region_list) != len(set(region_list)):
-                duplicates = [r for r in region_list if region_list.count(r) > 1]
+            if len(regions_tuple) != len(set(regions_tuple)):
+                duplicates = [r for r in regions_tuple if regions_tuple.count(r) > 1]
                 raise ValueError(
                     f"regions[{backend!r}] contains duplicate region(s): {duplicates!r}",
                 )
+            materialized[backend] = regions_tuple
+        # Freeze the validated regions so callers cannot mutate the config
+        # post-construction and bypass the checks above. The inner per-
+        # backend tuples were created during validation; here we wrap the
+        # outer dict in types.MappingProxyType so the mapping itself is
+        # also read-only. The dataclass is frozen so we use
+        # object.__setattr__ to write through.
+        object.__setattr__(self, "regions", types.MappingProxyType(materialized))
 
 
 class FailoverRouter:
@@ -145,8 +171,16 @@ class FailoverRouter:
         # Last applied transition seq per backend, for out-of-order notify drop.
         # See on_cb_state_change docstring.
         self._last_seq: dict[str, int] = {}
+        # Per-backend probe generation token. Incremented when a probe slot is
+        # claimed in _handle_open AND when reset() runs. The probing thread
+        # captures its generation locally and only commits / runs finally
+        # cleanup when the stored generation still matches. Without this, an
+        # admin reset() racing with a new OPEN can let an old probe's commit
+        # land under the new probe's pending claim, or let an old probe's
+        # finally wipe the new probe's claim.
+        self._probe_gen: dict[str, int] = {}
 
-    def _try_lazy_recovery_unlocked(self, backend: str, region_list: list[str]) -> None:
+    def _try_lazy_recovery_unlocked(self, backend: str, region_list: Sequence[str]) -> None:
         """Restore primary if min_failover_duration has elapsed since failover.
 
         Caller must hold self._lock. Mutates _active_region and _failover_at
@@ -279,7 +313,7 @@ class FailoverRouter:
         self,
         backend: str,
         old_state: str,
-        region_list: list[str],
+        region_list: Sequence[str],
     ) -> None:
         """Internal: evaluate failover when CB enters OPEN.
 
@@ -295,6 +329,7 @@ class FailoverRouter:
         # flag is set BEFORE _failover_pending so the finally cleanup is
         # always reachable when the actual flag is set.
         pending_claimed = False
+        my_gen = 0
         primary = region_list[0]
         committed = False
         timeout = self._config.health_check_timeout_seconds
@@ -319,6 +354,12 @@ class FailoverRouter:
                 pending_claimed = True
                 self._failover_pending[backend] = True
                 self._closed_during_probe.pop(backend, None)
+                # Capture a per-claim generation token. Both reset() and a
+                # fresh slot claim in _handle_open bump _probe_gen, so a
+                # stale probe whose generation no longer matches will not
+                # commit and will not wipe the new owner's claim in finally.
+                self._probe_gen[backend] = self._probe_gen.get(backend, 0) + 1
+                my_gen = self._probe_gen[backend]
 
             for candidate in region_list[1:]:
                 probe_result = False
@@ -370,6 +411,15 @@ class FailoverRouter:
                     probe_result = bool(probe_outcome[0])
                 if probe_result:
                     with self._lock:
+                        # Generation mismatch means reset() ran (or another
+                        # probe took over the slot) since we claimed it. Do
+                        # not clobber the new owner's state.
+                        if self._probe_gen.get(backend, 0) != my_gen:
+                            logger.info(
+                                "Failover probe for %r succeeded but commit was aborted because the probe slot was reclaimed (gen mismatch).",
+                                backend,
+                            )
+                            return
                         if not self._failover_pending.get(backend, False):
                             logger.info(
                                 "Failover probe for %r succeeded but commit was aborted because pending failover state was cleared before commit.",
@@ -415,20 +465,22 @@ class FailoverRouter:
         finally:
             # Clean up only when:
             # - we actually claimed the probe slot (pending_claimed=True), AND
-            # - the probe did not commit (commit clears pending atomically).
-            # This prevents (a) wiping a subsequent concurrent probe's claim
-            # after a successful commit, and (b) leaving _failover_pending stuck
-            # True if a BaseException fires between slot claim and probe start.
+            # - the probe did not commit (commit clears pending atomically), AND
+            # - the probe generation we own still matches the current generation
+            #   (i.e. reset() did not run and another probe did not claim the
+            #   slot in the meantime). This prevents wiping a subsequent
+            #   concurrent probe's claim after our probe was superseded.
             if pending_claimed and not committed:
                 with self._lock:
-                    self._failover_pending[backend] = False
-                    self._closed_during_probe.pop(backend, None)
+                    if self._probe_gen.get(backend, 0) == my_gen:
+                        self._failover_pending[backend] = False
+                        self._closed_during_probe.pop(backend, None)
 
     def _handle_closed(
         self,
         backend: str,
         old_state: str,
-        region_list: list[str],
+        region_list: Sequence[str],
     ) -> None:
         """Internal: evaluate recovery when CB returns to CLOSED."""
         with self._lock:
@@ -546,4 +598,8 @@ class FailoverRouter:
             # whose _transition_seq starts at 0) can resume notifying without
             # its early notifies being dropped as stale by lingering last_seq.
             self._last_seq.pop(backend, None)
+            # Bump probe generation so any in-flight probe whose slot we just
+            # cleared cannot commit (gen mismatch) and cannot wipe a fresh
+            # claim made by a subsequent OPEN.
+            self._probe_gen[backend] = self._probe_gen.get(backend, 0) + 1
         logger.info("Administrative reset for %r: restored primary %r.", backend, region_list[0])

--- a/massgen/backend/cb_failover.py
+++ b/massgen/backend/cb_failover.py
@@ -17,6 +17,7 @@ import logging
 import threading
 import time
 import types
+from collections import Counter
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass, field
 from typing import Any
@@ -92,7 +93,7 @@ class FailoverConfig:
                         f"regions[{backend!r}] contains invalid region: {region!r}",
                     )
             if len(regions_tuple) != len(set(regions_tuple)):
-                duplicates = [r for r in regions_tuple if regions_tuple.count(r) > 1]
+                duplicates = sorted(r for r, c in Counter(regions_tuple).items() if c > 1)
                 raise ValueError(
                     f"regions[{backend!r}] contains duplicate region(s): {duplicates!r}",
                 )
@@ -505,8 +506,11 @@ class FailoverRouter:
                             if callable(close):
                                 try:
                                     close()
-                                except Exception:  # noqa: BLE001 -- best-effort cleanup
-                                    pass
+                                except Exception as close_exc:  # noqa: BLE001 -- best-effort cleanup
+                                    logger.debug(
+                                        "Best-effort close() on probe return value raised %s; ignoring.",
+                                        type(close_exc).__name__,
+                                    )
                             sink[0] = TypeError(
                                 "health_probe returned a coroutine, awaitable, async generator, " "or generator; probes must return bool synchronously -- see " "FailoverRouter.__init__ docstring.",
                             )

--- a/massgen/backend/cb_failover.py
+++ b/massgen/backend/cb_failover.py
@@ -1,0 +1,357 @@
+"""Multi-region failover router for LLM circuit breakers (Phase 6).
+
+When a backend's circuit breaker enters OPEN, FailoverRouter redirects
+traffic to a secondary region. When the CB recovers (CLOSED), it restores
+the primary after a configurable minimum failover duration.
+
+Opt-in: enabled=False in FailoverConfig is the default, preserving full
+back-compat. Wired into LLMCircuitBreaker via failover=None kwarg.
+
+Zero external dependencies -- pure Python, builds on existing CB abstractions.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class FailoverConfig:
+    """Configuration for the multi-region failover router.
+
+    All fields have safe defaults so existing CB configs need no changes.
+    Set enabled=True and populate regions to activate failover.
+    """
+
+    enabled: bool = False
+    # Map backend name to ordered list of region strings.
+    # First element is the primary; subsequent elements are secondaries
+    # tried in order. Example: {"gpt-5.4": ["us-east", "eu-west"]}
+    regions: dict[str, list[str]] = field(default_factory=dict)
+    # Seconds to wait for health probe before committing failover.
+    # Must be > 0.
+    health_check_timeout_seconds: float = 5.0
+    # Minimum seconds to stay on secondary after a failover before
+    # restoring primary on CB recovery. Prevents flapping. >= 0.
+    min_failover_duration_seconds: float = 30.0
+    # Reserved for future background recovery checks. Must be > 0.
+    recovery_check_interval_seconds: float = 10.0
+
+    def __post_init__(self) -> None:
+        """Validate all configuration fields."""
+        if self.health_check_timeout_seconds <= 0:
+            raise ValueError(
+                f"health_check_timeout_seconds must be > 0, "
+                f"got {self.health_check_timeout_seconds}",
+            )
+        if self.min_failover_duration_seconds < 0:
+            raise ValueError(
+                f"min_failover_duration_seconds must be >= 0, "
+                f"got {self.min_failover_duration_seconds}",
+            )
+        if self.recovery_check_interval_seconds <= 0:
+            raise ValueError(
+                f"recovery_check_interval_seconds must be > 0, "
+                f"got {self.recovery_check_interval_seconds}",
+            )
+        for backend, region_list in self.regions.items():
+            if not isinstance(backend, str) or not backend:
+                raise ValueError(
+                    f"regions keys must be non-empty strings, got {backend!r}",
+                )
+            if not region_list:
+                raise ValueError(
+                    f"regions[{backend!r}] must be a non-empty list, got {region_list!r}",
+                )
+            for region in region_list:
+                if not isinstance(region, str) or not region:
+                    raise ValueError(
+                        f"regions[{backend!r}] contains invalid region: {region!r}",
+                    )
+            if len(region_list) != len(set(region_list)):
+                duplicates = [r for r in region_list if region_list.count(r) > 1]
+                raise ValueError(
+                    f"regions[{backend!r}] contains duplicate region(s): {duplicates!r}",
+                )
+
+
+class FailoverRouter:
+    """Routes backends to secondary regions when their circuit breaker opens.
+
+    Thread-safe: all mutating methods acquire self._lock (threading.Lock).
+    Pure Python, zero external dependencies.
+
+    The router is event-driven: callers notify it via on_cb_state_change()
+    when a CB transitions. No background threads are created.
+    """
+
+    def __init__(
+        self,
+        config: FailoverConfig,
+        cb_registry: dict[str, Any] | None = None,
+        *,
+        clock: Callable[[], float] | None = None,
+        health_probe: Callable[[str], bool] | None = None,
+    ) -> None:
+        """Initialize the failover router.
+
+        Args:
+            config: Failover configuration including enabled flag and region map.
+            cb_registry: Optional mapping of backend names to LLMCircuitBreaker
+                instances, used only for snapshot() enrichment. Does not affect
+                routing decisions.
+            clock: Monotonic clock for measuring failover duration. Defaults to
+                time.monotonic. Injectable for tests.
+            health_probe: Callable that accepts a region string and returns True
+                if the region is healthy. Defaults to a function that always
+                returns True (assume healthy). Injectable for tests to simulate
+                failures. Any exception raised by the probe is caught and treated
+                as a probe failure -- no failover is committed.
+        """
+        self._config = config
+        self._cb_registry = cb_registry
+        self._clock: Callable[[], float] = clock or time.monotonic
+        self._health_probe: Callable[[str], bool] = health_probe or (lambda _region: True)
+        self._lock = threading.Lock()
+        # Per-backend failover state:
+        #   _active_region[backend] = str (current active region)
+        #   _failover_at[backend] = float | None (clock value when failover committed, None if not failed over)
+        #   _failover_pending[backend] = bool (True while a probe is in-flight for this backend)
+        #     Prevents concurrent threads from all probing and committing independently.
+        self._active_region: dict[str, str] = {}
+        self._failover_at: dict[str, float | None] = {}
+        self._failover_pending: dict[str, bool] = {}
+
+    def get_active_region(self, backend: str) -> str | None:
+        """Return the active region for a backend, or None if not configured.
+
+        Returns None when config.enabled is False or the backend has no
+        regions configured. Returns the primary (regions[backend][0]) when
+        not failed over, or the secondary when failed over.
+
+        Args:
+            backend: Logical backend name matching a key in config.regions.
+
+        Returns:
+            Active region string, or None.
+        """
+        if not self._config.enabled:
+            return None
+        region_list = self._config.regions.get(backend)
+        if not region_list:
+            return None
+        with self._lock:
+            return self._active_region.get(backend, region_list[0])
+
+    def on_cb_state_change(self, backend: str, old_state: str, new_state: str) -> None:
+        """Evaluate failover or recovery when a circuit breaker changes state.
+
+        When new_state=="open": attempt failover to the first secondary region
+        that passes the health probe. If already failed over or the probe
+        fails, the current routing is preserved.
+
+        When new_state=="closed": restore primary if the minimum failover
+        duration has elapsed. If the duration has not elapsed, recovery is
+        deferred (logged but not applied).
+
+        This method is a no-op when:
+        - config.enabled is False
+        - backend is not in config.regions
+        - An exception is raised by the health probe (treated as probe failure)
+
+        Args:
+            backend: Logical backend name.
+            old_state: CB state before the transition (for logging).
+            new_state: CB state after the transition.
+        """
+        if not self._config.enabled:
+            return
+        region_list = self._config.regions.get(backend)
+        if not region_list:
+            return
+
+        if new_state == "open":
+            self._handle_open(backend, old_state, region_list)
+        elif new_state == "closed":
+            self._handle_closed(backend, old_state, region_list)
+
+    def _handle_open(
+        self,
+        backend: str,
+        old_state: str,
+        region_list: list[str],
+    ) -> None:
+        """Internal: evaluate failover when CB enters OPEN.
+
+        Uses a _failover_pending flag to prevent concurrent threads from each
+        launching independent probes and committing redundant failovers. The
+        first thread to set the flag wins the probe; all subsequent callers
+        see either the pending flag or the committed failover and return early.
+        """
+        with self._lock:
+            already_failed_over = self._failover_at.get(backend) is not None
+            pending = self._failover_pending.get(backend, False)
+            if already_failed_over or pending:
+                # Idempotent: already on secondary, or another thread is probing.
+                return
+            if len(region_list) < 2:
+                # No secondary configured for this backend.
+                logger.warning(
+                    "Failover triggered for %r but no secondary region configured "
+                    "(regions list has only one entry).",
+                    backend,
+                )
+                return
+            # Claim the probe slot before releasing the lock.
+            self._failover_pending[backend] = True
+
+        # Probe runs outside the lock so it cannot block concurrent reads.
+        primary = region_list[0]
+        committed = False
+        try:
+            for candidate in region_list[1:]:
+                probe_result = False
+                try:
+                    probe_result = bool(self._health_probe(candidate))
+                except Exception:  # noqa: BLE001 -- probe failures must never propagate
+                    logger.warning(
+                        "Health probe for %r raised an exception; skipping region %r.",
+                        backend,
+                        candidate,
+                    )
+                    continue
+                if probe_result:
+                    with self._lock:
+                        self._active_region[backend] = candidate
+                        self._failover_at[backend] = self._clock()
+                    logger.info(
+                        "Failover committed for %r: %r -> %r (CB transitioned %s -> open).",
+                        backend,
+                        primary,
+                        candidate,
+                        old_state,
+                    )
+                    committed = True
+                    return
+                else:
+                    logger.warning(
+                        "Health probe failed for %r region %r; trying next.",
+                        backend,
+                        candidate,
+                    )
+
+            if not committed:
+                logger.warning(
+                    "All secondary regions for %r failed health probe; staying on primary %r.",
+                    backend,
+                    primary,
+                )
+        finally:
+            # Always clear the pending flag so future OPEN events can retry.
+            with self._lock:
+                self._failover_pending[backend] = False
+
+    def _handle_closed(
+        self,
+        backend: str,
+        old_state: str,
+        region_list: list[str],
+    ) -> None:
+        """Internal: evaluate recovery when CB returns to CLOSED."""
+        with self._lock:
+            failover_at = self._failover_at.get(backend)
+            if failover_at is None:
+                # Not failed over -- nothing to restore.
+                return
+            now = self._clock()
+            elapsed = now - failover_at
+            min_duration = self._config.min_failover_duration_seconds
+            if elapsed >= min_duration:
+                primary = region_list[0]
+                self._active_region.pop(backend, None)
+                self._failover_at[backend] = None
+                logger.info(
+                    "Recovery complete for %r: restored primary %r "
+                    "(elapsed=%.1fs >= min_duration=%.1fs, CB transitioned %s -> closed).",
+                    backend,
+                    primary,
+                    elapsed,
+                    min_duration,
+                    old_state,
+                )
+            else:
+                remaining = min_duration - elapsed
+                active = self._active_region.get(backend, region_list[0])
+                logger.info(
+                    "Recovery deferred for %r: staying on %r for %.1f more seconds "
+                    "(elapsed=%.1fs < min_duration=%.1fs).",
+                    backend,
+                    active,
+                    remaining,
+                    elapsed,
+                    min_duration,
+                )
+
+    def is_failed_over(self, backend: str) -> bool:
+        """Return True iff the backend is currently routing to a secondary region.
+
+        Args:
+            backend: Logical backend name.
+
+        Returns:
+            True if currently failed over, False otherwise (including when
+            config.enabled is False or backend has no regions configured).
+        """
+        if not self._config.enabled:
+            return False
+        with self._lock:
+            return self._failover_at.get(backend) is not None
+
+    def snapshot(self) -> dict[str, Any]:
+        """Return an observable point-in-time snapshot of all backends.
+
+        All live fields are captured under a single lock acquisition.
+
+        Returns:
+            Dict with key "backends" mapping each configured backend name to
+            a dict containing:
+            - "active_region": current active region string (primary or secondary)
+            - "failed_over": bool
+            - "failover_at": float | None (monotonic timestamp, None if not failed over)
+        """
+        with self._lock:
+            result: dict[str, Any] = {}
+            for backend, region_list in self._config.regions.items():
+                primary = region_list[0]
+                active = self._active_region.get(backend, primary)
+                failover_at = self._failover_at.get(backend)
+                result[backend] = {
+                    "active_region": active,
+                    "failed_over": failover_at is not None,
+                    "failover_at": failover_at,
+                }
+        return {"backends": result}
+
+    def reset(self, backend: str) -> None:
+        """Administratively restore the primary region for a backend.
+
+        Clears failover state regardless of min_failover_duration_seconds.
+        Safe to call when not failed over (no-op in that case).
+
+        Args:
+            backend: Logical backend name.
+        """
+        region_list = self._config.regions.get(backend)
+        with self._lock:
+            self._active_region.pop(backend, None)
+            self._failover_at[backend] = None
+            self._failover_pending[backend] = False
+        if region_list:
+            logger.info("Administrative reset for %r: restored primary %r.", backend, region_list[0])

--- a/massgen/backend/cb_failover.py
+++ b/massgen/backend/cb_failover.py
@@ -86,7 +86,8 @@ class FailoverRouter:
     Pure Python, zero external dependencies.
 
     The router is event-driven: callers notify it via on_cb_state_change()
-    when a CB transitions. No background threads are created.
+    when a CB transitions, passing a required monotonically-increasing seq
+    so out-of-order notifies are dropped. No background threads are created.
     """
 
     def __init__(
@@ -103,16 +104,32 @@ class FailoverRouter:
             clock: Monotonic clock for measuring failover duration. Defaults to
                 time.monotonic. Injectable for tests.
             health_probe: Callable that accepts a region string and returns True
-                if the region is healthy. Defaults to a function that always
-                returns True (assume healthy). Injectable for tests to simulate
-                failures. Any exception raised by the probe is caught and treated
-                as a probe failure -- no failover is committed. Each probe call
-                runs under a `health_check_timeout_seconds` deadline; on timeout
-                the probe is treated as a failure and the next region is tried.
+                if the region is healthy. When None, defaults to a function that
+                always returns True. WARNING: the default is NOT production safe
+                -- it will commit failover to the configured secondary on every
+                CB OPEN even if the secondary is also down. Production callers
+                must provide an explicit probe that actually checks the region.
+                A one-shot WARNING is logged at construction when config.enabled
+                is True and no explicit probe is supplied. Any exception raised
+                by the probe is caught and treated as a probe failure -- no
+                failover is committed. Each probe call runs under a
+                health_check_timeout_seconds deadline; on timeout the probe is
+                treated as a failure and the next region is tried.
         """
         self._config = config
         self._clock: Callable[[], float] = clock or time.monotonic
-        self._health_probe: Callable[[str], bool] = health_probe or (lambda _region: True)
+        if health_probe is None:
+            self._health_probe: Callable[[str], bool] = lambda _region: True
+            if config.enabled:
+                logger.warning(
+                    "FailoverRouter constructed with enabled=True and no explicit "
+                    "health_probe; using default probe that returns True for all "
+                    "regions. This is NOT production safe -- failover will commit "
+                    "to the configured secondary even if it is also unhealthy. "
+                    "Provide a real probe via the health_probe= kwarg.",
+                )
+        else:
+            self._health_probe = health_probe
         self._lock = threading.Lock()
         # Per-backend failover state:
         #   _active_region[backend] = str (current active region)
@@ -125,6 +142,9 @@ class FailoverRouter:
         self._failover_at: dict[str, float | None] = {}
         self._failover_pending: dict[str, bool] = {}
         self._closed_during_probe: dict[str, bool] = {}
+        # Last applied transition seq per backend, for out-of-order notify drop.
+        # See on_cb_state_change docstring.
+        self._last_seq: dict[str, int] = {}
 
     def _try_lazy_recovery_unlocked(self, backend: str, region_list: list[str]) -> None:
         """Restore primary if min_failover_duration has elapsed since failover.
@@ -180,7 +200,14 @@ class FailoverRouter:
             self._try_lazy_recovery_unlocked(backend, region_list)
             return self._active_region.get(backend, region_list[0])
 
-    def on_cb_state_change(self, backend: str, old_state: str, new_state: str) -> None:
+    def on_cb_state_change(
+        self,
+        backend: str,
+        old_state: str,
+        new_state: str,
+        *,
+        seq: int,
+    ) -> None:
         """Evaluate failover or recovery when a circuit breaker changes state.
 
         When new_state=="open": attempt failover to the first secondary region
@@ -194,22 +221,58 @@ class FailoverRouter:
         This method is a no-op when:
         - config.enabled is False
         - backend is not in config.regions
+        - new_state is not "open" or "closed" (e.g. "half_open" or any
+          unrecognized value -- ignored without consuming a seq slot)
         - An exception is raised by the health probe (treated as probe failure)
+        - seq is not strictly greater than the last applied seq for this
+          backend (the notify is stale and would otherwise overwrite a
+          fresher CB state with an older view)
 
         Args:
             backend: Logical backend name.
             old_state: CB state before the transition (for logging).
             new_state: CB state after the transition.
+            seq: Monotonically increasing transition sequence number from the
+                CB. Required, kwarg-only. record_failure / record_success
+                release self._lock before calling _notify_failover, so a stale
+                notify can otherwise overwrite a fresher one and leave the
+                router in a state inconsistent with the actual CB state. Pass
+                a unique strictly-increasing integer from the producer; tests
+                calling this method directly may use any monotonically
+                increasing sequence (e.g. 1, 2, 3 ...).
         """
         if not self._config.enabled:
             return
         region_list = self._config.regions.get(backend)
         if not region_list:
             return
+        # Drop notifies with new_state that this router doesn't act on
+        # (e.g. "half_open"). Without this guard an unknown state would
+        # consume a seq slot and silently drop subsequent legitimate
+        # notifies whose seq is <= the consumed value.
+        if new_state not in ("open", "closed"):
+            logger.debug(
+                "Ignoring failover notify for %r with unsupported new_state=%r.",
+                backend,
+                new_state,
+            )
+            return
+
+        with self._lock:
+            last = self._last_seq.get(backend, 0)
+            if seq <= last:
+                logger.debug(
+                    "Dropping stale failover notify for %r: seq=%d <= last=%d.",
+                    backend,
+                    seq,
+                    last,
+                )
+                return
+            self._last_seq[backend] = seq
 
         if new_state == "open":
             self._handle_open(backend, old_state, region_list)
-        elif new_state == "closed":
+        else:  # new_state == "closed", guarded above
             self._handle_closed(backend, old_state, region_list)
 
     def _handle_open(
@@ -269,12 +332,19 @@ class FailoverRouter:
                 # leaks until process exit. The thread is daemon so it does
                 # not delay shutdown. Probe authors should use timeouts in
                 # their HTTP clients to avoid the leak in practice.
-                probe_outcome: list[bool | BaseException] = [False]
+                probe_outcome: list[bool | Exception] = [False]
 
-                def _probe_runner(region: str = candidate, sink: list[bool | BaseException] = probe_outcome) -> None:
+                def _probe_runner(region: str = candidate, sink: list[bool | Exception] = probe_outcome) -> None:
+                    """Run health probe in a daemon thread; record bool or Exception in sink.
+
+                    KeyboardInterrupt and SystemExit are not caught -- consistent
+                    with the policy in LLMCircuitBreaker._notify_failover. If a
+                    probe somehow raises one in this worker thread, it surfaces
+                    as a thread crash rather than being absorbed.
+                    """
                     try:
                         sink[0] = bool(self._health_probe(region))
-                    except BaseException as exc:  # noqa: BLE001 -- never let probe break router
+                    except Exception as exc:  # noqa: BLE001 -- never let probe break router
                         sink[0] = exc
 
                 probe_thread = threading.Thread(target=_probe_runner, name=f"failover-probe-{candidate}", daemon=True)
@@ -288,7 +358,7 @@ class FailoverRouter:
                         timeout,
                     )
                     probe_result = False
-                elif isinstance(probe_outcome[0], BaseException):
+                elif isinstance(probe_outcome[0], Exception):
                     logger.warning(
                         "Health probe for %r raised %s; skipping region %r.",
                         backend,
@@ -451,8 +521,14 @@ class FailoverRouter:
     def reset(self, backend: str) -> None:
         """Administratively restore the primary region for a backend.
 
-        Clears failover state regardless of min_failover_duration_seconds.
-        Safe to call when not failed over (no-op in that case).
+        Clears all per-backend tracking state -- active region, failover
+        timestamp, in-flight probe pending flag, closed-during-probe latch,
+        and last-applied seq -- regardless of min_failover_duration_seconds
+        and regardless of whether a failover is currently in progress.
+        Clearing _last_seq lets a fresh producer (e.g. a hot-swapped CB
+        instance whose _transition_seq starts at 0) resume notifying without
+        having its early notifies dropped as stale. No-op when backend is
+        not in config.regions.
 
         Args:
             backend: Logical backend name.
@@ -466,4 +542,8 @@ class FailoverRouter:
             self._failover_at[backend] = None
             self._failover_pending[backend] = False
             self._closed_during_probe.pop(backend, None)
+            # Clear seq history so a new producer (or hot-swapped CB instance
+            # whose _transition_seq starts at 0) can resume notifying without
+            # its early notifies being dropped as stale by lingering last_seq.
+            self._last_seq.pop(backend, None)
         logger.info("Administrative reset for %r: restored primary %r.", backend, region_list[0])

--- a/massgen/backend/cb_failover.py
+++ b/massgen/backend/cb_failover.py
@@ -12,6 +12,7 @@ Zero external dependencies -- pure Python, builds on existing CB abstractions.
 
 from __future__ import annotations
 
+import inspect
 import logging
 import threading
 import time
@@ -60,15 +61,15 @@ class FailoverConfig:
         """Validate all configuration fields."""
         if self.health_check_timeout_seconds <= 0:
             raise ValueError(
-                f"health_check_timeout_seconds must be > 0, " f"got {self.health_check_timeout_seconds}",
+                f"health_check_timeout_seconds must be > 0, got {self.health_check_timeout_seconds}",
             )
         if self.min_failover_duration_seconds < 0:
             raise ValueError(
-                f"min_failover_duration_seconds must be >= 0, " f"got {self.min_failover_duration_seconds}",
+                f"min_failover_duration_seconds must be >= 0, got {self.min_failover_duration_seconds}",
             )
         if self.recovery_check_interval_seconds <= 0:
             raise ValueError(
-                f"recovery_check_interval_seconds must be > 0, " f"got {self.recovery_check_interval_seconds}",
+                f"recovery_check_interval_seconds must be > 0, got {self.recovery_check_interval_seconds}",
             )
         # Materialize each region sequence into a tuple BEFORE iterating so
         # iterator inputs (which would otherwise be consumed by the first
@@ -144,6 +145,20 @@ class FailoverRouter:
         """
         self._config = config
         self._clock: Callable[[], float] = clock or time.monotonic
+        if health_probe is not None and self._is_async_callable(health_probe):
+            # bool(coroutine) is always True, so an async probe would always
+            # report healthy without ever being awaited. Reject at construction
+            # rather than silently failover on every CB OPEN. The check covers
+            # async def functions, async generator functions, and callable
+            # instances whose __call__ is async.
+            raise ValueError(
+                "health_probe must be a synchronous callable returning bool. "
+                "Async probes (including async def, async generators, and "
+                "callables with async __call__) are not supported in this "
+                "version of FailoverRouter. Wrap your async function with "
+                "asyncio.run() or use a synchronous HTTP client (e.g. "
+                "requests, httpx.Client).",
+            )
         if health_probe is None:
             self._health_probe: Callable[[str], bool] = lambda _region: True
             if config.enabled:
@@ -162,12 +177,10 @@ class FailoverRouter:
         #   _failover_at[backend] = float | None (clock value when failover committed, None if not failed over)
         #   _failover_pending[backend] = bool (True while a probe is in-flight for this backend)
         #     Prevents concurrent threads from all probing and committing independently.
-        #   _closed_during_probe[backend] = bool (True when CLOSED arrived while a probe was pending)
         #     Prevents stale OPEN probes from committing after the CB has already recovered.
         self._active_region: dict[str, str] = {}
         self._failover_at: dict[str, float | None] = {}
         self._failover_pending: dict[str, bool] = {}
-        self._closed_during_probe: dict[str, bool] = {}
         # Last applied transition seq per backend, for out-of-order notify drop.
         # See on_cb_state_change docstring.
         self._last_seq: dict[str, int] = {}
@@ -179,14 +192,45 @@ class FailoverRouter:
         # land under the new probe's pending claim, or let an old probe's
         # finally wipe the new probe's claim.
         self._probe_gen: dict[str, int] = {}
+        # Latest CB state we were notified about, captured under self._lock at
+        # the same point as _last_seq[backend] is updated. Used at probe-commit
+        # time so a probe whose pending claim was made for an OPEN that has
+        # since been superseded by CLOSED (and possibly another OPEN) commits
+        # only when the most recent CB state is still OPEN. Without this,
+        # OPEN(1)+CLOSED(2)+OPEN(3) interleaved with an in-flight probe could
+        # leave the router on the primary while the CB is actually OPEN.
+        self._last_state: dict[str, str] = {}
+
+    @staticmethod
+    def _is_async_callable(probe: object) -> bool:
+        """Return True if ``probe`` would produce an awaitable when called.
+
+        ``asyncio.iscoroutinefunction`` only catches ``async def`` functions;
+        it misses async generator functions and callable instances whose
+        ``__call__`` is async. All three would silently misbehave because
+        ``bool(coroutine_or_async_gen)`` is always True.
+        """
+        if inspect.iscoroutinefunction(probe) or inspect.isasyncgenfunction(probe):
+            return True
+        call = getattr(probe, "__call__", None)
+        if call is not None and (inspect.iscoroutinefunction(call) or inspect.isasyncgenfunction(call)):
+            return True
+        return False
 
     def _try_lazy_recovery_unlocked(self, backend: str, region_list: Sequence[str]) -> None:
         """Restore primary if min_failover_duration has elapsed since failover.
 
-        Caller must hold self._lock. Mutates _active_region and _failover_at
-        when eligible. No-op when not failed over or duration not elapsed.
         Used by get_active_region, is_failed_over, and snapshot to keep router
-        observation methods consistent.
+        observation methods consistent. No-op when not failed over or when the
+        configured min_failover_duration_seconds has not elapsed.
+
+        Locking contract: caller MUST hold self._lock.
+
+        Args:
+            backend: Logical backend name being observed.
+            region_list: Configured ordered region sequence for the backend.
+                regions[backend][0] is restored as the active region when the
+                duration condition is met.
         """
         failover_at = self._failover_at.get(backend)
         if failover_at is None:
@@ -303,17 +347,25 @@ class FailoverRouter:
                 )
                 return
             self._last_seq[backend] = seq
+            self._last_state[backend] = new_state
 
+        # Pass our seq through so the dispatch can detect a newer notify
+        # that arrived between our seq update and our lock re-acquisition.
+        # Without this, low-seq OPEN + high-seq CLOSED dispatched concurrently
+        # could let the OPEN's _handle_open commit a failover after the
+        # CLOSED's _handle_closed already ran (as a no-op, because failover
+        # was not yet committed).
         if new_state == "open":
-            self._handle_open(backend, old_state, region_list)
+            self._handle_open(backend, old_state, region_list, seq)
         else:  # new_state == "closed", guarded above
-            self._handle_closed(backend, old_state, region_list)
+            self._handle_closed(backend, old_state, region_list, seq)
 
     def _handle_open(
         self,
         backend: str,
         old_state: str,
         region_list: Sequence[str],
+        seq: int,
     ) -> None:
         """Internal: evaluate failover when CB enters OPEN.
 
@@ -321,6 +373,24 @@ class FailoverRouter:
         launching independent probes and committing redundant failovers. The
         first thread to set the flag wins the probe; all subsequent callers
         see either the pending flag or the committed failover and return early.
+        A per-claim generation token (_probe_gen[backend], my_gen local) gates
+        both the probe-success commit and the finally cleanup so a stale
+        probe whose slot was reclaimed by reset() + new OPEN cannot commit
+        under the new owner's claim or wipe it during cleanup.
+
+        Locking contract: takes self._lock for the slot claim and again for
+        the probe-success commit. Probe execution and the daemon thread join
+        run OUTSIDE the lock so concurrent reads are not blocked.
+
+        Args:
+            backend: Logical backend name being notified.
+            old_state: CB state value before the transition (for logging).
+            region_list: Configured ordered region sequence for the backend.
+                region_list[0] is the primary; region_list[1:] are probed in
+                order until one passes the health probe.
+            seq: Transition seq we were dispatched with. If _last_seq has
+                advanced past us, a newer notify arrived between
+                on_cb_state_change's lock-release and ours -- abort.
         """
         # The whole probe (lock-claim + probe loop + commit) runs under one
         # try/finally so a BaseException (KeyboardInterrupt, SystemExit,
@@ -335,6 +405,20 @@ class FailoverRouter:
         timeout = self._config.health_check_timeout_seconds
         try:
             with self._lock:
+                # If a newer notify advanced _last_seq past our seq while we
+                # were between on_cb_state_change's lock-release and this
+                # claim, the CB's authoritative state has moved past ours.
+                # Aborting prevents a stale OPEN from committing a failover
+                # after a fresher CLOSED already ran (and observed
+                # failover_at=None as a no-op).
+                if self._last_seq.get(backend, 0) > seq:
+                    logger.debug(
+                        "Failover OPEN seq=%d for %r superseded by later notify (last=%d); aborting.",
+                        seq,
+                        backend,
+                        self._last_seq.get(backend, 0),
+                    )
+                    return
                 already_failed_over = self._failover_at.get(backend) is not None
                 pending = self._failover_pending.get(backend, False)
                 if already_failed_over or pending:
@@ -353,7 +437,6 @@ class FailoverRouter:
                 # is True) and clears the (False) pending flag harmlessly.
                 pending_claimed = True
                 self._failover_pending[backend] = True
-                self._closed_during_probe.pop(backend, None)
                 # Capture a per-claim generation token. Both reset() and a
                 # fresh slot claim in _handle_open bump _probe_gen, so a
                 # stale probe whose generation no longer matches will not
@@ -362,6 +445,27 @@ class FailoverRouter:
                 my_gen = self._probe_gen[backend]
 
             for candidate in region_list[1:]:
+                # Cheap per-iteration abort check: if reset() ran or CB
+                # already returned to CLOSED while we were probing earlier
+                # secondaries, do not waste time probing remaining regions.
+                # The commit guard would catch this anyway, but short-
+                # circuiting here saves up to (len(secondaries) - 1) *
+                # health_check_timeout_seconds of wall-clock time.
+                with self._lock:
+                    if self._probe_gen.get(backend, 0) != my_gen:
+                        logger.info(
+                            "Failover probe for %r aborted mid-loop: probe slot was reclaimed (gen mismatch).",
+                            backend,
+                        )
+                        return
+                    if self._last_state.get(backend, "open") != "open":
+                        logger.info(
+                            "Failover probe for %r aborted mid-loop: latest CB state is %r, not OPEN.",
+                            backend,
+                            self._last_state.get(backend),
+                        )
+                        return
+
                 probe_result = False
                 # Enforce health_check_timeout_seconds via a daemon thread +
                 # join(timeout). A hanging probe must not block the calling
@@ -382,9 +486,32 @@ class FailoverRouter:
                     with the policy in LLMCircuitBreaker._notify_failover. If a
                     probe somehow raises one in this worker thread, it surfaces
                     as a thread crash rather than being absorbed.
+
+                    Detects coroutine/awaitable, async-generator, and sync-
+                    generator return values (e.g. a sync lambda that calls an
+                    async function, or a probe defined with `def f(): yield x`)
+                    and treats them as a probe failure rather than a true
+                    result, since bool(...) is always True for these types.
                     """
                     try:
-                        sink[0] = bool(self._health_probe(region))
+                        result = self._health_probe(region)
+                        # Treat awaitables (coroutines, futures, Tasks) AND
+                        # async generator iterators as probe failures rather
+                        # than silently truthy results. Async gen iterators
+                        # are not awaitable but bool(...) is still True,
+                        # which would falsely report healthy.
+                        if inspect.isawaitable(result) or inspect.isasyncgen(result) or inspect.isgenerator(result):
+                            close = getattr(result, "close", None)
+                            if callable(close):
+                                try:
+                                    close()
+                                except Exception:  # noqa: BLE001 -- best-effort cleanup
+                                    pass
+                            sink[0] = TypeError(
+                                "health_probe returned a coroutine, awaitable, async generator, " "or generator; probes must return bool synchronously -- see " "FailoverRouter.__init__ docstring.",
+                            )
+                            return
+                        sink[0] = bool(result)
                     except Exception as exc:  # noqa: BLE001 -- never let probe break router
                         sink[0] = exc
 
@@ -392,13 +519,18 @@ class FailoverRouter:
                 probe_thread.start()
                 probe_thread.join(timeout=timeout)
                 if probe_thread.is_alive():
+                    # Skip the trailing "Health probe failed for ... trying
+                    # next" log below: the timeout warning already says what
+                    # happened, and we want to move on to the next region
+                    # without the duplicate "failed" message that suggests a
+                    # different cause.
                     logger.warning(
                         "Health probe for %r region %r timed out after %.1fs; treating as failure (thread abandoned).",
                         backend,
                         candidate,
                         timeout,
                     )
-                    probe_result = False
+                    continue
                 elif isinstance(probe_outcome[0], Exception):
                     logger.warning(
                         "Health probe for %r raised %s; skipping region %r.",
@@ -426,20 +558,28 @@ class FailoverRouter:
                                 backend,
                             )
                             return
-                        if self._closed_during_probe.get(backend, False):
+                        if self._last_state.get(backend, "open") != "open":
+                            # Authoritative latest CB state is not OPEN
+                            # (CLOSED arrived during probe AND no fresher
+                            # OPEN superseded it). Do not commit failover.
+                            # If CLOSED was followed by a fresher OPEN, the
+                            # state will be "open" again and we DO commit --
+                            # otherwise OPEN(1)+CLOSED(2)+OPEN(3) interleaved
+                            # with our probe would silently leave the router
+                            # on the primary while the CB is OPEN.
                             logger.info(
-                                "Failover probe for %r succeeded but commit was aborted because the circuit breaker closed during the probe.",
+                                "Failover probe for %r succeeded but commit was aborted because latest CB state is %r, not OPEN.",
                                 backend,
+                                self._last_state.get(backend),
                             )
                             return
                         self._active_region[backend] = candidate
                         self._failover_at[backend] = self._clock()
-                        # Atomically clear pending+latch so observers don't see
-                        # a transient (failed_over=True, pending=True) state
+                        # Atomically clear pending so observers don't see a
+                        # transient (failed_over=True, pending=True) state
                         # that could cause a subsequent OPEN event to be
                         # wrongly suppressed if recovery races with this commit.
                         self._failover_pending[backend] = False
-                        self._closed_during_probe.pop(backend, None)
                     logger.info(
                         "Failover committed for %r: %r -> %r (CB transitioned %s -> open).",
                         backend,
@@ -474,16 +614,43 @@ class FailoverRouter:
                 with self._lock:
                     if self._probe_gen.get(backend, 0) == my_gen:
                         self._failover_pending[backend] = False
-                        self._closed_during_probe.pop(backend, None)
 
     def _handle_closed(
         self,
         backend: str,
         old_state: str,
         region_list: Sequence[str],
+        seq: int,
     ) -> None:
-        """Internal: evaluate recovery when CB returns to CLOSED."""
+        """Internal: evaluate recovery when CB returns to CLOSED.
+
+        Restores primary if the configured min_failover_duration_seconds has
+        elapsed since the failover; otherwise logs a deferral. When a probe
+        is currently in flight, the commit-time guard in _handle_open reads
+        self._last_state (which on_cb_state_change updated to "closed" before
+        dispatching us) and aborts the commit, so the CLOSED notification is
+        not silently lost.
+
+        Locking contract: takes self._lock for the duration of the routine.
+
+        Args:
+            backend: Logical backend name being notified.
+            old_state: CB state value before the transition (for logging).
+            region_list: Configured ordered region sequence for the backend.
+                region_list[0] is the primary that recovery restores.
+            seq: Transition seq we were dispatched with. If _last_seq has
+                advanced past us, a newer notify arrived between
+                on_cb_state_change's lock-release and ours -- abort.
+        """
         with self._lock:
+            if self._last_seq.get(backend, 0) > seq:
+                logger.debug(
+                    "Failover CLOSED seq=%d for %r superseded by later notify (last=%d); aborting.",
+                    seq,
+                    backend,
+                    self._last_seq.get(backend, 0),
+                )
+                return
             failover_at = self._failover_at.get(backend)
             if failover_at is not None:
                 now = self._clock()
@@ -513,12 +680,6 @@ class FailoverRouter:
                         min_duration,
                     )
                 return
-            if self._failover_pending.get(backend, False):
-                self._closed_during_probe[backend] = True
-                logger.debug(
-                    "CLOSED notification for %r arrived during an in-flight failover probe; " "marking probe for abort.",
-                    backend,
-                )
 
     def is_failed_over(self, backend: str) -> bool:
         """Return True iff the backend is currently routing to a secondary region.
@@ -574,8 +735,8 @@ class FailoverRouter:
         """Administratively restore the primary region for a backend.
 
         Clears all per-backend tracking state -- active region, failover
-        timestamp, in-flight probe pending flag, closed-during-probe latch,
-        and last-applied seq -- regardless of min_failover_duration_seconds
+        timestamp, in-flight probe pending flag, last-applied seq, and
+        latest CB state -- regardless of min_failover_duration_seconds
         and regardless of whether a failover is currently in progress.
         Clearing _last_seq lets a fresh producer (e.g. a hot-swapped CB
         instance whose _transition_seq starts at 0) resume notifying without
@@ -593,11 +754,11 @@ class FailoverRouter:
             self._active_region.pop(backend, None)
             self._failover_at[backend] = None
             self._failover_pending[backend] = False
-            self._closed_during_probe.pop(backend, None)
             # Clear seq history so a new producer (or hot-swapped CB instance
             # whose _transition_seq starts at 0) can resume notifying without
             # its early notifies being dropped as stale by lingering last_seq.
             self._last_seq.pop(backend, None)
+            self._last_state.pop(backend, None)
             # Bump probe generation so any in-flight probe whose slot we just
             # cleared cannot commit (gen mismatch) and cannot wipe a fresh
             # claim made by a subsequent OPEN.

--- a/massgen/backend/llm_circuit_breaker.py
+++ b/massgen/backend/llm_circuit_breaker.py
@@ -1012,6 +1012,12 @@ class LLMCircuitBreaker:
         order. FailoverRouter mitigates this by tracking _last_seq[backend]
         and dropping stale notifications, so the next genuine transition
         resyncs router state with CB state.
+
+        WARNING: in-memory transition paths must NOT call this helper. They
+        must capture ``self._transition_seq`` inline under the lock that
+        guards the state mutation so the seq is captured at the same point
+        as the mutation. Calling _next_seq() from those paths would re-
+        acquire self._lock and break that invariant.
         """
         with self._lock:
             self._transition_seq += 1

--- a/massgen/backend/llm_circuit_breaker.py
+++ b/massgen/backend/llm_circuit_breaker.py
@@ -257,6 +257,16 @@ class LLMCircuitBreaker:
         self._last_failure_time = 0.0
         self._open_until = 0.0  # monotonic deadline for OPEN state
         self._half_open_probe_active = False
+        # Monotonically increasing sequence for state transitions, captured
+        # under self._lock at the same point as the transition itself. The
+        # number is passed to FailoverRouter.on_cb_state_change so observers
+        # can drop notifications that arrive out-of-order relative to the
+        # actual CB state mutation order. Concurrent record_failure /
+        # record_success on the same backend can otherwise interleave such
+        # that a stale "open" notify arrives at the router AFTER a "closed"
+        # notify, leaving the router stuck on secondary while the CB is
+        # actually closed.
+        self._transition_seq = 0
 
     # -- Public interface ---------------------------------------------------
 
@@ -435,7 +445,7 @@ class LLMCircuitBreaker:
                             "half_open",
                             "open",
                         )
-                    self._notify_failover("half_open", "open")
+                    self._notify_failover("half_open", "open", seq=self._next_seq())
                 else:
                     self._log(
                         "Circuit breaker opened",
@@ -449,7 +459,7 @@ class LLMCircuitBreaker:
                             prev_label,  # now from _prev_state, never stale
                             "open",
                         )
-                    self._notify_failover(prev_label, "open")
+                    self._notify_failover(prev_label, "open", seq=self._next_seq())
             else:
                 self._log(
                     "Failure recorded",
@@ -460,6 +470,7 @@ class LLMCircuitBreaker:
             return
 
         _transition_args: tuple[str, str, str] | None = None
+        _seq = 0
         with self._lock:
             self._failure_count += 1
             now = time.monotonic()
@@ -478,6 +489,8 @@ class LLMCircuitBreaker:
                     error_type=error_type,
                 )
                 _transition_args = (self.backend_name, "half_open", "open")
+                self._transition_seq += 1
+                _seq = self._transition_seq
 
             elif self._failure_count >= effective_max:
                 if prev_state == CircuitState.OPEN:
@@ -501,6 +514,8 @@ class LLMCircuitBreaker:
                         error_type=error_type,
                     )
                     _transition_args = (self.backend_name, prev_state.value, "open")
+                    self._transition_seq += 1
+                    _seq = self._transition_seq
             else:
                 self._log(
                     "Failure recorded",
@@ -515,7 +530,7 @@ class LLMCircuitBreaker:
                 *_transition_args,
             )
         if _transition_args is not None:
-            self._notify_failover(_transition_args[1], "open")
+            self._notify_failover(_transition_args[1], "open", seq=_seq)
 
     def record_success(self) -> None:
         """Record a successful API call. Resets failure counter and closes circuit."""
@@ -543,10 +558,11 @@ class LLMCircuitBreaker:
                         prev_state_str,
                         "closed",
                     )
-                self._notify_failover(prev_state_str, "closed")
+                self._notify_failover(prev_state_str, "closed", seq=self._next_seq())
             return
 
         _transition_args: tuple[str, str, str] | None = None
+        _seq = 0
         with self._lock:
             prev_state = self._state
             self._state = CircuitState.CLOSED
@@ -561,6 +577,8 @@ class LLMCircuitBreaker:
                     previous_state=prev_state.value,
                 )
                 _transition_args = (self.backend_name, prev_state.value, "closed")
+                self._transition_seq += 1
+                _seq = self._transition_seq
 
         if _transition_args is not None and self._metrics is not None:
             self._safe_emit(
@@ -568,7 +586,7 @@ class LLMCircuitBreaker:
                 *_transition_args,
             )
         if _transition_args is not None:
-            self._notify_failover(_transition_args[1], "closed")
+            self._notify_failover(_transition_args[1], "closed", seq=_seq)
 
     def force_open(self, reason: str = "", open_for_seconds: float = 0) -> None:
         """Force the circuit to OPEN state (e.g. on 429 STOP).
@@ -633,10 +651,11 @@ class LLMCircuitBreaker:
                     "open",
                 )
             if prev_state_value != CircuitState.OPEN.value:
-                self._notify_failover(prev_state_value, "open")
+                self._notify_failover(prev_state_value, "open", seq=self._next_seq())
             return
 
         _transition_args: tuple[str, str, str] | None = None
+        _seq = 0
         with self._lock:
             now = time.monotonic()
             prev_state = self._state
@@ -657,6 +676,8 @@ class LLMCircuitBreaker:
             self._log(f"Circuit breaker force-opened: {reason}", open_for_seconds=duration)
             if prev_state != CircuitState.OPEN:
                 _transition_args = (self.backend_name, prev_state.value, "open")
+                self._transition_seq += 1
+                _seq = self._transition_seq
 
         if _transition_args is not None and self._metrics is not None:
             self._safe_emit(
@@ -664,7 +685,7 @@ class LLMCircuitBreaker:
                 *_transition_args,
             )
         if _transition_args is not None:
-            self._notify_failover(_transition_args[1], "open")
+            self._notify_failover(_transition_args[1], "open", seq=_seq)
 
     def reset(self) -> None:
         """Reset circuit breaker to initial CLOSED state.
@@ -696,10 +717,11 @@ class LLMCircuitBreaker:
                     "closed",
                 )
             if prev_state_value != CircuitState.CLOSED.value:
-                self._notify_failover(prev_state_value, "closed")
+                self._notify_failover(prev_state_value, "closed", seq=self._next_seq())
             return
 
         _transition_args: tuple[str, str, str] | None = None
+        _seq = 0
         with self._lock:
             prev_state = self._state
             self._state = CircuitState.CLOSED
@@ -711,6 +733,8 @@ class LLMCircuitBreaker:
                 self._adaptive.reset_open_timer()
             if prev_state != CircuitState.CLOSED:
                 _transition_args = (self.backend_name, prev_state.value, "closed")
+                self._transition_seq += 1
+                _seq = self._transition_seq
 
         if _transition_args is not None and self._metrics is not None:
             self._safe_emit(
@@ -718,7 +742,7 @@ class LLMCircuitBreaker:
                 *_transition_args,
             )
         if _transition_args is not None:
-            self._notify_failover(_transition_args[1], "closed")
+            self._notify_failover(_transition_args[1], "closed", seq=_seq)
 
     # -- 429-aware retry wrapper --------------------------------------------
 
@@ -933,8 +957,9 @@ class LLMCircuitBreaker:
                                 "half_open",
                                 "open",
                             )
-                        self._notify_failover("half_open", "open")
+                        self._notify_failover("half_open", "open", seq=self._next_seq())
                 else:
+                    _seq = 0
                     with self._lock:
                         if self._state == CircuitState.HALF_OPEN and self._half_open_probe_active:
                             self._state = CircuitState.OPEN
@@ -944,13 +969,15 @@ class LLMCircuitBreaker:
                             self._half_open_probe_active = False
                             self._log("Probe terminated abnormally, circuit breaker re-opened")
                             _transition_args = (self.backend_name, "half_open", "open")
+                            self._transition_seq += 1
+                            _seq = self._transition_seq
                     if _transition_args is not None and self._metrics is not None:
                         self._safe_emit(
                             self._metrics.record_state_transition,
                             *_transition_args,
                         )
                     if _transition_args is not None:
-                        self._notify_failover(_transition_args[1], "open")
+                        self._notify_failover(_transition_args[1], "open", seq=_seq)
             raise
 
     # -- Internal helpers ---------------------------------------------------
@@ -966,19 +993,46 @@ class LLMCircuitBreaker:
         except Exception:  # noqa: BLE001
             pass
 
-    def _notify_failover(self, prev_state: str, new_state: str) -> None:
+    def _next_seq(self) -> int:
+        """Atomically increment and return the next transition sequence number.
+
+        Thread-safe: increment runs under self._lock. For in-memory state
+        transitions, callers should instead capture self._transition_seq
+        inline within the existing lock block that performs the transition,
+        so the seq value is captured at the same point as the state mutation.
+        For the store backend, where the state is mutated atomically by the
+        store and there is no local lock around the mutation, this helper
+        provides best-effort per-process monotonic seq.
+        """
+        with self._lock:
+            self._transition_seq += 1
+            return self._transition_seq
+
+    def _notify_failover(self, prev_state: str, new_state: str, seq: int) -> None:
         """Notify the attached failover router of a CB state transition.
 
-        Catches Exception and asyncio.CancelledError (a BaseException since
-        Python 3.8) so an observer bug or in-flight cancellation cannot break
-        CB state mutation. KeyboardInterrupt and SystemExit are re-raised so
-        user/process control signals are never silently swallowed. No-op when
-        no router is attached.
+        Any exception raised by the router is caught and logged at WARNING so
+        an observer bug or in-flight cancellation cannot break CB state
+        mutation. The catch covers Exception and other BaseException
+        subclasses including asyncio.CancelledError (a BaseException since
+        Python 3.8), GeneratorExit, and MemoryError. KeyboardInterrupt and
+        SystemExit are explicitly re-raised so user/process control signals
+        are never silently swallowed. No-op when no router is attached.
+
+        Args:
+            prev_state: CB state value (e.g. "closed", "half_open") before
+                the transition.
+            new_state: CB state value after the transition (typically "open"
+                or "closed").
+            seq: Monotonically increasing transition sequence number captured
+                under self._lock at the transition site. Lets the router
+                discard notifications that arrive out-of-order relative to
+                the actual CB state mutation order.
         """
         if self._failover is None:
             return
         try:
-            self._failover.on_cb_state_change(self.backend_name, prev_state, new_state)
+            self._failover.on_cb_state_change(self.backend_name, prev_state, new_state, seq=seq)
         except (KeyboardInterrupt, SystemExit):
             # Never swallow user/process control signals.
             raise
@@ -990,6 +1044,7 @@ class LLMCircuitBreaker:
                     "error_message": str(exc),
                     "prev_state": prev_state,
                     "new_state": new_state,
+                    "seq": seq,
                 },
                 exc_info=True,
             )

--- a/massgen/backend/llm_circuit_breaker.py
+++ b/massgen/backend/llm_circuit_breaker.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import asyncio
 import enum
+import logging
 import random
 import threading
 import time
@@ -24,6 +25,8 @@ from typing import TYPE_CHECKING, Any
 
 from ..logger_config import log_backend_activity
 from .cb_store import DEFAULT_CIRCUIT_BREAKER_STATE
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from massgen.observability.prometheus import CircuitBreakerMetrics
@@ -217,6 +220,10 @@ class LLMCircuitBreaker:
                 ``config`` so the adaptive math stays consistent with the
                 static fall-through behavior; a mismatch raises
                 ``ValueError``. When None, fixed thresholds are used.
+            failover: Optional FailoverRouter for multi-region failover routing.
+                Default None preserves existing behavior. When provided, the CB
+                notifies the router on state transitions to trigger failover or
+                recovery.
 
         Raises:
             ValueError: If ``adaptive`` is provided and its base config's
@@ -929,6 +936,22 @@ class LLMCircuitBreaker:
                                 "half_open",
                                 "open",
                             )
+                        if self._failover is not None:
+                            try:
+                                self._failover.on_cb_state_change(
+                                    self.backend_name,
+                                    "half_open",
+                                    "open",
+                                )
+                            except BaseException as exc:
+                                logger.warning(
+                                    "Failover notification failed in BaseException handler " "(store path)",
+                                    extra={
+                                        "error_type": type(exc).__name__,
+                                        "error_message": str(exc),
+                                    },
+                                    exc_info=True,
+                                )
                 else:
                     with self._lock:
                         if self._state == CircuitState.HALF_OPEN and self._half_open_probe_active:
@@ -938,13 +961,28 @@ class LLMCircuitBreaker:
                             self._open_until = time.monotonic() + self._effective_reset_time()
                             self._half_open_probe_active = False
                             self._log("Probe terminated abnormally, circuit breaker re-opened")
-                            if self._metrics is not None:
-                                _transition_args = (self.backend_name, "half_open", "open")
+                            _transition_args = (self.backend_name, "half_open", "open")
                     if _transition_args is not None and self._metrics is not None:
                         self._safe_emit(
                             self._metrics.record_state_transition,
                             *_transition_args,
                         )
+                    if _transition_args is not None and self._failover is not None:
+                        try:
+                            self._failover.on_cb_state_change(
+                                self.backend_name,
+                                _transition_args[1],
+                                "open",
+                            )
+                        except BaseException as exc:
+                            logger.warning(
+                                "Failover notification failed in BaseException handler " "(in-memory path)",
+                                extra={
+                                    "error_type": type(exc).__name__,
+                                    "error_message": str(exc),
+                                },
+                                exc_info=True,
+                            )
             raise
 
     # -- Internal helpers ---------------------------------------------------

--- a/massgen/backend/llm_circuit_breaker.py
+++ b/massgen/backend/llm_circuit_breaker.py
@@ -1003,6 +1003,15 @@ class LLMCircuitBreaker:
         For the store backend, where the state is mutated atomically by the
         store and there is no local lock around the mutation, this helper
         provides best-effort per-process monotonic seq.
+
+        Caveat: in the store branches (callers of atomic_record_failure,
+        atomic_record_success, cas_state) the seq is captured AFTER the
+        store mutation returns. Two concurrent threads can therefore order
+        their store mutations one way and their _next_seq() calls the other
+        way, producing notifications whose seq does not match store-commit
+        order. FailoverRouter mitigates this by tracking _last_seq[backend]
+        and dropping stale notifications, so the next genuine transition
+        resyncs router state with CB state.
         """
         with self._lock:
             self._transition_seq += 1

--- a/massgen/backend/llm_circuit_breaker.py
+++ b/massgen/backend/llm_circuit_breaker.py
@@ -435,8 +435,7 @@ class LLMCircuitBreaker:
                             "half_open",
                             "open",
                         )
-                    if self._failover is not None:
-                        self._failover.on_cb_state_change(self.backend_name, "half_open", "open")
+                    self._notify_failover("half_open", "open")
                 else:
                     self._log(
                         "Circuit breaker opened",
@@ -450,8 +449,7 @@ class LLMCircuitBreaker:
                             prev_label,  # now from _prev_state, never stale
                             "open",
                         )
-                    if self._failover is not None:
-                        self._failover.on_cb_state_change(self.backend_name, prev_label, "open")
+                    self._notify_failover(prev_label, "open")
             else:
                 self._log(
                     "Failure recorded",
@@ -516,8 +514,8 @@ class LLMCircuitBreaker:
                 self._metrics.record_state_transition,
                 *_transition_args,
             )
-        if _transition_args is not None and self._failover is not None:
-            self._failover.on_cb_state_change(self.backend_name, _transition_args[1], "open")
+        if _transition_args is not None:
+            self._notify_failover(_transition_args[1], "open")
 
     def record_success(self) -> None:
         """Record a successful API call. Resets failure counter and closes circuit."""
@@ -545,8 +543,7 @@ class LLMCircuitBreaker:
                         prev_state_str,
                         "closed",
                     )
-                if self._failover is not None:
-                    self._failover.on_cb_state_change(self.backend_name, prev_state_str, "closed")
+                self._notify_failover(prev_state_str, "closed")
             return
 
         _transition_args: tuple[str, str, str] | None = None
@@ -570,8 +567,8 @@ class LLMCircuitBreaker:
                 self._metrics.record_state_transition,
                 *_transition_args,
             )
-        if _transition_args is not None and self._failover is not None:
-            self._failover.on_cb_state_change(self.backend_name, _transition_args[1], "closed")
+        if _transition_args is not None:
+            self._notify_failover(_transition_args[1], "closed")
 
     def force_open(self, reason: str = "", open_for_seconds: float = 0) -> None:
         """Force the circuit to OPEN state (e.g. on 429 STOP).
@@ -635,8 +632,8 @@ class LLMCircuitBreaker:
                     prev_state_value,
                     "open",
                 )
-            if self._failover is not None and prev_state_value != CircuitState.OPEN.value:
-                self._failover.on_cb_state_change(self.backend_name, prev_state_value, "open")
+            if prev_state_value != CircuitState.OPEN.value:
+                self._notify_failover(prev_state_value, "open")
             return
 
         _transition_args: tuple[str, str, str] | None = None
@@ -666,8 +663,8 @@ class LLMCircuitBreaker:
                 self._metrics.record_state_transition,
                 *_transition_args,
             )
-        if _transition_args is not None and self._failover is not None:
-            self._failover.on_cb_state_change(self.backend_name, _transition_args[1], "open")
+        if _transition_args is not None:
+            self._notify_failover(_transition_args[1], "open")
 
     def reset(self) -> None:
         """Reset circuit breaker to initial CLOSED state.
@@ -698,8 +695,8 @@ class LLMCircuitBreaker:
                     prev_state_value,
                     "closed",
                 )
-            if self._failover is not None and prev_state_value != CircuitState.CLOSED.value:
-                self._failover.on_cb_state_change(self.backend_name, prev_state_value, "closed")
+            if prev_state_value != CircuitState.CLOSED.value:
+                self._notify_failover(prev_state_value, "closed")
             return
 
         _transition_args: tuple[str, str, str] | None = None
@@ -720,8 +717,8 @@ class LLMCircuitBreaker:
                 self._metrics.record_state_transition,
                 *_transition_args,
             )
-        if _transition_args is not None and self._failover is not None:
-            self._failover.on_cb_state_change(self.backend_name, _transition_args[1], "closed")
+        if _transition_args is not None:
+            self._notify_failover(_transition_args[1], "closed")
 
     # -- 429-aware retry wrapper --------------------------------------------
 
@@ -936,22 +933,7 @@ class LLMCircuitBreaker:
                                 "half_open",
                                 "open",
                             )
-                        if self._failover is not None:
-                            try:
-                                self._failover.on_cb_state_change(
-                                    self.backend_name,
-                                    "half_open",
-                                    "open",
-                                )
-                            except BaseException as exc:
-                                logger.warning(
-                                    "Failover notification failed in BaseException handler " "(store path)",
-                                    extra={
-                                        "error_type": type(exc).__name__,
-                                        "error_message": str(exc),
-                                    },
-                                    exc_info=True,
-                                )
+                        self._notify_failover("half_open", "open")
                 else:
                     with self._lock:
                         if self._state == CircuitState.HALF_OPEN and self._half_open_probe_active:
@@ -967,22 +949,8 @@ class LLMCircuitBreaker:
                             self._metrics.record_state_transition,
                             *_transition_args,
                         )
-                    if _transition_args is not None and self._failover is not None:
-                        try:
-                            self._failover.on_cb_state_change(
-                                self.backend_name,
-                                _transition_args[1],
-                                "open",
-                            )
-                        except BaseException as exc:
-                            logger.warning(
-                                "Failover notification failed in BaseException handler " "(in-memory path)",
-                                extra={
-                                    "error_type": type(exc).__name__,
-                                    "error_message": str(exc),
-                                },
-                                exc_info=True,
-                            )
+                    if _transition_args is not None:
+                        self._notify_failover(_transition_args[1], "open")
             raise
 
     # -- Internal helpers ---------------------------------------------------
@@ -997,6 +965,34 @@ class LLMCircuitBreaker:
             method(*args)
         except Exception:  # noqa: BLE001
             pass
+
+    def _notify_failover(self, prev_state: str, new_state: str) -> None:
+        """Notify the attached failover router of a CB state transition.
+
+        Catches Exception and asyncio.CancelledError (a BaseException since
+        Python 3.8) so an observer bug or in-flight cancellation cannot break
+        CB state mutation. KeyboardInterrupt and SystemExit are re-raised so
+        user/process control signals are never silently swallowed. No-op when
+        no router is attached.
+        """
+        if self._failover is None:
+            return
+        try:
+            self._failover.on_cb_state_change(self.backend_name, prev_state, new_state)
+        except (KeyboardInterrupt, SystemExit):
+            # Never swallow user/process control signals.
+            raise
+        except BaseException as exc:  # noqa: BLE001 -- never let observer break CB
+            logger.warning(
+                "Failover notification failed",
+                extra={
+                    "error_type": type(exc).__name__,
+                    "error_message": str(exc),
+                    "prev_state": prev_state,
+                    "new_state": new_state,
+                },
+                exc_info=True,
+            )
 
     def _log(self, message: str, **details: Any) -> None:
         """Log via structured backend activity logger."""

--- a/massgen/backend/llm_circuit_breaker.py
+++ b/massgen/backend/llm_circuit_breaker.py
@@ -29,6 +29,7 @@ if TYPE_CHECKING:
     from massgen.observability.prometheus import CircuitBreakerMetrics
 
     from .cb_adaptive import AdaptiveController
+    from .cb_failover import FailoverRouter
 
 # ---------------------------------------------------------------------------
 # 429 classification
@@ -197,6 +198,7 @@ class LLMCircuitBreaker:
         metrics: CircuitBreakerMetrics | None = None,
         store: Any = None,
         adaptive: AdaptiveController | None = None,
+        failover: FailoverRouter | None = None,
     ) -> None:
         """Initialize the LLM circuit breaker.
 
@@ -239,6 +241,7 @@ class LLMCircuitBreaker:
                     f"reset_time_seconds={self.config.reset_time_seconds}).",
                 )
         self._adaptive: AdaptiveController | None = adaptive
+        self._failover: FailoverRouter | None = failover
         self._lock = threading.Lock()
 
         # State
@@ -425,6 +428,8 @@ class LLMCircuitBreaker:
                             "half_open",
                             "open",
                         )
+                    if self._failover is not None:
+                        self._failover.on_cb_state_change(self.backend_name, "half_open", "open")
                 else:
                     self._log(
                         "Circuit breaker opened",
@@ -438,6 +443,8 @@ class LLMCircuitBreaker:
                             prev_label,  # now from _prev_state, never stale
                             "open",
                         )
+                    if self._failover is not None:
+                        self._failover.on_cb_state_change(self.backend_name, prev_label, "open")
             else:
                 self._log(
                     "Failure recorded",
@@ -465,8 +472,7 @@ class LLMCircuitBreaker:
                     failure_count=self._failure_count,
                     error_type=error_type,
                 )
-                if self._metrics is not None:
-                    _transition_args = (self.backend_name, "half_open", "open")
+                _transition_args = (self.backend_name, "half_open", "open")
 
             elif self._failure_count >= effective_max:
                 if prev_state == CircuitState.OPEN:
@@ -489,8 +495,7 @@ class LLMCircuitBreaker:
                         failure_count=self._failure_count,
                         error_type=error_type,
                     )
-                    if self._metrics is not None:
-                        _transition_args = (self.backend_name, prev_state.value, "open")
+                    _transition_args = (self.backend_name, prev_state.value, "open")
             else:
                 self._log(
                     "Failure recorded",
@@ -504,6 +509,8 @@ class LLMCircuitBreaker:
                 self._metrics.record_state_transition,
                 *_transition_args,
             )
+        if _transition_args is not None and self._failover is not None:
+            self._failover.on_cb_state_change(self.backend_name, _transition_args[1], "open")
 
     def record_success(self) -> None:
         """Record a successful API call. Resets failure counter and closes circuit."""
@@ -531,6 +538,8 @@ class LLMCircuitBreaker:
                         prev_state_str,
                         "closed",
                     )
+                if self._failover is not None:
+                    self._failover.on_cb_state_change(self.backend_name, prev_state_str, "closed")
             return
 
         _transition_args: tuple[str, str, str] | None = None
@@ -547,14 +556,15 @@ class LLMCircuitBreaker:
                     "Circuit breaker closed after success",
                     previous_state=prev_state.value,
                 )
-                if self._metrics is not None:
-                    _transition_args = (self.backend_name, prev_state.value, "closed")
+                _transition_args = (self.backend_name, prev_state.value, "closed")
 
         if _transition_args is not None and self._metrics is not None:
             self._safe_emit(
                 self._metrics.record_state_transition,
                 *_transition_args,
             )
+        if _transition_args is not None and self._failover is not None:
+            self._failover.on_cb_state_change(self.backend_name, _transition_args[1], "closed")
 
     def force_open(self, reason: str = "", open_for_seconds: float = 0) -> None:
         """Force the circuit to OPEN state (e.g. on 429 STOP).
@@ -618,6 +628,8 @@ class LLMCircuitBreaker:
                     prev_state_value,
                     "open",
                 )
+            if self._failover is not None and prev_state_value != CircuitState.OPEN.value:
+                self._failover.on_cb_state_change(self.backend_name, prev_state_value, "open")
             return
 
         _transition_args: tuple[str, str, str] | None = None
@@ -639,7 +651,7 @@ class LLMCircuitBreaker:
             if self._adaptive is not None and prev_state != CircuitState.OPEN:
                 self._adaptive.record_open()
             self._log(f"Circuit breaker force-opened: {reason}", open_for_seconds=duration)
-            if self._metrics is not None and prev_state != CircuitState.OPEN:
+            if prev_state != CircuitState.OPEN:
                 _transition_args = (self.backend_name, prev_state.value, "open")
 
         if _transition_args is not None and self._metrics is not None:
@@ -647,6 +659,8 @@ class LLMCircuitBreaker:
                 self._metrics.record_state_transition,
                 *_transition_args,
             )
+        if _transition_args is not None and self._failover is not None:
+            self._failover.on_cb_state_change(self.backend_name, _transition_args[1], "open")
 
     def reset(self) -> None:
         """Reset circuit breaker to initial CLOSED state.
@@ -677,6 +691,8 @@ class LLMCircuitBreaker:
                     prev_state_value,
                     "closed",
                 )
+            if self._failover is not None and prev_state_value != CircuitState.CLOSED.value:
+                self._failover.on_cb_state_change(self.backend_name, prev_state_value, "closed")
             return
 
         _transition_args: tuple[str, str, str] | None = None
@@ -689,7 +705,7 @@ class LLMCircuitBreaker:
             self._half_open_probe_active = False
             if self._adaptive is not None:
                 self._adaptive.reset_open_timer()
-            if self._metrics is not None and prev_state != CircuitState.CLOSED:
+            if prev_state != CircuitState.CLOSED:
                 _transition_args = (self.backend_name, prev_state.value, "closed")
 
         if _transition_args is not None and self._metrics is not None:
@@ -697,6 +713,8 @@ class LLMCircuitBreaker:
                 self._metrics.record_state_transition,
                 *_transition_args,
             )
+        if _transition_args is not None and self._failover is not None:
+            self._failover.on_cb_state_change(self.backend_name, _transition_args[1], "closed")
 
     # -- 429-aware retry wrapper --------------------------------------------
 
@@ -978,6 +996,11 @@ class LLMCircuitBreaker:
     def adaptive(self) -> AdaptiveController | None:
         """The AdaptiveController, if one was attached."""
         return self._adaptive
+
+    @property
+    def failover(self) -> FailoverRouter | None:
+        """The FailoverRouter, if one was attached."""
+        return self._failover
 
     def __repr__(self) -> str:
         if self._store is not None:

--- a/massgen/tests/test_cb_failover.py
+++ b/massgen/tests/test_cb_failover.py
@@ -44,7 +44,7 @@ def cb_config() -> LLMCircuitBreakerConfig:
 
 
 # ---------------------------------------------------------------------------
-# Category A: FailoverConfig validation (10 tests)
+# Category A: FailoverConfig validation (11 tests)
 # ---------------------------------------------------------------------------
 
 
@@ -105,6 +105,25 @@ class TestFailoverConfigValidation:
         )
         assert len(cfg.regions["gpt-5.4"]) == 3
 
+    def test_post_construction_mutation_rejected(self) -> None:
+        """Frozen dataclass + tuple-ized + MappingProxyType regions must reject all post-construction mutation."""
+        cfg = FailoverConfig(
+            enabled=True,
+            regions={"gpt-5.4": ["us-east", "eu-west"]},
+        )
+        # Field assignment on frozen dataclass.
+        with pytest.raises((AttributeError, Exception), match="(?i)frozen|cannot assign"):
+            cfg.enabled = False  # type: ignore[misc]
+        # Inner per-backend list is a tuple -- no append.
+        with pytest.raises(AttributeError):
+            cfg.regions["gpt-5.4"].append("ap-southeast")  # type: ignore[attr-defined]
+        # Outer mapping is MappingProxyType -- no item assignment.
+        with pytest.raises(TypeError):
+            cfg.regions["new-backend"] = ("a", "b")  # type: ignore[index]
+        # Outer mapping has no del either.
+        with pytest.raises(TypeError):
+            del cfg.regions["gpt-5.4"]  # type: ignore[misc]
+
 
 # ---------------------------------------------------------------------------
 # Category B: Failover trigger (7 tests)
@@ -163,7 +182,10 @@ class TestFailoverTrigger:
         elapsed = time.monotonic() - start
 
         # Two secondaries x 0.05s timeout => bounded above by ~0.5s with thread overhead.
-        assert elapsed < 1.0, f"on_cb_state_change should complete near timeout, took {elapsed:.2f}s"
+        # Bound is generous (>= ~6x theoretical max) so slow CI runners
+        # don't flake. The probe sleeps 5.0s, so any value < 5.0 still
+        # proves the timeout fired and the caller was unblocked early.
+        assert elapsed < 2.0, f"on_cb_state_change should complete near timeout, took {elapsed:.2f}s"
         assert not router.is_failed_over("gpt-5.4")
         # The pending flag must be cleared so a subsequent OPEN can retry.
         assert router._failover_pending.get("gpt-5.4", False) is False
@@ -564,7 +586,7 @@ class TestLLMCBIntegration:
 
 
 # ---------------------------------------------------------------------------
-# Category F: Concurrency (4 tests)
+# Category F: Concurrency (5 tests)
 # ---------------------------------------------------------------------------
 
 
@@ -671,6 +693,67 @@ class TestConcurrency:
         assert not thread.is_alive()
         assert not router.is_failed_over("gpt-5.4")
         assert router.get_active_region("gpt-5.4") == "us-east"
+
+    def test_reset_then_concurrent_new_open_does_not_lose_new_failover(
+        self,
+        simple_config: FailoverConfig,
+    ) -> None:
+        """T1 probing + admin reset() + T2 new OPEN must not let T1 wipe T2's claim or commit under T2's slot.
+
+        Without per-claim generation tokens, T1's terminal finally could clear
+        _failover_pending after T2 already re-claimed it, silently dropping
+        T2's failover. Or T1's late successful probe could commit T1's region
+        choice under T2's pending claim.
+        """
+        probe_started = threading.Event()
+        t1_probe_release = threading.Event()
+        t2_probe_release = threading.Event()
+        probe_call = [0]
+
+        def slow_probe(_region: str) -> bool:
+            probe_call[0] += 1
+            n = probe_call[0]
+            if n == 1:
+                probe_started.set()
+                assert t1_probe_release.wait(timeout=2.0)
+                return True  # T1 probe succeeds late.
+            # T2's probe -- release immediately when signalled.
+            assert t2_probe_release.wait(timeout=2.0)
+            return True
+
+        router = FailoverRouter(simple_config, health_probe=slow_probe)
+        t1 = threading.Thread(
+            target=router.on_cb_state_change,
+            args=("gpt-5.4", "closed", "open"),
+            kwargs={"seq": 1},
+        )
+        t1.start()
+        assert probe_started.wait(timeout=2.0)
+
+        # Admin reset -- bumps probe generation, clears pending + last_seq.
+        router.reset("gpt-5.4")
+
+        # T2 starts a fresh OPEN. seq=1 is fine because reset() cleared _last_seq.
+        t2 = threading.Thread(
+            target=router.on_cb_state_change,
+            args=("gpt-5.4", "closed", "open"),
+            kwargs={"seq": 1},
+        )
+        t2.start()
+
+        # Let both probes complete. T2 first so it can claim and commit, then
+        # T1 so its late commit attempt sees the generation mismatch.
+        t2_probe_release.set()
+        t1_probe_release.set()
+        t1.join(timeout=2.0)
+        t2.join(timeout=2.0)
+
+        assert not t1.is_alive()
+        assert not t2.is_alive()
+        # T2's failover must stand. T1's late commit must not have wiped it
+        # via the finally cleanup or overridden the active region.
+        assert router.is_failed_over("gpt-5.4")
+        assert router.get_active_region("gpt-5.4") == "eu-west"
 
     def test_closed_during_inflight_probe_aborts_failover(
         self,
@@ -800,15 +883,17 @@ class TestAdversarial:
         assert isinstance(entry2["failover_at"], float)
         assert entry2["active_region"] == "eu-west"
 
-    def test_no_secondary_configured_logs_warning_no_crash(self) -> None:
-        """Backend with only one region (no secondary) must not raise on OPEN."""
+    def test_no_secondary_configured_logs_warning_no_crash(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Backend with only one region (no secondary) must log WARNING and not raise on OPEN."""
         cfg = FailoverConfig(
             enabled=True,
             regions={"gpt-5.4": ["us-east"]},  # no secondary
         )
         router = FailoverRouter(cfg, health_probe=lambda _r: True)
-        router.on_cb_state_change("gpt-5.4", "closed", "open", seq=1)
+        with caplog.at_level("WARNING", logger="massgen.backend.cb_failover"):
+            router.on_cb_state_change("gpt-5.4", "closed", "open", seq=1)
         assert not router.is_failed_over("gpt-5.4")
+        assert any("no secondary region configured" in rec.message for rec in caplog.records)
 
 
 # ---------------------------------------------------------------------------

--- a/massgen/tests/test_cb_failover.py
+++ b/massgen/tests/test_cb_failover.py
@@ -1,0 +1,496 @@
+"""Tests for Phase 6 FailoverRouter (cb_failover.py)."""
+
+from __future__ import annotations
+
+import threading
+import time
+import unittest.mock
+
+import pytest
+
+from massgen.backend.cb_failover import FailoverConfig, FailoverRouter
+from massgen.backend.llm_circuit_breaker import (
+    CircuitState,
+    LLMCircuitBreaker,
+    LLMCircuitBreakerConfig,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def simple_config() -> FailoverConfig:
+    return FailoverConfig(
+        enabled=True,
+        regions={"gpt-5.4": ["us-east", "eu-west"]},
+        min_failover_duration_seconds=30.0,
+    )
+
+
+@pytest.fixture
+def router(simple_config: FailoverConfig) -> FailoverRouter:
+    return FailoverRouter(simple_config)
+
+
+@pytest.fixture
+def cb_config() -> LLMCircuitBreakerConfig:
+    return LLMCircuitBreakerConfig(enabled=True, max_failures=3, reset_time_seconds=60)
+
+
+# ---------------------------------------------------------------------------
+# Category A: FailoverConfig validation (6 tests)
+# ---------------------------------------------------------------------------
+
+
+class TestFailoverConfigValidation:
+    def test_defaults_valid(self) -> None:
+        """Default constructor must succeed -- enabled=False, empty regions."""
+        cfg = FailoverConfig()
+        assert cfg.enabled is False
+        assert cfg.regions == {}
+
+    def test_zero_health_check_timeout_rejects(self) -> None:
+        """health_check_timeout_seconds=0 must raise ValueError."""
+        with pytest.raises(ValueError, match="health_check_timeout_seconds"):
+            FailoverConfig(enabled=True, health_check_timeout_seconds=0)
+
+    def test_negative_min_failover_duration_rejects(self) -> None:
+        """min_failover_duration_seconds=-1 must raise ValueError."""
+        with pytest.raises(ValueError, match="min_failover_duration_seconds"):
+            FailoverConfig(enabled=True, min_failover_duration_seconds=-1.0)
+
+    def test_zero_recovery_check_interval_rejects(self) -> None:
+        """recovery_check_interval_seconds=0 must raise ValueError."""
+        with pytest.raises(ValueError, match="recovery_check_interval_seconds"):
+            FailoverConfig(enabled=True, recovery_check_interval_seconds=0)
+
+    def test_duplicate_region_in_list_rejects(self) -> None:
+        """Duplicate region strings within one backend must raise ValueError."""
+        with pytest.raises(ValueError, match="duplicate"):
+            FailoverConfig(enabled=True, regions={"gpt-5.4": ["us-east", "us-east"]})
+
+    def test_empty_region_string_rejects(self) -> None:
+        """An empty string in the regions list must raise ValueError."""
+        with pytest.raises(ValueError, match="invalid region"):
+            FailoverConfig(enabled=True, regions={"gpt-5.4": ["us-east", ""]})
+
+    def test_empty_region_list_rejects(self) -> None:
+        """An empty list for a backend must raise ValueError."""
+        with pytest.raises(ValueError, match="non-empty list"):
+            FailoverConfig(enabled=True, regions={"gpt-5.4": []})
+
+    def test_valid_multiregion_config_accepted(self) -> None:
+        """Three distinct regions must not raise."""
+        cfg = FailoverConfig(
+            enabled=True,
+            regions={"gpt-5.4": ["us-east", "eu-west", "ap-southeast"]},
+        )
+        assert len(cfg.regions["gpt-5.4"]) == 3
+
+
+# ---------------------------------------------------------------------------
+# Category B: Failover trigger (6 tests)
+# ---------------------------------------------------------------------------
+
+
+class TestFailoverTrigger:
+    def test_open_with_healthy_probe_commits_failover(self, simple_config: FailoverConfig) -> None:
+        """on_cb_state_change("open") with probe returning True must failover."""
+        router = FailoverRouter(simple_config, health_probe=lambda _r: True)
+        assert not router.is_failed_over("gpt-5.4")
+        router.on_cb_state_change("gpt-5.4", "closed", "open")
+        assert router.is_failed_over("gpt-5.4")
+
+    def test_open_with_failing_probe_stays_on_primary(self, simple_config: FailoverConfig) -> None:
+        """on_cb_state_change("open") with probe returning False must not failover."""
+        router = FailoverRouter(simple_config, health_probe=lambda _r: False)
+        router.on_cb_state_change("gpt-5.4", "closed", "open")
+        assert not router.is_failed_over("gpt-5.4")
+
+    def test_open_with_probe_raising_stays_on_primary(self, simple_config: FailoverConfig) -> None:
+        """Probe that raises must be swallowed; no failover committed."""
+        def raising_probe(_region: str) -> bool:
+            raise RuntimeError("network error")
+
+        router = FailoverRouter(simple_config, health_probe=raising_probe)
+        router.on_cb_state_change("gpt-5.4", "closed", "open")
+        assert not router.is_failed_over("gpt-5.4")
+
+    def test_get_active_region_returns_secondary_after_failover(self, simple_config: FailoverConfig) -> None:
+        """get_active_region must return the secondary region after failover."""
+        router = FailoverRouter(simple_config, health_probe=lambda _r: True)
+        router.on_cb_state_change("gpt-5.4", "closed", "open")
+        active = router.get_active_region("gpt-5.4")
+        assert active == "eu-west"
+
+    def test_get_active_region_returns_none_for_unknown_backend(self, simple_config: FailoverConfig) -> None:
+        """get_active_region returns None for a backend not in config.regions."""
+        router = FailoverRouter(simple_config)
+        assert router.get_active_region("unknown-backend") is None
+
+    def test_enabled_false_makes_all_methods_noop(self) -> None:
+        """FailoverConfig(enabled=False) must make get_active_region/is_failed_over/on_cb_state_change all no-ops."""
+        cfg = FailoverConfig(enabled=False, regions={"gpt-5.4": ["us-east", "eu-west"]})
+        router = FailoverRouter(cfg, health_probe=lambda _r: True)
+        router.on_cb_state_change("gpt-5.4", "closed", "open")
+        assert not router.is_failed_over("gpt-5.4")
+        assert router.get_active_region("gpt-5.4") is None
+
+
+# ---------------------------------------------------------------------------
+# Category C: Recovery (4 tests)
+# ---------------------------------------------------------------------------
+
+
+class TestRecovery:
+    def test_closed_after_min_duration_restores_primary(self, simple_config: FailoverConfig) -> None:
+        """on_cb_state_change("closed") after min_failover_duration elapsed must restore primary."""
+        clock_values = [0.0, 31.0]
+        call_count = [0]
+
+        def fake_clock() -> float:
+            v = clock_values[min(call_count[0], len(clock_values) - 1)]
+            call_count[0] += 1
+            return v
+
+        cfg = FailoverConfig(
+            enabled=True,
+            regions={"gpt-5.4": ["us-east", "eu-west"]},
+            min_failover_duration_seconds=30.0,
+        )
+        router = FailoverRouter(cfg, clock=fake_clock, health_probe=lambda _r: True)
+        router.on_cb_state_change("gpt-5.4", "closed", "open")
+        assert router.is_failed_over("gpt-5.4")
+
+        router.on_cb_state_change("gpt-5.4", "open", "closed")
+        assert not router.is_failed_over("gpt-5.4")
+        assert router.get_active_region("gpt-5.4") == "us-east"
+
+    def test_closed_before_min_duration_defers_recovery(self, simple_config: FailoverConfig) -> None:
+        """on_cb_state_change("closed") before min duration elapsed must keep secondary."""
+        clock_values = [0.0, 5.0]  # only 5s elapsed, min is 30s
+        call_count = [0]
+
+        def fake_clock() -> float:
+            v = clock_values[min(call_count[0], len(clock_values) - 1)]
+            call_count[0] += 1
+            return v
+
+        cfg = FailoverConfig(
+            enabled=True,
+            regions={"gpt-5.4": ["us-east", "eu-west"]},
+            min_failover_duration_seconds=30.0,
+        )
+        router = FailoverRouter(cfg, clock=fake_clock, health_probe=lambda _r: True)
+        router.on_cb_state_change("gpt-5.4", "closed", "open")
+        assert router.is_failed_over("gpt-5.4")
+
+        router.on_cb_state_change("gpt-5.4", "open", "closed")
+        # Too soon -- must remain failed over
+        assert router.is_failed_over("gpt-5.4")
+        assert router.get_active_region("gpt-5.4") == "eu-west"
+
+    def test_reset_admin_restores_primary_immediately(self, simple_config: FailoverConfig) -> None:
+        """reset() must restore primary regardless of min_failover_duration."""
+        router = FailoverRouter(simple_config, health_probe=lambda _r: True)
+        router.on_cb_state_change("gpt-5.4", "closed", "open")
+        assert router.is_failed_over("gpt-5.4")
+
+        router.reset("gpt-5.4")
+        assert not router.is_failed_over("gpt-5.4")
+        assert router.get_active_region("gpt-5.4") == "us-east"
+
+    def test_closed_when_not_failed_over_is_noop(self, simple_config: FailoverConfig) -> None:
+        """on_cb_state_change("closed") when not failed over must not crash."""
+        router = FailoverRouter(simple_config)
+        router.on_cb_state_change("gpt-5.4", "open", "closed")  # must not raise
+        assert not router.is_failed_over("gpt-5.4")
+
+
+# ---------------------------------------------------------------------------
+# Category D: Multi-backend isolation (2 tests)
+# ---------------------------------------------------------------------------
+
+
+class TestMultiBackendIsolation:
+    def test_failover_for_one_backend_does_not_affect_another(self) -> None:
+        """Failover for backend A must not change the active region of backend B."""
+        cfg = FailoverConfig(
+            enabled=True,
+            regions={
+                "backend-a": ["us-east", "eu-west"],
+                "backend-b": ["ap-southeast", "us-west"],
+            },
+        )
+        router = FailoverRouter(cfg, health_probe=lambda _r: True)
+        router.on_cb_state_change("backend-a", "closed", "open")
+        assert router.is_failed_over("backend-a")
+        assert not router.is_failed_over("backend-b")
+        assert router.get_active_region("backend-b") == "ap-southeast"
+
+    def test_snapshot_reports_all_configured_backends(self) -> None:
+        """snapshot() must include an entry for every backend in config.regions."""
+        cfg = FailoverConfig(
+            enabled=True,
+            regions={
+                "backend-a": ["us-east", "eu-west"],
+                "backend-b": ["ap-southeast"],
+            },
+        )
+        router = FailoverRouter(cfg, health_probe=lambda _r: True)
+        snap = router.snapshot()
+        assert "backends" in snap
+        assert "backend-a" in snap["backends"]
+        assert "backend-b" in snap["backends"]
+        assert snap["backends"]["backend-a"]["active_region"] == "us-east"
+        assert snap["backends"]["backend-b"]["failed_over"] is False
+
+
+# ---------------------------------------------------------------------------
+# Category E: LLM CB integration (4 tests)
+# ---------------------------------------------------------------------------
+
+
+class TestLLMCBIntegration:
+    def test_llm_cb_failover_none_is_back_compat(self, cb_config: LLMCircuitBreakerConfig) -> None:
+        """LLMCircuitBreaker(failover=None) must behave identically to pre-Phase 6."""
+        cb = LLMCircuitBreaker(cb_config, failover=None)
+        assert cb.failover is None
+        cb.record_failure()
+        assert cb.failure_count == 1
+
+    def test_record_failure_to_open_calls_on_cb_state_change(
+        self, cb_config: LLMCircuitBreakerConfig, simple_config: FailoverConfig
+    ) -> None:
+        """When CB transitions CLOSED -> OPEN via record_failure, on_cb_state_change must be called."""
+        router = FailoverRouter(simple_config, health_probe=lambda _r: True)
+        cb = LLMCircuitBreaker(cb_config, backend_name="gpt-5.4", failover=router)
+        for _ in range(cb_config.max_failures):
+            cb.record_failure()
+        assert cb.state == CircuitState.OPEN
+        assert router.is_failed_over("gpt-5.4")
+
+    def test_record_success_from_half_open_triggers_closed_notification(
+        self, cb_config: LLMCircuitBreakerConfig, simple_config: FailoverConfig
+    ) -> None:
+        """HALF_OPEN -> CLOSED via record_success must notify router of 'closed'."""
+        clock_values = [0.0, 31.0]
+        call_count = [0]
+
+        def fake_clock() -> float:
+            v = clock_values[min(call_count[0], len(clock_values) - 1)]
+            call_count[0] += 1
+            return v
+
+        cfg = FailoverConfig(
+            enabled=True,
+            regions={"gpt-5.4": ["us-east", "eu-west"]},
+            min_failover_duration_seconds=30.0,
+        )
+        router = FailoverRouter(cfg, clock=fake_clock, health_probe=lambda _r: True)
+        cb = LLMCircuitBreaker(cb_config, backend_name="gpt-5.4", failover=router)
+
+        # Drive to OPEN -> failover committed
+        for _ in range(cb_config.max_failures):
+            cb.record_failure()
+        assert router.is_failed_over("gpt-5.4")
+
+        # Manually set HALF_OPEN
+        with cb._lock:
+            cb._state = CircuitState.HALF_OPEN
+            cb._half_open_probe_active = False
+
+        # record_success: HALF_OPEN -> CLOSED, router should restore primary
+        cb.record_success()
+        assert cb.state == CircuitState.CLOSED
+        assert not router.is_failed_over("gpt-5.4")
+
+    def test_force_open_notifies_router(
+        self, cb_config: LLMCircuitBreakerConfig, simple_config: FailoverConfig
+    ) -> None:
+        """force_open must call on_cb_state_change('open') on the router."""
+        router = FailoverRouter(simple_config, health_probe=lambda _r: True)
+        cb = LLMCircuitBreaker(cb_config, backend_name="gpt-5.4", failover=router)
+        cb.force_open(reason="test")
+        assert router.is_failed_over("gpt-5.4")
+
+
+# ---------------------------------------------------------------------------
+# Category F: Concurrency (2 tests)
+# ---------------------------------------------------------------------------
+
+
+class TestConcurrency:
+    def test_concurrent_open_events_commit_exactly_one_failover(
+        self, simple_config: FailoverConfig
+    ) -> None:
+        """8 threads calling on_cb_state_change("open") simultaneously must yield exactly one failover."""
+        probe_call_count = [0]
+        probe_lock = threading.Lock()
+
+        def counting_probe(_region: str) -> bool:
+            with probe_lock:
+                probe_call_count[0] += 1
+            return True
+
+        router = FailoverRouter(simple_config, health_probe=counting_probe)
+        barrier = threading.Barrier(8)
+        errors: list[Exception] = []
+
+        def worker() -> None:
+            try:
+                barrier.wait()
+                router.on_cb_state_change("gpt-5.4", "closed", "open")
+            except Exception as exc:  # noqa: BLE001
+                errors.append(exc)
+
+        threads = [threading.Thread(target=worker) for _ in range(8)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert not errors, f"Thread errors: {errors}"
+        # Exactly one failover committed (subsequent calls are idempotent)
+        assert router.is_failed_over("gpt-5.4")
+        assert router.get_active_region("gpt-5.4") == "eu-west"
+
+    def test_concurrent_get_and_set_does_not_corrupt_state(
+        self, simple_config: FailoverConfig
+    ) -> None:
+        """Concurrent get_active_region + on_cb_state_change must not raise or corrupt state."""
+        router = FailoverRouter(simple_config, health_probe=lambda _r: True)
+        errors: list[Exception] = []
+        stop = threading.Event()
+
+        def reader() -> None:
+            try:
+                for _ in range(500):
+                    region = router.get_active_region("gpt-5.4")
+                    assert region in (None, "us-east", "eu-west"), f"Unexpected: {region}"
+            except Exception as exc:  # noqa: BLE001
+                errors.append(exc)
+
+        def writer() -> None:
+            try:
+                for i in range(50):
+                    if i % 2 == 0:
+                        router.on_cb_state_change("gpt-5.4", "closed", "open")
+                    else:
+                        router.reset("gpt-5.4")
+            except Exception as exc:  # noqa: BLE001
+                errors.append(exc)
+
+        threads = [threading.Thread(target=reader) for _ in range(4)]
+        threads.append(threading.Thread(target=writer))
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert not errors, f"Concurrent errors: {errors}"
+
+
+# ---------------------------------------------------------------------------
+# Category G: Adversarial (4 tests)
+# ---------------------------------------------------------------------------
+
+
+class TestAdversarial:
+    def test_on_cb_state_change_unknown_old_state_does_not_crash(
+        self, simple_config: FailoverConfig
+    ) -> None:
+        """on_cb_state_change with a garbage old_state must not raise."""
+        router = FailoverRouter(simple_config, health_probe=lambda _r: True)
+        router.on_cb_state_change("gpt-5.4", "totally_invalid_state", "open")
+        # Should have committed failover normally
+        assert router.is_failed_over("gpt-5.4")
+
+    def test_probe_raises_arbitrary_exception_no_crash(
+        self, simple_config: FailoverConfig
+    ) -> None:
+        """health_probe that raises ValueError must be caught; no failover."""
+        def evil_probe(_region: str) -> bool:
+            raise ValueError("bad region")
+
+        router = FailoverRouter(simple_config, health_probe=evil_probe)
+        router.on_cb_state_change("gpt-5.4", "closed", "open")
+        assert not router.is_failed_over("gpt-5.4")
+
+    def test_clock_backward_skew_does_not_cause_premature_recovery(
+        self, simple_config: FailoverConfig
+    ) -> None:
+        """If clock goes backward after failover, recovery must not trigger prematurely."""
+        # failover at t=100, close at t=90 (skew): elapsed = 90-100 = -10 (clamped to 0 via sign)
+        # 0 < 30 (min_duration), so should NOT restore
+        clock_values = [100.0, 90.0]
+        call_count = [0]
+
+        def fake_clock() -> float:
+            v = clock_values[min(call_count[0], len(clock_values) - 1)]
+            call_count[0] += 1
+            return v
+
+        cfg = FailoverConfig(
+            enabled=True,
+            regions={"gpt-5.4": ["us-east", "eu-west"]},
+            min_failover_duration_seconds=30.0,
+        )
+        router = FailoverRouter(cfg, clock=fake_clock, health_probe=lambda _r: True)
+        router.on_cb_state_change("gpt-5.4", "closed", "open")
+        assert router.is_failed_over("gpt-5.4")
+
+        router.on_cb_state_change("gpt-5.4", "open", "closed")
+        # elapsed = 90-100 = -10 < 30 -- must stay failed over
+        assert router.is_failed_over("gpt-5.4")
+
+    def test_second_open_when_already_failed_over_is_idempotent(
+        self, simple_config: FailoverConfig
+    ) -> None:
+        """on_cb_state_change("open") while already failed over must not double-failover."""
+        probe_count = [0]
+
+        def counting_probe(_region: str) -> bool:
+            probe_count[0] += 1
+            return True
+
+        router = FailoverRouter(simple_config, health_probe=counting_probe)
+        router.on_cb_state_change("gpt-5.4", "closed", "open")
+        first_probe_count = probe_count[0]
+
+        # Second open event while already on secondary
+        router.on_cb_state_change("gpt-5.4", "closed", "open")
+        assert probe_count[0] == first_probe_count, "Probe called again despite already failed over"
+        assert router.get_active_region("gpt-5.4") == "eu-west"
+
+    def test_snapshot_is_point_in_time_consistent(self, simple_config: FailoverConfig) -> None:
+        """snapshot() must return a dict with expected structure for all backends."""
+        router = FailoverRouter(simple_config, health_probe=lambda _r: True)
+        snap = router.snapshot()
+        assert "backends" in snap
+        entry = snap["backends"]["gpt-5.4"]
+        assert "active_region" in entry
+        assert "failed_over" in entry
+        assert "failover_at" in entry
+        assert entry["failed_over"] is False
+        assert entry["failover_at"] is None
+
+        router.on_cb_state_change("gpt-5.4", "closed", "open")
+        snap2 = router.snapshot()
+        entry2 = snap2["backends"]["gpt-5.4"]
+        assert entry2["failed_over"] is True
+        assert isinstance(entry2["failover_at"], float)
+        assert entry2["active_region"] == "eu-west"
+
+    def test_no_secondary_configured_logs_warning_no_crash(self) -> None:
+        """Backend with only one region (no secondary) must not raise on OPEN."""
+        cfg = FailoverConfig(
+            enabled=True,
+            regions={"gpt-5.4": ["us-east"]},  # no secondary
+        )
+        router = FailoverRouter(cfg, health_probe=lambda _r: True)
+        router.on_cb_state_change("gpt-5.4", "closed", "open")
+        assert not router.is_failed_over("gpt-5.4")

--- a/massgen/tests/test_cb_failover.py
+++ b/massgen/tests/test_cb_failover.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
+import asyncio
 import threading
-import time
 import unittest.mock
 
 import pytest
@@ -14,7 +14,6 @@ from massgen.backend.llm_circuit_breaker import (
     LLMCircuitBreaker,
     LLMCircuitBreakerConfig,
 )
-
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -41,7 +40,7 @@ def cb_config() -> LLMCircuitBreakerConfig:
 
 
 # ---------------------------------------------------------------------------
-# Category A: FailoverConfig validation (6 tests)
+# Category A: FailoverConfig validation (10 tests)
 # ---------------------------------------------------------------------------
 
 
@@ -76,6 +75,16 @@ class TestFailoverConfigValidation:
         """An empty string in the regions list must raise ValueError."""
         with pytest.raises(ValueError, match="invalid region"):
             FailoverConfig(enabled=True, regions={"gpt-5.4": ["us-east", ""]})
+
+    def test_whitespace_region_rejected(self) -> None:
+        """Whitespace-only region names must raise ValueError."""
+        with pytest.raises(ValueError, match="invalid region"):
+            FailoverConfig(enabled=True, regions={"x": ["primary", "  "]})
+
+    def test_whitespace_backend_rejected(self) -> None:
+        """Whitespace-only backend names must raise ValueError."""
+        with pytest.raises(ValueError, match="non-empty strings"):
+            FailoverConfig(enabled=True, regions={"  ": ["p", "s"]})
 
     def test_empty_region_list_rejects(self) -> None:
         """An empty list for a backend must raise ValueError."""
@@ -112,6 +121,7 @@ class TestFailoverTrigger:
 
     def test_open_with_probe_raising_stays_on_primary(self, simple_config: FailoverConfig) -> None:
         """Probe that raises must be swallowed; no failover committed."""
+
         def raising_probe(_region: str) -> bool:
             raise RuntimeError("network error")
 
@@ -141,20 +151,17 @@ class TestFailoverTrigger:
 
 
 # ---------------------------------------------------------------------------
-# Category C: Recovery (4 tests)
+# Category C: Recovery (12 tests)
 # ---------------------------------------------------------------------------
 
 
 class TestRecovery:
     def test_closed_after_min_duration_restores_primary(self, simple_config: FailoverConfig) -> None:
         """on_cb_state_change("closed") after min_failover_duration elapsed must restore primary."""
-        clock_values = [0.0, 31.0]
-        call_count = [0]
+        now = [0.0]
 
         def fake_clock() -> float:
-            v = clock_values[min(call_count[0], len(clock_values) - 1)]
-            call_count[0] += 1
-            return v
+            return now[0]
 
         cfg = FailoverConfig(
             enabled=True,
@@ -165,19 +172,17 @@ class TestRecovery:
         router.on_cb_state_change("gpt-5.4", "closed", "open")
         assert router.is_failed_over("gpt-5.4")
 
+        now[0] = 31.0
         router.on_cb_state_change("gpt-5.4", "open", "closed")
         assert not router.is_failed_over("gpt-5.4")
         assert router.get_active_region("gpt-5.4") == "us-east"
 
     def test_closed_before_min_duration_defers_recovery(self, simple_config: FailoverConfig) -> None:
         """on_cb_state_change("closed") before min duration elapsed must keep secondary."""
-        clock_values = [0.0, 5.0]  # only 5s elapsed, min is 30s
-        call_count = [0]
+        now = [0.0]
 
         def fake_clock() -> float:
-            v = clock_values[min(call_count[0], len(clock_values) - 1)]
-            call_count[0] += 1
-            return v
+            return now[0]
 
         cfg = FailoverConfig(
             enabled=True,
@@ -188,10 +193,180 @@ class TestRecovery:
         router.on_cb_state_change("gpt-5.4", "closed", "open")
         assert router.is_failed_over("gpt-5.4")
 
+        now[0] = 5.0  # only 5s elapsed, min is 30s
         router.on_cb_state_change("gpt-5.4", "open", "closed")
         # Too soon -- must remain failed over
         assert router.is_failed_over("gpt-5.4")
         assert router.get_active_region("gpt-5.4") == "eu-west"
+
+    def test_closed_during_post_commit_window_triggers_recovery(self) -> None:
+        """CLOSED after failover commit but before pending clears must recover."""
+        cfg = FailoverConfig(
+            enabled=True,
+            regions={"gpt-5.4": ["us-east", "eu-west"]},
+            min_failover_duration_seconds=0.0,
+        )
+        router = FailoverRouter(cfg, health_probe=lambda _r: True)
+        hook_called = [False]
+        real_lock = threading.Lock()
+
+        class PostCommitHookLock:
+            def __enter__(self) -> None:
+                real_lock.acquire()
+
+            def __exit__(
+                self,
+                exc_type: object,
+                exc_value: object,
+                traceback: object,
+            ) -> bool:
+                real_lock.release()
+                # After the atomic commit fix, pending is cleared at the same
+                # lock acquisition that writes _failover_at, so the "in window"
+                # check is now just "commit just happened" (failover_at != None).
+                if not hook_called[0] and router._failover_at.get("gpt-5.4") is not None:
+                    hook_called[0] = True
+                    router.on_cb_state_change("gpt-5.4", "open", "closed")
+                return False
+
+        router._lock = PostCommitHookLock()  # type: ignore[assignment]
+
+        router.on_cb_state_change("gpt-5.4", "closed", "open")
+
+        assert hook_called[0]
+        assert not router.is_failed_over("gpt-5.4")
+        assert router.get_active_region("gpt-5.4") == "us-east"
+        assert router._failover_at["gpt-5.4"] is None
+
+    def test_get_active_region_lazy_recovery_after_min_duration(self) -> None:
+        """get_active_region must restore primary after deferred recovery matures."""
+        now = [10.0]
+
+        def fake_clock() -> float:
+            return now[0]
+
+        cfg = FailoverConfig(
+            enabled=True,
+            regions={"gpt-5.4": ["us-east", "eu-west"]},
+            min_failover_duration_seconds=30.0,
+        )
+        router = FailoverRouter(cfg, clock=fake_clock, health_probe=lambda _r: True)
+        router.on_cb_state_change("gpt-5.4", "closed", "open")
+        assert router.is_failed_over("gpt-5.4")
+
+        now[0] = 50.0
+
+        assert router.get_active_region("gpt-5.4") == "us-east"
+        assert not router.is_failed_over("gpt-5.4")
+        assert router._failover_at["gpt-5.4"] is None
+
+    def test_get_active_region_no_lazy_recovery_before_min_duration(self) -> None:
+        """get_active_region must keep secondary before min duration elapses."""
+        now = [10.0]
+
+        def fake_clock() -> float:
+            return now[0]
+
+        cfg = FailoverConfig(
+            enabled=True,
+            regions={"gpt-5.4": ["us-east", "eu-west"]},
+            min_failover_duration_seconds=30.0,
+        )
+        router = FailoverRouter(cfg, clock=fake_clock, health_probe=lambda _r: True)
+        router.on_cb_state_change("gpt-5.4", "closed", "open")
+        assert router.is_failed_over("gpt-5.4")
+
+        now[0] = 20.0
+
+        assert router.get_active_region("gpt-5.4") == "eu-west"
+        assert router.is_failed_over("gpt-5.4")
+
+    def test_is_failed_over_lazy_recovery_after_min_duration(self) -> None:
+        """is_failed_over must apply lazy recovery so it agrees with get_active_region."""
+        now = [10.0]
+
+        def fake_clock() -> float:
+            return now[0]
+
+        cfg = FailoverConfig(
+            enabled=True,
+            regions={"gpt-5.4": ["us-east", "eu-west"]},
+            min_failover_duration_seconds=30.0,
+        )
+        router = FailoverRouter(cfg, clock=fake_clock, health_probe=lambda _r: True)
+        router.on_cb_state_change("gpt-5.4", "closed", "open")
+        assert router.is_failed_over("gpt-5.4")
+
+        now[0] = 50.0
+
+        # Calling is_failed_over first must itself drive recovery.
+        assert not router.is_failed_over("gpt-5.4")
+        assert router.get_active_region("gpt-5.4") == "us-east"
+
+    def test_snapshot_lazy_recovery_after_min_duration(self) -> None:
+        """snapshot must apply lazy recovery so it stays consistent with get_active_region."""
+        now = [10.0]
+
+        def fake_clock() -> float:
+            return now[0]
+
+        cfg = FailoverConfig(
+            enabled=True,
+            regions={"gpt-5.4": ["us-east", "eu-west"]},
+            min_failover_duration_seconds=30.0,
+        )
+        router = FailoverRouter(cfg, clock=fake_clock, health_probe=lambda _r: True)
+        router.on_cb_state_change("gpt-5.4", "closed", "open")
+
+        now[0] = 50.0
+
+        # Calling snapshot first must itself drive recovery.
+        snap = router.snapshot()
+        assert snap["backends"]["gpt-5.4"]["active_region"] == "us-east"
+        assert snap["backends"]["gpt-5.4"]["failed_over"] is False
+        assert snap["backends"]["gpt-5.4"]["failover_at"] is None
+        assert router.get_active_region("gpt-5.4") == "us-east"
+
+    def test_lazy_recovery_negative_elapsed_does_not_recover(self) -> None:
+        """_try_lazy_recovery_unlocked must not recover if clock goes backward (elapsed < 0)."""
+        now = [100.0]
+
+        def fake_clock() -> float:
+            return now[0]
+
+        cfg = FailoverConfig(
+            enabled=True,
+            regions={"gpt-5.4": ["us-east", "eu-west"]},
+            min_failover_duration_seconds=30.0,
+        )
+        router = FailoverRouter(cfg, clock=fake_clock, health_probe=lambda _r: True)
+        router.on_cb_state_change("gpt-5.4", "closed", "open")
+        assert router.is_failed_over("gpt-5.4")
+
+        # Clock skews backward.
+        now[0] = 50.0
+        # Lazy recovery via get_active_region: elapsed = 50-100 = -50 < 30, no-op.
+        assert router.get_active_region("gpt-5.4") == "eu-west"
+        assert router.is_failed_over("gpt-5.4")
+
+    def test_lazy_recovery_zero_min_duration_recovers_on_first_observation(self) -> None:
+        """min_failover_duration_seconds=0 must allow lazy recovery on the first observation post-failover."""
+        now = [10.0]
+
+        def fake_clock() -> float:
+            return now[0]
+
+        cfg = FailoverConfig(
+            enabled=True,
+            regions={"gpt-5.4": ["us-east", "eu-west"]},
+            min_failover_duration_seconds=0.0,
+        )
+        router = FailoverRouter(cfg, clock=fake_clock, health_probe=lambda _r: True)
+        router.on_cb_state_change("gpt-5.4", "closed", "open")
+
+        # First observation at the same clock instant: elapsed = 0 >= 0 -> recover.
+        assert router.get_active_region("gpt-5.4") == "us-east"
+        assert not router.is_failed_over("gpt-5.4")
 
     def test_reset_admin_restores_primary_immediately(self, simple_config: FailoverConfig) -> None:
         """reset() must restore primary regardless of min_failover_duration."""
@@ -208,6 +383,14 @@ class TestRecovery:
         router = FailoverRouter(simple_config)
         router.on_cb_state_change("gpt-5.4", "open", "closed")  # must not raise
         assert not router.is_failed_over("gpt-5.4")
+
+    def test_reset_unknown_backend_is_noop(self, simple_config: FailoverConfig) -> None:
+        """reset() for an unknown backend must not create state or raise."""
+        router = FailoverRouter(simple_config)
+        router.reset("unknown")
+        assert "unknown" not in router._active_region
+        assert "unknown" not in router._failover_at
+        assert "unknown" not in router._failover_pending
 
 
 # ---------------------------------------------------------------------------
@@ -263,7 +446,9 @@ class TestLLMCBIntegration:
         assert cb.failure_count == 1
 
     def test_record_failure_to_open_calls_on_cb_state_change(
-        self, cb_config: LLMCircuitBreakerConfig, simple_config: FailoverConfig
+        self,
+        cb_config: LLMCircuitBreakerConfig,
+        simple_config: FailoverConfig,
     ) -> None:
         """When CB transitions CLOSED -> OPEN via record_failure, on_cb_state_change must be called."""
         router = FailoverRouter(simple_config, health_probe=lambda _r: True)
@@ -274,16 +459,15 @@ class TestLLMCBIntegration:
         assert router.is_failed_over("gpt-5.4")
 
     def test_record_success_from_half_open_triggers_closed_notification(
-        self, cb_config: LLMCircuitBreakerConfig, simple_config: FailoverConfig
+        self,
+        cb_config: LLMCircuitBreakerConfig,
+        simple_config: FailoverConfig,
     ) -> None:
         """HALF_OPEN -> CLOSED via record_success must notify router of 'closed'."""
-        clock_values = [0.0, 31.0]
-        call_count = [0]
+        now = [0.0]
 
         def fake_clock() -> float:
-            v = clock_values[min(call_count[0], len(clock_values) - 1)]
-            call_count[0] += 1
-            return v
+            return now[0]
 
         cfg = FailoverConfig(
             enabled=True,
@@ -303,13 +487,18 @@ class TestLLMCBIntegration:
             cb._state = CircuitState.HALF_OPEN
             cb._half_open_probe_active = False
 
+        # Advance clock past min_failover_duration so recovery can complete.
+        now[0] = 31.0
+
         # record_success: HALF_OPEN -> CLOSED, router should restore primary
         cb.record_success()
         assert cb.state == CircuitState.CLOSED
         assert not router.is_failed_over("gpt-5.4")
 
     def test_force_open_notifies_router(
-        self, cb_config: LLMCircuitBreakerConfig, simple_config: FailoverConfig
+        self,
+        cb_config: LLMCircuitBreakerConfig,
+        simple_config: FailoverConfig,
     ) -> None:
         """force_open must call on_cb_state_change('open') on the router."""
         router = FailoverRouter(simple_config, health_probe=lambda _r: True)
@@ -319,13 +508,14 @@ class TestLLMCBIntegration:
 
 
 # ---------------------------------------------------------------------------
-# Category F: Concurrency (2 tests)
+# Category F: Concurrency (4 tests)
 # ---------------------------------------------------------------------------
 
 
 class TestConcurrency:
     def test_concurrent_open_events_commit_exactly_one_failover(
-        self, simple_config: FailoverConfig
+        self,
+        simple_config: FailoverConfig,
     ) -> None:
         """8 threads calling on_cb_state_change("open") simultaneously must yield exactly one failover."""
         probe_call_count = [0]
@@ -357,14 +547,15 @@ class TestConcurrency:
         # Exactly one failover committed (subsequent calls are idempotent)
         assert router.is_failed_over("gpt-5.4")
         assert router.get_active_region("gpt-5.4") == "eu-west"
+        assert probe_call_count[0] <= 1
 
     def test_concurrent_get_and_set_does_not_corrupt_state(
-        self, simple_config: FailoverConfig
+        self,
+        simple_config: FailoverConfig,
     ) -> None:
         """Concurrent get_active_region + on_cb_state_change must not raise or corrupt state."""
         router = FailoverRouter(simple_config, health_probe=lambda _r: True)
         errors: list[Exception] = []
-        stop = threading.Event()
 
         def reader() -> None:
             try:
@@ -393,15 +584,73 @@ class TestConcurrency:
 
         assert not errors, f"Concurrent errors: {errors}"
 
+    def test_reset_during_inflight_probe_aborts_failover(
+        self,
+        simple_config: FailoverConfig,
+    ) -> None:
+        """reset() during an in-flight probe must prevent the probe from committing."""
+        probe_started = threading.Event()
+        probe_release = threading.Event()
+
+        def slow_probe(_region: str) -> bool:
+            probe_started.set()
+            assert probe_release.wait(timeout=2.0)
+            return True
+
+        router = FailoverRouter(simple_config, health_probe=slow_probe)
+        thread = threading.Thread(
+            target=router.on_cb_state_change,
+            args=("gpt-5.4", "closed", "open"),
+        )
+
+        thread.start()
+        assert probe_started.wait(timeout=2.0)
+        router.reset("gpt-5.4")
+        probe_release.set()
+        thread.join(timeout=2.0)
+
+        assert not thread.is_alive()
+        assert not router.is_failed_over("gpt-5.4")
+        assert router.get_active_region("gpt-5.4") == "us-east"
+
+    def test_closed_during_inflight_probe_aborts_failover(
+        self,
+        simple_config: FailoverConfig,
+    ) -> None:
+        """CLOSED during an in-flight probe must prevent the probe from committing."""
+        probe_started = threading.Event()
+        probe_release = threading.Event()
+
+        def slow_probe(_region: str) -> bool:
+            probe_started.set()
+            assert probe_release.wait(timeout=2.0)
+            return True
+
+        router = FailoverRouter(simple_config, health_probe=slow_probe)
+        thread = threading.Thread(
+            target=router.on_cb_state_change,
+            args=("gpt-5.4", "closed", "open"),
+        )
+
+        thread.start()
+        assert probe_started.wait(timeout=2.0)
+        router.on_cb_state_change("gpt-5.4", "open", "closed")
+        probe_release.set()
+        thread.join(timeout=2.0)
+
+        assert not thread.is_alive()
+        assert not router.is_failed_over("gpt-5.4")
+
 
 # ---------------------------------------------------------------------------
-# Category G: Adversarial (4 tests)
+# Category G: Adversarial (6 tests)
 # ---------------------------------------------------------------------------
 
 
 class TestAdversarial:
     def test_on_cb_state_change_unknown_old_state_does_not_crash(
-        self, simple_config: FailoverConfig
+        self,
+        simple_config: FailoverConfig,
     ) -> None:
         """on_cb_state_change with a garbage old_state must not raise."""
         router = FailoverRouter(simple_config, health_probe=lambda _r: True)
@@ -410,9 +659,11 @@ class TestAdversarial:
         assert router.is_failed_over("gpt-5.4")
 
     def test_probe_raises_arbitrary_exception_no_crash(
-        self, simple_config: FailoverConfig
+        self,
+        simple_config: FailoverConfig,
     ) -> None:
         """health_probe that raises ValueError must be caught; no failover."""
+
         def evil_probe(_region: str) -> bool:
             raise ValueError("bad region")
 
@@ -421,18 +672,16 @@ class TestAdversarial:
         assert not router.is_failed_over("gpt-5.4")
 
     def test_clock_backward_skew_does_not_cause_premature_recovery(
-        self, simple_config: FailoverConfig
+        self,
+        simple_config: FailoverConfig,
     ) -> None:
         """If clock goes backward after failover, recovery must not trigger prematurely."""
-        # failover at t=100, close at t=90 (skew): elapsed = 90-100 = -10 (clamped to 0 via sign)
-        # 0 < 30 (min_duration), so should NOT restore
-        clock_values = [100.0, 90.0]
-        call_count = [0]
+        # failover at t=100, close at t=90 (skew): elapsed = 90-100 = -10
+        # -10 < 30 (min_duration), so must NOT restore
+        now = [100.0]
 
         def fake_clock() -> float:
-            v = clock_values[min(call_count[0], len(clock_values) - 1)]
-            call_count[0] += 1
-            return v
+            return now[0]
 
         cfg = FailoverConfig(
             enabled=True,
@@ -443,12 +692,15 @@ class TestAdversarial:
         router.on_cb_state_change("gpt-5.4", "closed", "open")
         assert router.is_failed_over("gpt-5.4")
 
+        now[0] = 90.0  # clock skew backward
         router.on_cb_state_change("gpt-5.4", "open", "closed")
-        # elapsed = 90-100 = -10 < 30 -- must stay failed over
+        # Both _handle_closed and lazy recovery in is_failed_over must see negative elapsed.
         assert router.is_failed_over("gpt-5.4")
+        assert router.get_active_region("gpt-5.4") == "eu-west"
 
     def test_second_open_when_already_failed_over_is_idempotent(
-        self, simple_config: FailoverConfig
+        self,
+        simple_config: FailoverConfig,
     ) -> None:
         """on_cb_state_change("open") while already failed over must not double-failover."""
         probe_count = [0]
@@ -494,3 +746,38 @@ class TestAdversarial:
         router = FailoverRouter(cfg, health_probe=lambda _r: True)
         router.on_cb_state_change("gpt-5.4", "closed", "open")
         assert not router.is_failed_over("gpt-5.4")
+
+
+# ---------------------------------------------------------------------------
+# Category H: Phase 6 integration (1 test)
+# ---------------------------------------------------------------------------
+
+
+class TestPhase6Integration:
+    @pytest.mark.asyncio
+    async def test_base_exception_probe_reopen_notifies_failover(
+        self,
+        cb_config: LLMCircuitBreakerConfig,
+    ) -> None:
+        """CancelledError during HALF_OPEN probe must notify failover of re-open."""
+        failover = unittest.mock.Mock()
+        cb = LLMCircuitBreaker(
+            cb_config,
+            backend_name="gpt-5.4",
+            failover=failover,
+        )
+        with cb._lock:
+            cb._state = CircuitState.HALF_OPEN
+            cb._half_open_probe_active = False
+
+        async def cancelled_probe() -> None:
+            raise asyncio.CancelledError()
+
+        with pytest.raises(asyncio.CancelledError):
+            await cb.call_with_retry(cancelled_probe, max_retries=1)
+
+        failover.on_cb_state_change.assert_called_with(
+            "gpt-5.4",
+            "half_open",
+            "open",
+        )

--- a/massgen/tests/test_cb_failover.py
+++ b/massgen/tests/test_cb_failover.py
@@ -6,6 +6,7 @@ import asyncio
 import threading
 import time
 import unittest.mock
+from collections.abc import Sequence
 
 import pytest
 
@@ -111,8 +112,9 @@ class TestFailoverConfigValidation:
             enabled=True,
             regions={"gpt-5.4": ["us-east", "eu-west"]},
         )
-        # Field assignment on frozen dataclass.
-        with pytest.raises((AttributeError, Exception), match="(?i)frozen|cannot assign"):
+        # Field assignment on frozen dataclass raises FrozenInstanceError
+        # (subclass of AttributeError).
+        with pytest.raises(AttributeError, match=r"(?i)frozen|cannot assign"):
             cfg.enabled = False  # type: ignore[misc]
         # Inner per-backend list is a tuple -- no append.
         with pytest.raises(AttributeError):
@@ -298,9 +300,15 @@ class TestRecovery:
                 # After the atomic commit fix, pending is cleared at the same
                 # lock acquisition that writes _failover_at, so the "in window"
                 # check is now just "commit just happened" (failover_at != None).
+                # The CLOSED notify must use a STRICTLY GREATER seq than the
+                # OPEN notify currently committing, otherwise on_cb_state_change
+                # drops it as stale and _handle_closed never runs (the test
+                # would still pass via lazy recovery from the assertions, but
+                # would no longer exercise the post-commit recovery path it
+                # claims to test).
                 if not hook_called[0] and router._failover_at.get("gpt-5.4") is not None:
                     hook_called[0] = True
-                    router.on_cb_state_change("gpt-5.4", "open", "closed", seq=1)
+                    router.on_cb_state_change("gpt-5.4", "open", "closed", seq=3)
                 return False
 
         router._lock = PostCommitHookLock()  # type: ignore[assignment]
@@ -586,7 +594,7 @@ class TestLLMCBIntegration:
 
 
 # ---------------------------------------------------------------------------
-# Category F: Concurrency (5 tests)
+# Category F: Concurrency (8 tests)
 # ---------------------------------------------------------------------------
 
 
@@ -597,7 +605,18 @@ class TestConcurrency:
         self,
         simple_config: FailoverConfig,
     ) -> None:
-        """8 threads calling on_cb_state_change("open", seq=1) simultaneously must yield exactly one failover."""
+        """8 threads calling on_cb_state_change("open") simultaneously must yield exactly one failover.
+
+        Each worker passes a distinct seq so multiple notifications can pass
+        the seq-dedup gate (which thread passes depends on lock acquisition
+        order against the strictly-greater-than-last_seq check); the threads
+        that do pass then race in _handle_open against the _failover_pending
+        claim. The invariant being tested is that regardless of dedup order,
+        exactly one thread wins the pending claim and runs the probe, so
+        probe_call_count[0] == 1. Without distinct seq, all 8 share seq=1 and
+        only the first-arriving thread passes dedup, masking the pending
+        claim race entirely.
+        """
         probe_call_count = [0]
         probe_lock = threading.Lock()
 
@@ -610,14 +629,14 @@ class TestConcurrency:
         barrier = threading.Barrier(8)
         errors: list[Exception] = []
 
-        def worker() -> None:
+        def worker(my_seq: int) -> None:
             try:
                 barrier.wait()
-                router.on_cb_state_change("gpt-5.4", "closed", "open", seq=1)
+                router.on_cb_state_change("gpt-5.4", "closed", "open", seq=my_seq)
             except Exception as exc:  # noqa: BLE001
                 errors.append(exc)
 
-        threads = [threading.Thread(target=worker) for _ in range(8)]
+        threads = [threading.Thread(target=worker, args=(i + 1,)) for i in range(8)]
         for t in threads:
             t.start()
         for t in threads:
@@ -784,6 +803,252 @@ class TestConcurrency:
 
         assert not thread.is_alive()
         assert not router.is_failed_over("gpt-5.4")
+
+    def test_closed_can_race_between_seq_update_and_open_probe_claim(
+        self,
+        simple_config: FailoverConfig,
+    ) -> None:
+        """A fresher CLOSED must still suppress an older OPEN even if it lands before _handle_open claims pending.
+
+        Forces the vulnerable interleaving:
+        1. T_OPEN(seq=1) acquires the seq lock, writes _last_seq=1, then pauses
+           in a wrapped _handle_open before claiming the probe slot.
+        2. T_CLOSED(seq=2) runs while failover_at=None and pending=False, so
+           _handle_closed observes nothing to recover and updates _last_seq=2.
+        3. T_OPEN resumes. It must NOT claim a probe slot and must NOT commit
+           failover, because the CB's authoritative state has advanced past
+           the OPEN we are dispatching for.
+
+        The seq guard at the top of _handle_open's claim block (last_seq > seq
+        => abort) is what makes this safe.
+        """
+        open_handler_entered = threading.Event()
+        allow_open_handler = threading.Event()
+        probe_started = threading.Event()
+
+        def slow_probe(_region: str) -> bool:
+            probe_started.set()
+            return True
+
+        router = FailoverRouter(simple_config, health_probe=slow_probe)
+        original_handle_open = router._handle_open
+
+        def delayed_handle_open(
+            backend: str,
+            old_state: str,
+            region_list: Sequence[str],
+            seq: int,
+        ) -> None:
+            open_handler_entered.set()
+            assert allow_open_handler.wait(timeout=2.0)
+            original_handle_open(backend, old_state, region_list, seq)
+
+        router._handle_open = delayed_handle_open  # type: ignore[method-assign]
+
+        open_thread = threading.Thread(
+            target=router.on_cb_state_change,
+            args=("gpt-5.4", "closed", "open"),
+            kwargs={"seq": 1},
+        )
+        open_thread.start()
+
+        assert open_handler_entered.wait(timeout=2.0)
+        assert router._last_seq["gpt-5.4"] == 1
+        assert router._failover_pending.get("gpt-5.4", False) is False
+
+        closed_thread = threading.Thread(
+            target=router.on_cb_state_change,
+            args=("gpt-5.4", "open", "closed"),
+            kwargs={"seq": 2},
+        )
+        closed_thread.start()
+        closed_thread.join(timeout=2.0)
+
+        assert not closed_thread.is_alive()
+        assert router._last_seq["gpt-5.4"] == 2
+        # _closed_during_probe was removed in favor of _last_state-based
+        # commit guard; assert the equivalent invariant on _last_state instead.
+        assert router._last_state.get("gpt-5.4") == "closed"
+        assert router._failover_at.get("gpt-5.4") is None
+
+        allow_open_handler.set()
+        open_thread.join(timeout=2.0)
+
+        assert not open_thread.is_alive()
+        # Probe must NEVER have started: _handle_open's seq guard sees
+        # _last_seq=2 > seq=1 and aborts before the probe loop.
+        assert not probe_started.is_set()
+        assert router._failover_pending.get("gpt-5.4", False) is False
+        assert not router.is_failed_over("gpt-5.4")
+        assert router.get_active_region("gpt-5.4") == "us-east"
+
+    def test_async_health_probe_rejected_at_construction(self) -> None:
+        """An async health_probe must be rejected at __init__, not silently misused.
+
+        Without the rejection, bool(coroutine) is always True, so every CB
+        OPEN would commit failover without actually probing.
+        """
+        cfg = FailoverConfig(
+            enabled=True,
+            regions={"gpt-5.4": ["us-east", "eu-west"]},
+        )
+
+        async def async_probe(_region: str) -> bool:  # type: ignore[misc]
+            return True
+
+        with pytest.raises(ValueError, match=r"(?i)async probes.*are not supported"):
+            FailoverRouter(cfg, health_probe=async_probe)  # type: ignore[arg-type]
+
+        # Async generator function (yields inside async def) -- bool(async_gen) is True.
+        async def async_gen_probe(_region: str):  # type: ignore[misc]
+            yield True
+
+        with pytest.raises(ValueError, match=r"(?i)async probes.*are not supported"):
+            FailoverRouter(cfg, health_probe=async_gen_probe)  # type: ignore[arg-type]
+
+        # Callable instance whose __call__ is async -- bool(coroutine) is True.
+        class AsyncCallable:
+            async def __call__(self, _region: str) -> bool:
+                return True
+
+        with pytest.raises(ValueError, match=r"(?i)async probes.*are not supported"):
+            FailoverRouter(cfg, health_probe=AsyncCallable())  # type: ignore[arg-type]
+
+    def test_lambda_returning_coroutine_treated_as_probe_failure(
+        self,
+        simple_config: FailoverConfig,
+    ) -> None:
+        """A sync callable that returns a coroutine must be treated as probe failure, not silent success.
+
+        The construction-time _is_async_callable check cannot detect this (the
+        lambda itself is sync), so the probe runner inspects the return value
+        and rejects awaitables. Without this, bool(unawaited coroutine) would
+        be True and every region would falsely pass.
+        """
+
+        async def _async_check(_r: str) -> bool:
+            return True
+
+        # Lambda is sync but returns a coroutine.
+        router = FailoverRouter(simple_config, health_probe=lambda r: _async_check(r))  # type: ignore[arg-type, return-value]
+        router.on_cb_state_change("gpt-5.4", "closed", "open", seq=1)
+        # Probe returned awaitable -> treated as exception -> region skipped.
+        # Both regions yield coroutines, both skipped, no failover.
+        assert not router.is_failed_over("gpt-5.4")
+        assert router.get_active_region("gpt-5.4") == "us-east"
+
+    def test_sync_callable_returning_sync_generator_treated_as_probe_failure(
+        self,
+        simple_config: FailoverConfig,
+    ) -> None:
+        """Sync callable returning a sync generator iterator must also be rejected.
+
+        Sync generators are not awaitable and not async generators, but
+        bool(sync_gen) is True -- without an explicit isgenerator check, a
+        probe like `lambda r: (x for x in [True])` would falsely report healthy.
+        """
+
+        def make_sync_gen(_r: str):  # type: ignore[no-untyped-def]
+            yield True
+
+        router = FailoverRouter(simple_config, health_probe=make_sync_gen)  # type: ignore[arg-type]
+        router.on_cb_state_change("gpt-5.4", "closed", "open", seq=1)
+        assert not router.is_failed_over("gpt-5.4")
+        assert router.get_active_region("gpt-5.4") == "us-east"
+
+    def test_sync_callable_returning_async_generator_treated_as_probe_failure(
+        self,
+        simple_config: FailoverConfig,
+    ) -> None:
+        """Sync callable returning an async generator iterator must also be rejected.
+
+        Async gen iterators are not awaitable (so isawaitable returns False)
+        but bool(async_gen_iter) is True -- without the explicit isasyncgen
+        check, every region would falsely pass.
+        """
+
+        def make_async_gen(_r: str):  # type: ignore[no-untyped-def]
+            async def gen():
+                yield True
+
+            return gen()  # async generator iterator
+
+        router = FailoverRouter(simple_config, health_probe=make_async_gen)  # type: ignore[arg-type]
+        router.on_cb_state_change("gpt-5.4", "closed", "open", seq=1)
+        assert not router.is_failed_over("gpt-5.4")
+        assert router.get_active_region("gpt-5.4") == "us-east"
+
+    def test_open_close_open_during_probe_commits_for_latest_open(
+        self,
+        simple_config: FailoverConfig,
+    ) -> None:
+        """OPEN(1)+CLOSED(2)+OPEN(3) with in-flight probe must commit failover for the latest OPEN.
+
+        Pre-fix: T1 probe aborts at commit (the now-removed
+        _closed_during_probe latch was set by T2); T3 OPEN dropped on
+        pending=True. End state mismatch (CB OPEN, router on primary).
+        Post-fix: commit guard checks _last_state == "open" and commits when
+        a fresher OPEN superseded the CLOSED.
+        """
+        probe_started = threading.Event()
+        allow_probe_finish = threading.Event()
+
+        def slow_probe(_region: str) -> bool:
+            probe_started.set()
+            assert allow_probe_finish.wait(timeout=2.0)
+            return True
+
+        router = FailoverRouter(simple_config, health_probe=slow_probe)
+
+        t1 = threading.Thread(
+            target=router.on_cb_state_change,
+            args=("gpt-5.4", "closed", "open"),
+            kwargs={"seq": 1},
+        )
+        t1.start()
+        assert probe_started.wait(timeout=2.0)
+
+        router.on_cb_state_change("gpt-5.4", "open", "closed", seq=2)
+        router.on_cb_state_change("gpt-5.4", "closed", "open", seq=3)
+
+        allow_probe_finish.set()
+        t1.join(timeout=2.0)
+        assert not t1.is_alive()
+
+        assert router.is_failed_over("gpt-5.4")
+        assert router.get_active_region("gpt-5.4") == "eu-west"
+
+    def test_open_close_during_probe_does_not_commit(
+        self,
+        simple_config: FailoverConfig,
+    ) -> None:
+        """OPEN(1)+CLOSED(2) during in-flight probe must NOT commit failover (latest is CLOSED)."""
+        probe_started = threading.Event()
+        allow_probe_finish = threading.Event()
+
+        def slow_probe(_region: str) -> bool:
+            probe_started.set()
+            assert allow_probe_finish.wait(timeout=2.0)
+            return True
+
+        router = FailoverRouter(simple_config, health_probe=slow_probe)
+
+        t1 = threading.Thread(
+            target=router.on_cb_state_change,
+            args=("gpt-5.4", "closed", "open"),
+            kwargs={"seq": 1},
+        )
+        t1.start()
+        assert probe_started.wait(timeout=2.0)
+
+        router.on_cb_state_change("gpt-5.4", "open", "closed", seq=2)
+
+        allow_probe_finish.set()
+        t1.join(timeout=2.0)
+        assert not t1.is_alive()
+
+        assert not router.is_failed_over("gpt-5.4")
+        assert router.get_active_region("gpt-5.4") == "us-east"
 
 
 # ---------------------------------------------------------------------------

--- a/massgen/tests/test_cb_failover.py
+++ b/massgen/tests/test_cb_failover.py
@@ -118,13 +118,13 @@ class TestFailoverTrigger:
         """on_cb_state_change("open") with probe returning True must failover."""
         router = FailoverRouter(simple_config, health_probe=lambda _r: True)
         assert not router.is_failed_over("gpt-5.4")
-        router.on_cb_state_change("gpt-5.4", "closed", "open")
+        router.on_cb_state_change("gpt-5.4", "closed", "open", seq=2)
         assert router.is_failed_over("gpt-5.4")
 
     def test_open_with_failing_probe_stays_on_primary(self, simple_config: FailoverConfig) -> None:
         """on_cb_state_change("open") with probe returning False must not failover."""
         router = FailoverRouter(simple_config, health_probe=lambda _r: False)
-        router.on_cb_state_change("gpt-5.4", "closed", "open")
+        router.on_cb_state_change("gpt-5.4", "closed", "open", seq=2)
         assert not router.is_failed_over("gpt-5.4")
 
     def test_open_with_probe_raising_stays_on_primary(self, simple_config: FailoverConfig) -> None:
@@ -134,7 +134,7 @@ class TestFailoverTrigger:
             raise RuntimeError("network error")
 
         router = FailoverRouter(simple_config, health_probe=raising_probe)
-        router.on_cb_state_change("gpt-5.4", "closed", "open")
+        router.on_cb_state_change("gpt-5.4", "closed", "open", seq=1)
         assert not router.is_failed_over("gpt-5.4")
 
     def test_hanging_probe_times_out_per_health_check_timeout_seconds(self) -> None:
@@ -159,7 +159,7 @@ class TestFailoverTrigger:
         router = FailoverRouter(cfg, health_probe=hanging_probe)
 
         start = time.monotonic()
-        router.on_cb_state_change("gpt-5.4", "closed", "open")
+        router.on_cb_state_change("gpt-5.4", "closed", "open", seq=1)
         elapsed = time.monotonic() - start
 
         # Two secondaries x 0.05s timeout => bounded above by ~0.5s with thread overhead.
@@ -171,7 +171,7 @@ class TestFailoverTrigger:
     def test_get_active_region_returns_secondary_after_failover(self, simple_config: FailoverConfig) -> None:
         """get_active_region must return the secondary region after failover."""
         router = FailoverRouter(simple_config, health_probe=lambda _r: True)
-        router.on_cb_state_change("gpt-5.4", "closed", "open")
+        router.on_cb_state_change("gpt-5.4", "closed", "open", seq=1)
         active = router.get_active_region("gpt-5.4")
         assert active == "eu-west"
 
@@ -184,7 +184,7 @@ class TestFailoverTrigger:
         """FailoverConfig(enabled=False) must make get_active_region/is_failed_over/on_cb_state_change all no-ops."""
         cfg = FailoverConfig(enabled=False, regions={"gpt-5.4": ["us-east", "eu-west"]})
         router = FailoverRouter(cfg, health_probe=lambda _r: True)
-        router.on_cb_state_change("gpt-5.4", "closed", "open")
+        router.on_cb_state_change("gpt-5.4", "closed", "open", seq=1)
         assert not router.is_failed_over("gpt-5.4")
         assert router.get_active_region("gpt-5.4") is None
 
@@ -198,7 +198,7 @@ class TestRecovery:
     """on_cb_state_change("closed") + lazy recovery via observation methods."""
 
     def test_closed_after_min_duration_restores_primary(self, simple_config: FailoverConfig) -> None:
-        """on_cb_state_change("closed") after min_failover_duration elapsed must restore primary."""
+        """on_cb_state_change("closed", seq=1) after min_failover_duration elapsed must restore primary."""
         now = [0.0]
 
         def fake_clock() -> float:
@@ -210,16 +210,16 @@ class TestRecovery:
             min_failover_duration_seconds=30.0,
         )
         router = FailoverRouter(cfg, clock=fake_clock, health_probe=lambda _r: True)
-        router.on_cb_state_change("gpt-5.4", "closed", "open")
+        router.on_cb_state_change("gpt-5.4", "closed", "open", seq=1)
         assert router.is_failed_over("gpt-5.4")
 
         now[0] = 31.0
-        router.on_cb_state_change("gpt-5.4", "open", "closed")
+        router.on_cb_state_change("gpt-5.4", "open", "closed", seq=2)
         assert not router.is_failed_over("gpt-5.4")
         assert router.get_active_region("gpt-5.4") == "us-east"
 
     def test_closed_before_min_duration_defers_recovery(self, simple_config: FailoverConfig) -> None:
-        """on_cb_state_change("closed") before min duration elapsed must keep secondary."""
+        """on_cb_state_change("closed", seq=1) before min duration elapsed must keep secondary."""
         now = [0.0]
 
         def fake_clock() -> float:
@@ -231,11 +231,11 @@ class TestRecovery:
             min_failover_duration_seconds=30.0,
         )
         router = FailoverRouter(cfg, clock=fake_clock, health_probe=lambda _r: True)
-        router.on_cb_state_change("gpt-5.4", "closed", "open")
+        router.on_cb_state_change("gpt-5.4", "closed", "open", seq=1)
         assert router.is_failed_over("gpt-5.4")
 
         now[0] = 5.0  # only 5s elapsed, min is 30s
-        router.on_cb_state_change("gpt-5.4", "open", "closed")
+        router.on_cb_state_change("gpt-5.4", "open", "closed", seq=2)
         # Too soon -- must remain failed over
         assert router.is_failed_over("gpt-5.4")
         assert router.get_active_region("gpt-5.4") == "eu-west"
@@ -278,12 +278,12 @@ class TestRecovery:
                 # check is now just "commit just happened" (failover_at != None).
                 if not hook_called[0] and router._failover_at.get("gpt-5.4") is not None:
                     hook_called[0] = True
-                    router.on_cb_state_change("gpt-5.4", "open", "closed")
+                    router.on_cb_state_change("gpt-5.4", "open", "closed", seq=1)
                 return False
 
         router._lock = PostCommitHookLock()  # type: ignore[assignment]
 
-        router.on_cb_state_change("gpt-5.4", "closed", "open")
+        router.on_cb_state_change("gpt-5.4", "closed", "open", seq=2)
 
         assert hook_called[0]
         assert not router.is_failed_over("gpt-5.4")
@@ -303,7 +303,7 @@ class TestRecovery:
             min_failover_duration_seconds=30.0,
         )
         router = FailoverRouter(cfg, clock=fake_clock, health_probe=lambda _r: True)
-        router.on_cb_state_change("gpt-5.4", "closed", "open")
+        router.on_cb_state_change("gpt-5.4", "closed", "open", seq=1)
         assert router.is_failed_over("gpt-5.4")
 
         now[0] = 50.0
@@ -325,7 +325,7 @@ class TestRecovery:
             min_failover_duration_seconds=30.0,
         )
         router = FailoverRouter(cfg, clock=fake_clock, health_probe=lambda _r: True)
-        router.on_cb_state_change("gpt-5.4", "closed", "open")
+        router.on_cb_state_change("gpt-5.4", "closed", "open", seq=1)
         assert router.is_failed_over("gpt-5.4")
 
         now[0] = 20.0
@@ -346,7 +346,7 @@ class TestRecovery:
             min_failover_duration_seconds=30.0,
         )
         router = FailoverRouter(cfg, clock=fake_clock, health_probe=lambda _r: True)
-        router.on_cb_state_change("gpt-5.4", "closed", "open")
+        router.on_cb_state_change("gpt-5.4", "closed", "open", seq=1)
         assert router.is_failed_over("gpt-5.4")
 
         now[0] = 50.0
@@ -368,7 +368,7 @@ class TestRecovery:
             min_failover_duration_seconds=30.0,
         )
         router = FailoverRouter(cfg, clock=fake_clock, health_probe=lambda _r: True)
-        router.on_cb_state_change("gpt-5.4", "closed", "open")
+        router.on_cb_state_change("gpt-5.4", "closed", "open", seq=1)
 
         now[0] = 50.0
 
@@ -392,7 +392,7 @@ class TestRecovery:
             min_failover_duration_seconds=30.0,
         )
         router = FailoverRouter(cfg, clock=fake_clock, health_probe=lambda _r: True)
-        router.on_cb_state_change("gpt-5.4", "closed", "open")
+        router.on_cb_state_change("gpt-5.4", "closed", "open", seq=1)
         assert router.is_failed_over("gpt-5.4")
 
         # Clock skews backward.
@@ -414,7 +414,7 @@ class TestRecovery:
             min_failover_duration_seconds=0.0,
         )
         router = FailoverRouter(cfg, clock=fake_clock, health_probe=lambda _r: True)
-        router.on_cb_state_change("gpt-5.4", "closed", "open")
+        router.on_cb_state_change("gpt-5.4", "closed", "open", seq=1)
 
         # First observation at the same clock instant: elapsed = 0 >= 0 -> recover.
         assert router.get_active_region("gpt-5.4") == "us-east"
@@ -423,7 +423,7 @@ class TestRecovery:
     def test_reset_admin_restores_primary_immediately(self, simple_config: FailoverConfig) -> None:
         """reset() must restore primary regardless of min_failover_duration."""
         router = FailoverRouter(simple_config, health_probe=lambda _r: True)
-        router.on_cb_state_change("gpt-5.4", "closed", "open")
+        router.on_cb_state_change("gpt-5.4", "closed", "open", seq=1)
         assert router.is_failed_over("gpt-5.4")
 
         router.reset("gpt-5.4")
@@ -431,9 +431,9 @@ class TestRecovery:
         assert router.get_active_region("gpt-5.4") == "us-east"
 
     def test_closed_when_not_failed_over_is_noop(self, simple_config: FailoverConfig) -> None:
-        """on_cb_state_change("closed") when not failed over must not crash."""
+        """on_cb_state_change("closed", seq=1) when not failed over must not crash."""
         router = FailoverRouter(simple_config)
-        router.on_cb_state_change("gpt-5.4", "open", "closed")  # must not raise
+        router.on_cb_state_change("gpt-5.4", "open", "closed", seq=2)  # must not raise
         assert not router.is_failed_over("gpt-5.4")
 
     def test_reset_unknown_backend_is_noop(self, simple_config: FailoverConfig) -> None:
@@ -463,7 +463,7 @@ class TestMultiBackendIsolation:
             },
         )
         router = FailoverRouter(cfg, health_probe=lambda _r: True)
-        router.on_cb_state_change("backend-a", "closed", "open")
+        router.on_cb_state_change("backend-a", "closed", "open", seq=1)
         assert router.is_failed_over("backend-a")
         assert not router.is_failed_over("backend-b")
         assert router.get_active_region("backend-b") == "ap-southeast"
@@ -556,7 +556,7 @@ class TestLLMCBIntegration:
         cb_config: LLMCircuitBreakerConfig,
         simple_config: FailoverConfig,
     ) -> None:
-        """force_open must call on_cb_state_change('open') on the router."""
+        """force_open must call on_cb_state_change('open', seq=1) on the router."""
         router = FailoverRouter(simple_config, health_probe=lambda _r: True)
         cb = LLMCircuitBreaker(cb_config, backend_name="gpt-5.4", failover=router)
         cb.force_open(reason="test")
@@ -575,7 +575,7 @@ class TestConcurrency:
         self,
         simple_config: FailoverConfig,
     ) -> None:
-        """8 threads calling on_cb_state_change("open") simultaneously must yield exactly one failover."""
+        """8 threads calling on_cb_state_change("open", seq=1) simultaneously must yield exactly one failover."""
         probe_call_count = [0]
         probe_lock = threading.Lock()
 
@@ -591,7 +591,7 @@ class TestConcurrency:
         def worker() -> None:
             try:
                 barrier.wait()
-                router.on_cb_state_change("gpt-5.4", "closed", "open")
+                router.on_cb_state_change("gpt-5.4", "closed", "open", seq=1)
             except Exception as exc:  # noqa: BLE001
                 errors.append(exc)
 
@@ -605,7 +605,7 @@ class TestConcurrency:
         # Exactly one failover committed (subsequent calls are idempotent)
         assert router.is_failed_over("gpt-5.4")
         assert router.get_active_region("gpt-5.4") == "eu-west"
-        assert probe_call_count[0] <= 1
+        assert probe_call_count[0] == 1
 
     def test_concurrent_get_and_set_does_not_corrupt_state(
         self,
@@ -627,7 +627,7 @@ class TestConcurrency:
             try:
                 for i in range(50):
                     if i % 2 == 0:
-                        router.on_cb_state_change("gpt-5.4", "closed", "open")
+                        router.on_cb_state_change("gpt-5.4", "closed", "open", seq=1)
                     else:
                         router.reset("gpt-5.4")
             except Exception as exc:  # noqa: BLE001
@@ -659,6 +659,7 @@ class TestConcurrency:
         thread = threading.Thread(
             target=router.on_cb_state_change,
             args=("gpt-5.4", "closed", "open"),
+            kwargs={"seq": 1},
         )
 
         thread.start()
@@ -688,11 +689,13 @@ class TestConcurrency:
         thread = threading.Thread(
             target=router.on_cb_state_change,
             args=("gpt-5.4", "closed", "open"),
+            kwargs={"seq": 1},
         )
 
         thread.start()
         assert probe_started.wait(timeout=2.0)
-        router.on_cb_state_change("gpt-5.4", "open", "closed")
+        # Use a strictly greater seq so the CLOSED is not dropped as stale.
+        router.on_cb_state_change("gpt-5.4", "open", "closed", seq=2)
         probe_release.set()
         thread.join(timeout=2.0)
 
@@ -714,7 +717,7 @@ class TestAdversarial:
     ) -> None:
         """on_cb_state_change with a garbage old_state must not raise."""
         router = FailoverRouter(simple_config, health_probe=lambda _r: True)
-        router.on_cb_state_change("gpt-5.4", "totally_invalid_state", "open")
+        router.on_cb_state_change("gpt-5.4", "totally_invalid_state", "open", seq=1)
         # Should have committed failover normally
         assert router.is_failed_over("gpt-5.4")
 
@@ -728,7 +731,7 @@ class TestAdversarial:
             raise ValueError("bad region")
 
         router = FailoverRouter(simple_config, health_probe=evil_probe)
-        router.on_cb_state_change("gpt-5.4", "closed", "open")
+        router.on_cb_state_change("gpt-5.4", "closed", "open", seq=1)
         assert not router.is_failed_over("gpt-5.4")
 
     def test_clock_backward_skew_does_not_cause_premature_recovery(
@@ -749,11 +752,11 @@ class TestAdversarial:
             min_failover_duration_seconds=30.0,
         )
         router = FailoverRouter(cfg, clock=fake_clock, health_probe=lambda _r: True)
-        router.on_cb_state_change("gpt-5.4", "closed", "open")
+        router.on_cb_state_change("gpt-5.4", "closed", "open", seq=1)
         assert router.is_failed_over("gpt-5.4")
 
         now[0] = 90.0  # clock skew backward
-        router.on_cb_state_change("gpt-5.4", "open", "closed")
+        router.on_cb_state_change("gpt-5.4", "open", "closed", seq=2)
         # Both _handle_closed and lazy recovery in is_failed_over must see negative elapsed.
         assert router.is_failed_over("gpt-5.4")
         assert router.get_active_region("gpt-5.4") == "eu-west"
@@ -762,7 +765,7 @@ class TestAdversarial:
         self,
         simple_config: FailoverConfig,
     ) -> None:
-        """on_cb_state_change("open") while already failed over must not double-failover."""
+        """on_cb_state_change("open", seq=1) while already failed over must not double-failover."""
         probe_count = [0]
 
         def counting_probe(_region: str) -> bool:
@@ -770,11 +773,11 @@ class TestAdversarial:
             return True
 
         router = FailoverRouter(simple_config, health_probe=counting_probe)
-        router.on_cb_state_change("gpt-5.4", "closed", "open")
+        router.on_cb_state_change("gpt-5.4", "closed", "open", seq=1)
         first_probe_count = probe_count[0]
 
         # Second open event while already on secondary
-        router.on_cb_state_change("gpt-5.4", "closed", "open")
+        router.on_cb_state_change("gpt-5.4", "closed", "open", seq=2)
         assert probe_count[0] == first_probe_count, "Probe called again despite already failed over"
         assert router.get_active_region("gpt-5.4") == "eu-west"
 
@@ -790,7 +793,7 @@ class TestAdversarial:
         assert entry["failed_over"] is False
         assert entry["failover_at"] is None
 
-        router.on_cb_state_change("gpt-5.4", "closed", "open")
+        router.on_cb_state_change("gpt-5.4", "closed", "open", seq=1)
         snap2 = router.snapshot()
         entry2 = snap2["backends"]["gpt-5.4"]
         assert entry2["failed_over"] is True
@@ -804,17 +807,17 @@ class TestAdversarial:
             regions={"gpt-5.4": ["us-east"]},  # no secondary
         )
         router = FailoverRouter(cfg, health_probe=lambda _r: True)
-        router.on_cb_state_change("gpt-5.4", "closed", "open")
+        router.on_cb_state_change("gpt-5.4", "closed", "open", seq=1)
         assert not router.is_failed_over("gpt-5.4")
 
 
 # ---------------------------------------------------------------------------
-# Category H: Phase 6 integration (4 tests)
+# Category H: Phase 6 integration (9 tests)
 # ---------------------------------------------------------------------------
 
 
 class TestPhase6Integration:
-    """Phase 6 BaseException handler integration with LLMCircuitBreaker."""
+    """Phase 6 integration: BaseException handler, KI/SE re-raise, seq drop, default probe warning, reset+seq, unknown new_state."""
 
     @pytest.mark.asyncio
     async def test_base_exception_probe_reopen_notifies_failover(
@@ -838,11 +841,10 @@ class TestPhase6Integration:
         with pytest.raises(asyncio.CancelledError):
             await cb.call_with_retry(cancelled_probe, max_retries=1)
 
-        failover.on_cb_state_change.assert_called_with(
-            "gpt-5.4",
-            "half_open",
-            "open",
-        )
+        # seq is passed by LLMCircuitBreaker; assert positional + seq present.
+        call = failover.on_cb_state_change.call_args
+        assert call.args == ("gpt-5.4", "half_open", "open")
+        assert call.kwargs.get("seq", 0) > 0
 
     def test_notify_failover_propagates_keyboard_interrupt(
         self,
@@ -884,3 +886,106 @@ class TestPhase6Integration:
             cb.record_failure()
         assert cb.state == CircuitState.OPEN
         assert failover.on_cb_state_change.called
+
+    def test_stale_seq_notifications_dropped_by_router(self) -> None:
+        """on_cb_state_change must drop notifications whose seq <= last applied.
+
+        Simulates the record_failure / record_success out-of-order race: a
+        stale 'open' notify arriving after a fresher 'closed' notify must
+        not leave the router stuck on secondary while the CB is closed.
+        """
+        # Use a stable clock + large min duration so lazy recovery does not
+        # mask the seq-drop semantics being tested.
+        now = [0.0]
+
+        def fake_clock() -> float:
+            return now[0]
+
+        cfg = FailoverConfig(
+            enabled=True,
+            regions={"gpt-5.4": ["us-east", "eu-west"]},
+            min_failover_duration_seconds=30.0,
+        )
+        router = FailoverRouter(cfg, clock=fake_clock, health_probe=lambda _r: True)
+
+        # Fresh transition: CLOSED -> OPEN at seq=10, fails over.
+        router.on_cb_state_change("gpt-5.4", "closed", "open", seq=10)
+        assert router.is_failed_over("gpt-5.4")
+
+        # Fresher transition: OPEN -> CLOSED at seq=11, advance clock past
+        # min_failover_duration so recovery commits.
+        now[0] = 31.0
+        router.on_cb_state_change("gpt-5.4", "open", "closed", seq=11)
+        assert not router.is_failed_over("gpt-5.4")
+
+        # Stale CLOSED -> OPEN at seq=5 arrives late (race) -- must be dropped.
+        router.on_cb_state_change("gpt-5.4", "closed", "open", seq=5)
+        assert not router.is_failed_over("gpt-5.4")
+
+        # Stale equal-seq must also be dropped.
+        router.on_cb_state_change("gpt-5.4", "closed", "open", seq=11)
+        assert not router.is_failed_over("gpt-5.4")
+
+    def test_default_probe_warning_when_enabled(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Constructing FailoverRouter with enabled=True and no probe must log a WARNING."""
+        cfg = FailoverConfig(
+            enabled=True,
+            regions={"gpt-5.4": ["us-east", "eu-west"]},
+        )
+        with caplog.at_level("WARNING", logger="massgen.backend.cb_failover"):
+            FailoverRouter(cfg)
+        assert any("NOT production safe" in rec.message for rec in caplog.records)
+
+    def test_default_probe_no_warning_when_disabled(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Disabled router constructed with no probe must not warn."""
+        cfg = FailoverConfig(enabled=False)
+        with caplog.at_level("WARNING", logger="massgen.backend.cb_failover"):
+            FailoverRouter(cfg)
+        assert not any("NOT production safe" in rec.message for rec in caplog.records)
+
+    def test_unknown_new_state_does_not_consume_seq_slot(self) -> None:
+        """Unsupported new_state ('half_open' etc) must NOT advance _last_seq.
+
+        Otherwise a stray notify with new_state='half_open' would silently
+        block subsequent legitimate 'open' / 'closed' notifies whose seq is
+        less than or equal to the consumed value.
+        """
+        cfg = FailoverConfig(
+            enabled=True,
+            regions={"gpt-5.4": ["us-east", "eu-west"]},
+            min_failover_duration_seconds=30.0,
+        )
+        router = FailoverRouter(cfg, health_probe=lambda _r: True)
+
+        # Stray notify with unsupported new_state -- ignored, seq not consumed.
+        router.on_cb_state_change("gpt-5.4", "open", "half_open", seq=100)
+        assert router._last_seq.get("gpt-5.4", 0) == 0
+
+        # Subsequent notify arriving later in time but with a smaller seq must still apply.
+        router.on_cb_state_change("gpt-5.4", "closed", "open", seq=5)
+        assert router.is_failed_over("gpt-5.4")
+
+    def test_reset_clears_last_seq_for_subsequent_lower_seq_notifies(self) -> None:
+        """reset() must clear _last_seq so a fresh producer (e.g. hot-swapped CB) resumes from seq=1.
+
+        Without this, a router admin reset followed by a new CB instance whose
+        _transition_seq starts at 0 would have its early notifies dropped as
+        stale because the router still remembers the old CB's high seq.
+        """
+        cfg = FailoverConfig(
+            enabled=True,
+            regions={"gpt-5.4": ["us-east", "eu-west"]},
+            min_failover_duration_seconds=30.0,
+        )
+        router = FailoverRouter(cfg, health_probe=lambda _r: True)
+
+        # First lifecycle: failover at seq=10, admin reset.
+        router.on_cb_state_change("gpt-5.4", "closed", "open", seq=10)
+        assert router.is_failed_over("gpt-5.4")
+        router.reset("gpt-5.4")
+        assert not router.is_failed_over("gpt-5.4")
+
+        # Simulate a fresh producer (e.g. hot-swapped CB whose seq counter
+        # restarted at 0). seq=1 must apply, NOT be dropped as stale.
+        router.on_cb_state_change("gpt-5.4", "closed", "open", seq=1)
+        assert router.is_failed_over("gpt-5.4")

--- a/massgen/tests/test_cb_failover.py
+++ b/massgen/tests/test_cb_failover.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import threading
+import time
 import unittest.mock
 
 import pytest
@@ -22,6 +23,7 @@ from massgen.backend.llm_circuit_breaker import (
 
 @pytest.fixture
 def simple_config() -> FailoverConfig:
+    """Two-region failover config with 30s min duration."""
     return FailoverConfig(
         enabled=True,
         regions={"gpt-5.4": ["us-east", "eu-west"]},
@@ -31,11 +33,13 @@ def simple_config() -> FailoverConfig:
 
 @pytest.fixture
 def router(simple_config: FailoverConfig) -> FailoverRouter:
+    """Default-probe router built from simple_config."""
     return FailoverRouter(simple_config)
 
 
 @pytest.fixture
 def cb_config() -> LLMCircuitBreakerConfig:
+    """Enabled CB config with 3 failures threshold."""
     return LLMCircuitBreakerConfig(enabled=True, max_failures=3, reset_time_seconds=60)
 
 
@@ -45,6 +49,8 @@ def cb_config() -> LLMCircuitBreakerConfig:
 
 
 class TestFailoverConfigValidation:
+    """FailoverConfig field validation."""
+
     def test_defaults_valid(self) -> None:
         """Default constructor must succeed -- enabled=False, empty regions."""
         cfg = FailoverConfig()
@@ -101,11 +107,13 @@ class TestFailoverConfigValidation:
 
 
 # ---------------------------------------------------------------------------
-# Category B: Failover trigger (6 tests)
+# Category B: Failover trigger (7 tests)
 # ---------------------------------------------------------------------------
 
 
 class TestFailoverTrigger:
+    """on_cb_state_change("open") behavior with various probe outcomes."""
+
     def test_open_with_healthy_probe_commits_failover(self, simple_config: FailoverConfig) -> None:
         """on_cb_state_change("open") with probe returning True must failover."""
         router = FailoverRouter(simple_config, health_probe=lambda _r: True)
@@ -128,6 +136,37 @@ class TestFailoverTrigger:
         router = FailoverRouter(simple_config, health_probe=raising_probe)
         router.on_cb_state_change("gpt-5.4", "closed", "open")
         assert not router.is_failed_over("gpt-5.4")
+
+    def test_hanging_probe_times_out_per_health_check_timeout_seconds(self) -> None:
+        """A probe that hangs longer than health_check_timeout_seconds must be cancelled.
+
+        Without timeout enforcement, a hanging probe blocks the calling thread
+        and leaves _failover_pending stuck True, silently disabling all
+        subsequent OPEN events for that backend.
+        """
+        cfg = FailoverConfig(
+            enabled=True,
+            regions={"gpt-5.4": ["us-east", "eu-west", "ap-southeast"]},
+            health_check_timeout_seconds=0.05,
+            min_failover_duration_seconds=30.0,
+        )
+
+        def hanging_probe(_region: str) -> bool:
+            # Block far longer than the configured timeout.
+            time.sleep(5.0)
+            return True
+
+        router = FailoverRouter(cfg, health_probe=hanging_probe)
+
+        start = time.monotonic()
+        router.on_cb_state_change("gpt-5.4", "closed", "open")
+        elapsed = time.monotonic() - start
+
+        # Two secondaries x 0.05s timeout => bounded above by ~0.5s with thread overhead.
+        assert elapsed < 1.0, f"on_cb_state_change should complete near timeout, took {elapsed:.2f}s"
+        assert not router.is_failed_over("gpt-5.4")
+        # The pending flag must be cleared so a subsequent OPEN can retry.
+        assert router._failover_pending.get("gpt-5.4", False) is False
 
     def test_get_active_region_returns_secondary_after_failover(self, simple_config: FailoverConfig) -> None:
         """get_active_region must return the secondary region after failover."""
@@ -156,6 +195,8 @@ class TestFailoverTrigger:
 
 
 class TestRecovery:
+    """on_cb_state_change("closed") + lazy recovery via observation methods."""
+
     def test_closed_after_min_duration_restores_primary(self, simple_config: FailoverConfig) -> None:
         """on_cb_state_change("closed") after min_failover_duration elapsed must restore primary."""
         now = [0.0]
@@ -211,7 +252,17 @@ class TestRecovery:
         real_lock = threading.Lock()
 
         class PostCommitHookLock:
+            """Lock proxy that injects a CLOSED notification after each commit-block lock release.
+
+            NOTE: this test deliberately reaches into private attrs
+            (_failover_at, _failover_pending) and replaces _lock to simulate a
+            CLOSED notification arriving in the post-commit/pre-finally window.
+            If FailoverRouter switches to RLock or renames these private
+            attributes, this test must be updated.
+            """
+
             def __enter__(self) -> None:
+                """Acquire the inner real lock."""
                 real_lock.acquire()
 
             def __exit__(
@@ -220,6 +271,7 @@ class TestRecovery:
                 exc_value: object,
                 traceback: object,
             ) -> bool:
+                """Release the lock, then optionally fire a one-shot CLOSED notification."""
                 real_lock.release()
                 # After the atomic commit fix, pending is cleared at the same
                 # lock acquisition that writes _failover_at, so the "in window"
@@ -399,6 +451,8 @@ class TestRecovery:
 
 
 class TestMultiBackendIsolation:
+    """Per-backend state must not leak across backends."""
+
     def test_failover_for_one_backend_does_not_affect_another(self) -> None:
         """Failover for backend A must not change the active region of backend B."""
         cfg = FailoverConfig(
@@ -438,6 +492,8 @@ class TestMultiBackendIsolation:
 
 
 class TestLLMCBIntegration:
+    """Wiring between LLMCircuitBreaker state transitions and FailoverRouter notifications."""
+
     def test_llm_cb_failover_none_is_back_compat(self, cb_config: LLMCircuitBreakerConfig) -> None:
         """LLMCircuitBreaker(failover=None) must behave identically to pre-Phase 6."""
         cb = LLMCircuitBreaker(cb_config, failover=None)
@@ -513,6 +569,8 @@ class TestLLMCBIntegration:
 
 
 class TestConcurrency:
+    """Multi-thread safety of FailoverRouter operations."""
+
     def test_concurrent_open_events_commit_exactly_one_failover(
         self,
         simple_config: FailoverConfig,
@@ -648,6 +706,8 @@ class TestConcurrency:
 
 
 class TestAdversarial:
+    """Edge cases and attacker-mindset scenarios."""
+
     def test_on_cb_state_change_unknown_old_state_does_not_crash(
         self,
         simple_config: FailoverConfig,
@@ -749,11 +809,13 @@ class TestAdversarial:
 
 
 # ---------------------------------------------------------------------------
-# Category H: Phase 6 integration (1 test)
+# Category H: Phase 6 integration (4 tests)
 # ---------------------------------------------------------------------------
 
 
 class TestPhase6Integration:
+    """Phase 6 BaseException handler integration with LLMCircuitBreaker."""
+
     @pytest.mark.asyncio
     async def test_base_exception_probe_reopen_notifies_failover(
         self,
@@ -781,3 +843,44 @@ class TestPhase6Integration:
             "half_open",
             "open",
         )
+
+    def test_notify_failover_propagates_keyboard_interrupt(
+        self,
+        cb_config: LLMCircuitBreakerConfig,
+    ) -> None:
+        """A router raising KeyboardInterrupt must propagate; CB must not silently swallow it."""
+        failover = unittest.mock.Mock()
+        failover.on_cb_state_change.side_effect = KeyboardInterrupt()
+        cb = LLMCircuitBreaker(cb_config, backend_name="gpt-5.4", failover=failover)
+
+        with pytest.raises(KeyboardInterrupt):
+            for _ in range(cb_config.max_failures):
+                cb.record_failure()
+
+    def test_notify_failover_propagates_system_exit(
+        self,
+        cb_config: LLMCircuitBreakerConfig,
+    ) -> None:
+        """A router raising SystemExit must propagate; CB must not silently swallow it."""
+        failover = unittest.mock.Mock()
+        failover.on_cb_state_change.side_effect = SystemExit(1)
+        cb = LLMCircuitBreaker(cb_config, backend_name="gpt-5.4", failover=failover)
+
+        with pytest.raises(SystemExit):
+            for _ in range(cb_config.max_failures):
+                cb.record_failure()
+
+    def test_notify_failover_swallows_generic_exception(
+        self,
+        cb_config: LLMCircuitBreakerConfig,
+    ) -> None:
+        """A router raising RuntimeError must be swallowed; CB state mutation completes."""
+        failover = unittest.mock.Mock()
+        failover.on_cb_state_change.side_effect = RuntimeError("router bug")
+        cb = LLMCircuitBreaker(cb_config, backend_name="gpt-5.4", failover=failover)
+
+        # Drive to OPEN. record_failure must not raise even though router raises.
+        for _ in range(cb_config.max_failures):
+            cb.record_failure()
+        assert cb.state == CircuitState.OPEN
+        assert failover.on_cb_state_change.called


### PR DESCRIPTION
## Description
Continues #1024/#1038 (Phase 1/2), #1056 (Phase 3 metrics), #1061 (Phase 4 distributed store), #1065 (Phase 5 adaptive). Adds opt-in multi-region failover.

Problem: a circuit breaker stops traffic to a failed backend, it doesn't redirect it. When us-east goes down, every request fails until us-east comes back, even when eu-west is healthy. The fix is to attach a router to the CB so the same OPEN transition that stops the primary triggers a health probe on a configured secondary; if the probe passes, traffic shifts there. When the primary closes, the router restores it after `min_failover_duration_seconds` so we don't flap.

`massgen/backend/cb_failover.py` is a new 430-line module: `FailoverConfig` (dataclass) + `FailoverRouter` (thread-safe, pure Python, no new deps) + a `_try_lazy_recovery_unlocked` helper. `LLMCircuitBreaker.__init__` takes an optional `failover=` router. With `failover=None` nothing changes -- all 195 existing CB tests pass unmodified.

### What the router does
- `on_cb_state_change(backend, old, "open")`: if not already failed over and no probe in flight, claim the probe slot, run `health_probe(secondary)`, and on success commit `_active_region[backend] = secondary` + `_failover_at[backend] = clock()` atomically under lock.
- `on_cb_state_change(backend, old, "closed")`: if failover_at is set and `clock() - failover_at >= min_failover_duration_seconds`, restore primary; otherwise log and defer.
- `get_active_region` / `is_failed_over` / `snapshot` all apply the same lazy recovery so observation methods stay consistent without a background thread.
- `reset(backend)` is admin override -- clears state regardless of min duration, and invalidates an in-flight probe via the pending flag.

### Wiring into LLMCircuitBreaker
- `record_failure` / `record_success` / `force_open` / `reset` all notify the router on state transitions, gated by `if self._failover is not None`.
- BaseException probe-reopen path (HALF_OPEN -> OPEN on cancellation) also notifies, wrapped in `except BaseException: logger.warning(..., exc_info=True)` so a misbehaving router can't mask the original raise.
- `LLMCircuitBreaker(failover=None)` is the default and unchanged.

### Concurrency hazards handled
- TOCTOU on probe slot: `_failover_pending` flag, claimed under lock before probe; concurrent OPEN events see pending=True and return.
- CLOSED arriving mid-probe: `_closed_during_probe` latch; commit guard checks it and aborts so the backend isn't stranded on secondary.
- `reset()` racing an in-flight probe: commit guard checks `_failover_pending` and aborts when the admin reset clears it; reset wins.
- Atomic pending+latch clear at commit (not just in finally) so a subsequent OPEN doesn't see a transient `(failed_over=True, pending=True)` and get suppressed.
- `if not committed:` on the finally block so a committed probe doesn't wipe a subsequent concurrent probe's pending claim.

### Tests
45 new tests in `massgen/tests/test_cb_failover.py` (783 lines):
- config validation: empty/whitespace/duplicate region rejection, bounds checks
- failover trigger: healthy probe, failing probe, raising probe, get_active_region after commit
- recovery: min-duration elapsed/deferred, post-commit window CLOSED, lazy recovery on get_active_region/is_failed_over/snapshot, negative elapsed (clock skew), min_duration=0 immediate, reset/unknown-backend
- multi-backend isolation: A failover does not affect B
- LLM CB integration: record_failure -> on_cb_state_change("open"), record_success from HALF_OPEN -> on_cb_state_change("closed"), force_open
- concurrency: 8-thread OPEN race -- exactly one probe call, exactly one commit; reader/writer concurrent
- adversarial: clock skew backward, idempotent double-OPEN, snapshot point-in-time consistency, no-secondary warning, reset during in-flight probe, CLOSED during in-flight probe
- Phase 6 BaseException integration: `asyncio.CancelledError` from probe re-opens CB and fires failover notification

## Type of change
- [x] New feature (`feat:`) - Non-breaking change which adds functionality

## Checklist
- [x] I have run pre-commit on my changed files and all checks pass
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (follow-up, not in this PR)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my feature works
- [x] New and existing unit tests pass locally with my changes

## Pre-commit status
```
$ pre-commit run --files massgen/backend/cb_failover.py massgen/backend/llm_circuit_breaker.py massgen/tests/test_cb_failover.py
check python ast.........................................................Passed
check docstring is first.................................................Passed
detect private key.......................................................Passed
trim trailing whitespace.................................................Passed
pyupgrade................................................................Passed
Add trailing commas......................................................Passed
isort....................................................................Passed
autoflake................................................................Passed
black....................................................................Passed
flake8...................................................................Passed
Check package with Pyroma................................................Passed
```

## How to Test
```bash
python -m pytest massgen/tests/test_cb_failover.py massgen/tests/test_cb_adaptive.py massgen/tests/test_cb_observability.py massgen/tests/test_cb_store.py massgen/tests/test_llm_circuit_breaker.py
```
Expected: 240 passed.

## Additional context
Every failover hook on `LLMCircuitBreaker` is guarded by `if self._failover is not None`. The Phase 4 `CircuitBreakerStore` and Phase 5 `AdaptiveController` contracts are unchanged.

Follow-ups deliberately out of scope: background recovery polling (currently lazy + event-driven only), async health probe, per-region CB state in `snapshot()`, cross-process failover coordination via the Phase 4 distributed store.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-region automatic failover with coordinated health probes and atomic region switching; optional integration with circuit-breaker transitions.

* **Configuration**
  * New settings: enable flag, per-backend ordered region lists, health-check timeout, minimum failover duration, and recovery check interval.

* **Reliability**
  * Single-probe coordination, probe timeout/exception handling, ordered transition delivery with stale-notification dropping, lazy recovery, and robust reset semantics.

* **Tests**
  * Extensive end-to-end tests covering timing, concurrency, edge cases, and failover + circuit-breaker integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->