### PR TITLE
feat: harden Antigravity CLI backend for v0.1.89

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -245,5 +245,11 @@ node_modules/
 .gemini/google_accounts.json
 .gemini/oauth_creds.json
 .gemini/.env
+# Antigravity CLI runtime artifacts (created by `agy` itself when invoked
+# from any directory — the upward project-discovery walk anchors here).
+# Without this, leftover dirs at the repo root can hijack a workspace
+# agent's project root and route file writes into agy's scratch dir.
+.antigravity/
+.antigravitycli/
 # WIP tests not yet implemented
 massgen/tests/_wip/

--- a/massgen/backend/antigravity_cli.py
+++ b/massgen/backend/antigravity_cli.py
@@ -392,13 +392,29 @@ class AntigravityCLIBackend(NativeToolBackendMixin, StreamingBufferMixin, LLMBac
         except OSError as exc:
             logger.warning(f"Antigravity CLI: failed to clean up AGENTS.md: {exc}")
 
-    def _write_workspace_settings_json(self) -> None:
+    def _workspace_hooks_json_path(self) -> Path:
+        """Path to agy's standalone hooks.json file.
+
+        Unlike Gemini CLI (which embeds hooks under ``"hooks"`` inside
+        ``settings.json``), agy 1.0.x reads hooks from a separate file.
+        Binary strings confirm: ``Loaded hooks.json from %s``,
+        ``No hooks.json found at %s``, ``failed to parse hooks.json``.
+        Subject to ``enableJsonHooks: true`` in settings.json (also
+        confirmed by ``json-hooks-enabled`` / ``EnableJsonHooks`` literals).
+        """
+        return self._workspace_config_dir() / "hooks.json"
+
+    def _write_workspace_settings_json(self, has_hooks: bool = False) -> None:
         """Write a minimal settings.json in the workspace config dir.
 
         In Docker mode (or any time we have an API key but no host OAuth
         login), this forces agy to use `selectedType: "gemini-api-key"` so it
         won't try to start the OAuth flow inside a headless container. The key
         itself is provided via the ``GEMINI_API_KEY`` env var, not in this file.
+
+        When ``has_hooks=True``, also sets ``enableJsonHooks: true`` so agy
+        will pick up our workspace ``hooks.json``. Without this gate agy's
+        log shows ``skipping hooks.json at %s`` instead of ``Loaded hooks.json``.
         """
         config_dir = self._workspace_config_dir()
         config_dir.mkdir(parents=True, exist_ok=True)
@@ -417,7 +433,54 @@ class AntigravityCLIBackend(NativeToolBackendMixin, StreamingBufferMixin, LLMBac
                 )
         if self._docker_execution or self.api_key:
             settings.setdefault("security", {}).setdefault("auth", {})["selectedType"] = "gemini-api-key"
+        if has_hooks:
+            settings["enableJsonHooks"] = True
         settings_path.write_text(json.dumps(settings, indent=2), encoding="utf-8")
+
+    def _write_hooks_json(self) -> bool:
+        """Write a workspace-local hooks.json built from MassGen's hook adapter.
+
+        Returns True iff a non-empty hooks payload was written (caller uses
+        this to decide whether to set ``enableJsonHooks`` in settings.json).
+        """
+        adapter = self._native_hook_adapter if hasattr(self, "_native_hook_adapter") else None
+        if not adapter:
+            return False
+        # Hook adapter needs to know where its IPC dir lives. Mirror the
+        # gemini_cli pattern (gemini_cli.py:1163-1164) but use our
+        # workspace config dir.
+        if hasattr(adapter, "hook_dir"):
+            adapter.hook_dir = self._workspace_config_dir()
+        if not self._massgen_hooks_config or not hasattr(adapter, "build_native_hooks_config"):
+            return False
+        try:
+            from ..mcp_tools.hooks import (  # noqa: F401 — type ref for clarity
+                GeneralHookManager,
+            )
+        except ImportError:
+            pass
+        # The orchestrator already converted MassGen hooks to the native
+        # config shape via `set_native_hooks_config`; reuse that here.
+        hooks_payload = self._massgen_hooks_config
+        if not hooks_payload or not hooks_payload.get("hooks"):
+            return False
+        hooks_path = self._workspace_hooks_json_path()
+        hooks_path.parent.mkdir(parents=True, exist_ok=True)
+        hooks_path.write_text(json.dumps(hooks_payload, indent=2), encoding="utf-8")
+        logger.info(
+            f"Antigravity CLI: wrote hooks.json to {hooks_path} " f"(events: {sorted(hooks_payload.get('hooks', {}).keys())})",
+        )
+        return True
+
+    def _restore_hooks_json(self) -> None:
+        """Remove the workspace-local hooks.json written by this backend."""
+        hooks_path = self._workspace_hooks_json_path()
+        if hooks_path.exists():
+            try:
+                hooks_path.unlink()
+                logger.info(f"Antigravity CLI: removed workspace {hooks_path}")
+            except OSError as exc:
+                logger.warning(f"Antigravity CLI: failed to remove {hooks_path}: {exc}")
 
     # ── Command construction ──────────────────────────────────────────────
 
@@ -874,7 +937,13 @@ class AntigravityCLIBackend(NativeToolBackendMixin, StreamingBufferMixin, LLMBac
         full_prompt = "\n\n".join(p for p in prompt_parts if p)
 
         self._write_mcp_config()
-        self._write_workspace_settings_json()
+        # Hooks are gated by `enableJsonHooks: true` in settings.json (per agy's
+        # `json-hooks-enabled` feature flag). Write hooks.json first, then pass
+        # has_hooks to the settings writer so the flag and the file are emitted
+        # together — otherwise agy logs "skipping hooks.json" instead of
+        # "Loaded hooks.json".
+        hooks_written = self._write_hooks_json()
+        self._write_workspace_settings_json(has_hooks=hooks_written)
         self._write_system_prompt_md()
         try:
             try:
@@ -941,6 +1010,7 @@ class AntigravityCLIBackend(NativeToolBackendMixin, StreamingBufferMixin, LLMBac
                 self._finalize_streaming_buffer(agent_id=agent_id)
         finally:
             self._restore_mcp_config()
+            self._restore_hooks_json()
             self._restore_system_prompt_md()
 
     # ── Message helpers ───────────────────────────────────────────────────

--- a/massgen/backend/antigravity_cli.py
+++ b/massgen/backend/antigravity_cli.py
@@ -289,6 +289,33 @@ class AntigravityCLIBackend(NativeToolBackendMixin, StreamingBufferMixin, LLMBac
         """Project-scoped agy data root, passed via ``--gemini_dir``."""
         return Path(self.cwd).resolve() / ".antigravity"
 
+    def _workspace_project_marker_dir(self) -> Path:
+        """Workspace-anchor for agy's project discovery walk.
+
+        agy walks UP from cwd looking for ``.antigravitycli/`` to decide the
+        project root. Without an anchor at the workspace level, agy adopts
+        whichever ancestor directory happens to contain one — which can be
+        a sibling MassGen agent's leftover or even the user's repo root if
+        anyone has ever run ``agy`` interactively there. The wrong project
+        root makes ``--add-dir`` ineffective: agy still routes
+        ``write_to_file`` into its internal scratch directory, hidden from
+        peers and snapshot promotion.
+
+        Pre-creating an empty ``.antigravitycli/`` at the workspace stops
+        the upward walk here (verified live).
+        """
+        return Path(self.cwd).resolve() / ".antigravitycli"
+
+    def _ensure_workspace_project_marker(self) -> None:
+        """Idempotently create the workspace project-discovery anchor."""
+        marker = self._workspace_project_marker_dir()
+        try:
+            marker.mkdir(parents=True, exist_ok=True)
+        except OSError as exc:
+            logger.warning(
+                f"Antigravity CLI: could not create project marker {marker}: {exc} " "— agy may walk up to a parent's .antigravitycli and adopt the wrong project",
+            )
+
     def _workspace_mcp_config_path(self) -> Path:
         """Where to drop our merged mcp_config.json so agy reads it."""
         return self._workspace_config_dir() / "config" / "mcp_config.json"
@@ -936,6 +963,11 @@ class AntigravityCLIBackend(NativeToolBackendMixin, StreamingBufferMixin, LLMBac
         prompt_parts.append(prompt)
         full_prompt = "\n\n".join(p for p in prompt_parts if p)
 
+        # Anchor agy's project discovery at the workspace root. Without this,
+        # agy walks up looking for a `.antigravitycli/` directory and adopts
+        # whichever parent it finds first — breaking workspace isolation and
+        # making --add-dir ineffective.
+        self._ensure_workspace_project_marker()
         self._write_mcp_config()
         # Hooks are gated by `enableJsonHooks: true` in settings.json (per agy's
         # `json-hooks-enabled` feature flag). Write hooks.json first, then pass

--- a/massgen/backend/antigravity_cli.py
+++ b/massgen/backend/antigravity_cli.py
@@ -123,6 +123,47 @@ class AntigravityCLIBackend(NativeToolBackendMixin, StreamingBufferMixin, LLMBac
                 "Run `agy --version` to verify.",
             )
 
+        # Synchronous binary health check: confirm `agy --version` runs cleanly.
+        # Catches stale/corrupt installs (binary file exists but doesn't execute)
+        # before the orchestrator throws this agent into coordination.
+        # Cheap (~50ms, no API call) and the only way to fail fast on a broken
+        # binary — full auth verification would require a real call.
+        skip_health_check = kwargs.get("skip_health_check", False)
+        if not skip_health_check:
+            self._verify_agy_binary_runs()
+
+    def _verify_agy_binary_runs(self) -> None:
+        """Run ``agy --version`` and raise if the binary is unusable.
+
+        Surfaces a clear error at construction time instead of letting the
+        first orchestration call burn a round on a broken install.
+        """
+        import subprocess
+
+        try:
+            result = subprocess.run(
+                [self._agy_path, "--version"],
+                capture_output=True,
+                text=True,
+                timeout=5,
+                check=False,
+            )
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            raise RuntimeError(
+                f"Antigravity CLI ('agy' at {self._agy_path}) is installed but "
+                f"won't run: {exc}. Try `{self._agy_path} --version` manually, "
+                "or reinstall with `curl -fsSL https://antigravity.google/cli/install.sh | bash`.",
+            ) from exc
+        if result.returncode != 0:
+            stderr = (result.stderr or result.stdout or "").strip()
+            raise RuntimeError(
+                f"Antigravity CLI ('agy' at {self._agy_path}) exited with code "
+                f"{result.returncode} on `--version`. Output: {stderr or '(empty)'}. "
+                "Try reinstalling with `curl -fsSL https://antigravity.google/cli/install.sh | bash`.",
+            )
+        version = (result.stdout or "").strip()
+        logger.info(f"Antigravity CLI: binary health check passed (agy version {version})")
+
     @property
     def cwd(self) -> str:
         if self.filesystem_manager:
@@ -248,18 +289,24 @@ class AntigravityCLIBackend(NativeToolBackendMixin, StreamingBufferMixin, LLMBac
         return Path(self.cwd).resolve() / ".AGENTS.md.massgen_backup"
 
     def _write_system_prompt_md(self) -> None:
-        """Write the MassGen system prompt to <cwd>/AGENTS.md.
+        """Write the MassGen system prompt to <cwd>/AGENTS.md atomically.
 
         agy treats AGENTS.md as persistent workspace context (not as the user
         request), so the model sees coordination/workflow instructions in the
         right channel instead of inside ``<USER_REQUEST>``. Backs up any
         pre-existing AGENTS.md so :meth:`_restore_system_prompt_md` can put
         the original back.
+
+        Atomic-write semantics: writes to ``AGENTS.md.massgen_tmp`` first,
+        then ``os.replace()`` onto the target. If we're killed between the
+        backup-rename and the new-content write, the backup still exists and
+        :meth:`_restore_system_prompt_md` recovers cleanly.
         """
         if not self.system_prompt:
             return
         path = self._workspace_agents_md_path()
         backup = self._workspace_agents_md_backup_path()
+        tmp_path = path.with_suffix(path.suffix + ".massgen_tmp")
         path.parent.mkdir(parents=True, exist_ok=True)
         if path.exists() and not backup.exists():
             try:
@@ -267,15 +314,27 @@ class AntigravityCLIBackend(NativeToolBackendMixin, StreamingBufferMixin, LLMBac
                 logger.info(f"Antigravity CLI: backed up existing {path} -> {backup}")
             except OSError as exc:
                 logger.warning(f"Antigravity CLI: could not back up {path}: {exc}")
-        path.write_text(self.system_prompt, encoding="utf-8")
+        tmp_path.write_text(self.system_prompt, encoding="utf-8")
+        os.replace(tmp_path, path)
         logger.info(
             f"Antigravity CLI: wrote system prompt ({len(self.system_prompt)} chars) to {path}",
         )
 
     def _restore_system_prompt_md(self) -> None:
-        """Restore the user's original AGENTS.md, or remove ours if none existed."""
+        """Restore the user's original AGENTS.md, or remove ours if none existed.
+
+        Best-effort: never raises. Cleans up our temp file if a previous call
+        was killed mid-write (rare but possible if the orchestrator cancels
+        the streaming generator).
+        """
         path = self._workspace_agents_md_path()
         backup = self._workspace_agents_md_backup_path()
+        tmp_path = path.with_suffix(path.suffix + ".massgen_tmp")
+        try:
+            if tmp_path.exists():
+                tmp_path.unlink()
+        except OSError as exc:
+            logger.warning(f"Antigravity CLI: failed to remove stale {tmp_path}: {exc}")
         try:
             if backup.exists():
                 backup.replace(path)
@@ -543,6 +602,38 @@ class AntigravityCLIBackend(NativeToolBackendMixin, StreamingBufferMixin, LLMBac
 
     # ── Streaming ─────────────────────────────────────────────────────────
 
+    @staticmethod
+    async def _terminate_subprocess(
+        proc: asyncio.subprocess.Process,
+        grace_seconds: float = 2.0,
+    ) -> None:
+        """SIGTERM agy and wait up to ``grace_seconds`` before SIGKILL.
+
+        Used on cancellation / unexpected error so we don't leak an orphan
+        agy process when the orchestrator gives up on the agent (timeout,
+        round restart, user abort, etc.).
+        """
+        if proc.returncode is not None:
+            return
+        try:
+            proc.terminate()
+        except ProcessLookupError:
+            return
+        try:
+            await asyncio.wait_for(proc.wait(), timeout=grace_seconds)
+        except TimeoutError:
+            logger.warning(
+                f"Antigravity CLI: agy didn't exit within {grace_seconds}s of SIGTERM — sending SIGKILL",
+            )
+            try:
+                proc.kill()
+            except ProcessLookupError:
+                return
+            try:
+                await asyncio.wait_for(proc.wait(), timeout=grace_seconds)
+            except TimeoutError:
+                logger.error("Antigravity CLI: agy did not exit after SIGKILL — giving up")
+
     async def _stream_local(
         self,
         prompt: str,
@@ -595,8 +686,8 @@ class AntigravityCLIBackend(NativeToolBackendMixin, StreamingBufferMixin, LLMBac
             finally:
                 await queue.put(_DONE)
 
-        asyncio.create_task(_read_stdout())
-        asyncio.create_task(_tail())
+        stdout_task = asyncio.create_task(_read_stdout())
+        tail_task = asyncio.create_task(_tail())
 
         done_count = 0
         try:
@@ -606,8 +697,19 @@ class AntigravityCLIBackend(NativeToolBackendMixin, StreamingBufferMixin, LLMBac
                     done_count += 1
                 else:
                     yield item  # type: ignore[misc]
+        except (asyncio.CancelledError, GeneratorExit):
+            # Orchestrator cancelled us (timeout, user abort, etc.). Cleanly
+            # terminate agy so it doesn't outlive the agent task, then
+            # propagate. Background reader tasks observe proc exit and finish
+            # on their own.
+            logger.info("Antigravity CLI: cancellation requested — terminating agy subprocess")
+            await self._terminate_subprocess(proc)
+            for task in (stdout_task, tail_task):
+                task.cancel()
+            raise
         except Exception as exc:
             logger.error(f"Antigravity CLI streaming error: {exc}")
+            await self._terminate_subprocess(proc)
             yield StreamChunk(type="error", error=str(exc))
             return
 
@@ -734,10 +836,42 @@ class AntigravityCLIBackend(NativeToolBackendMixin, StreamingBufferMixin, LLMBac
 
     @staticmethod
     def _message_content_to_text(content: Any) -> str:
+        """Squash a message's content into plain text for the ``agy -p`` arg.
+
+        Multimodal parts (images, audio, video, files) are inlined as
+        human-readable references — agy has filesystem/shell tools and can
+        ``read`` paths or fetch URLs itself when asked. We never silently
+        drop a non-text part; the goal is that the model sees enough to act.
+        """
         if isinstance(content, str):
             return content
         if isinstance(content, list):
-            return "".join(c.get("text", "") for c in content if isinstance(c, dict) and isinstance(c.get("text"), str))
+            parts: list[str] = []
+            for c in content:
+                if not isinstance(c, dict):
+                    parts.append(str(c))
+                    continue
+                if isinstance(c.get("text"), str):
+                    parts.append(c["text"])
+                    continue
+                ctype = c.get("type") or ""
+                # Image / audio / video / file references — surface a path or
+                # URL the agent can use via its native filesystem tools.
+                for key in ("source_path", "image_path", "audio_path", "video_path", "file_path", "url", "image_url"):
+                    val = c.get(key)
+                    if isinstance(val, str) and val:
+                        kind = ctype or key.split("_")[0]
+                        parts.append(f"[{kind}: {val}]")
+                        break
+                else:
+                    # base64-inlined content: too large for the prompt;
+                    # surface a brief stub so the agent knows it exists.
+                    if c.get("base64"):
+                        mime = c.get("mime_type", "binary")
+                        parts.append(f"[inline {ctype or mime} attachment ({len(c.get('base64', ''))} chars b64) — write to a local file if you need to inspect it]")
+                    elif ctype:
+                        parts.append(f"[{ctype} part]")
+            return "".join(parts)
         return str(content)
 
     def _build_prompt_from_messages(self, messages: list[dict[str, Any]]) -> str:

--- a/massgen/backend/antigravity_cli.py
+++ b/massgen/backend/antigravity_cli.py
@@ -35,6 +35,7 @@ from __future__ import annotations
 import asyncio
 import json
 import os
+import re
 import shutil
 from collections.abc import AsyncGenerator
 from pathlib import Path
@@ -48,6 +49,17 @@ from .native_tool_mixin import NativeToolBackendMixin
 AGY_DEFAULT_MODEL_LABEL = "Gemini 3.5 Flash (High)"
 AGY_AGENT_ID_LITERAL = "antigravity_cli"
 AGY_MCP_CONFIG_PATH = Path.home() / ".gemini" / "config" / "mcp_config.json"
+
+# Mirrors gemini_cli.py:48-52 so workflow-mode inference behaves identically
+# across both Google-CLI backends. The orchestrator embeds prior-round
+# candidate answers in a `<CURRENT ANSWERS from the agents>…<END OF CURRENT
+# ANSWERS>` block in the user message; we use it to know whether `vote`
+# would be a valid action this turn.
+_RE_CURRENT_ANSWERS = re.compile(
+    r"<CURRENT ANSWERS from the agents>(.*?)<END OF CURRENT ANSWERS>",
+    re.IGNORECASE | re.DOTALL,
+)
+_RE_AGENT_TAG = re.compile(r"<agent[^>]*>", re.IGNORECASE)
 
 
 class AntigravityCLIBackend(NativeToolBackendMixin, StreamingBufferMixin, LLMBackend):
@@ -103,6 +115,14 @@ class AntigravityCLIBackend(NativeToolBackendMixin, StreamingBufferMixin, LLMBac
         # Workspace-local MCP config (managed via --gemini_dir).
         self._mcp_config_managed_names: set[str] = set()
 
+        # Workflow-mode state — ported from gemini_cli.py:105-109. Tracks whether
+        # `vote` is a valid action this turn (depends on whether prior rounds
+        # produced candidate answers) and whether we've already accepted a
+        # workflow tool call in the current stream (dedup against double-emits).
+        self._workflow_call_mode: str = "any"
+        self._workflow_call_emitted_this_turn: bool = False
+        self._last_turn_missing_workflow_call: bool = False
+
         # Docker mode: agy's OAuth token state lives in HOME-scoped storage that
         # doesn't cross container boundaries. Require an API key instead.
         self._docker_execution = kwargs.get("command_line_execution_mode") == "docker"
@@ -131,6 +151,33 @@ class AntigravityCLIBackend(NativeToolBackendMixin, StreamingBufferMixin, LLMBac
         skip_health_check = kwargs.get("skip_health_check", False)
         if not skip_health_check:
             self._verify_agy_binary_runs()
+
+    def _has_cached_credentials(self) -> bool:
+        """True iff agy has a usable credential path available.
+
+        Parity with gemini_cli.py:255. agy honors:
+        - ``GEMINI_API_KEY`` / ``GOOGLE_API_KEY`` env (passed through subprocess)
+        - ``~/.gemini/google_accounts.json`` (Google OAuth login)
+        - ``~/.gemini/oauth_creds.json`` (alternate OAuth cache)
+        Returning False means the next ``agy -p`` call will hit the silent
+        UNAUTHENTICATED path our log scanner catches; we'd rather fail fast.
+        """
+        if self.api_key:
+            return True
+        gemini_home = Path.home() / ".gemini"
+        return (gemini_home / "google_accounts.json").exists() or (gemini_home / "oauth_creds.json").exists()
+
+    async def _ensure_authenticated(self) -> None:
+        """Raise if no credential source is available before launching agy.
+
+        Mirrors gemini_cli.py:262. Avoids burning a coordination round on an
+        empty agy run when the user just hasn't logged in / set an API key.
+        """
+        if self._has_cached_credentials():
+            return
+        raise RuntimeError(
+            "Antigravity CLI not authenticated. Run `agy` interactively to log in, " "or set GEMINI_API_KEY or GOOGLE_API_KEY in your environment.",
+        )
 
     def _verify_agy_binary_runs(self) -> None:
         """Run ``agy --version`` and raise if the binary is unusable.
@@ -756,6 +803,16 @@ class AntigravityCLIBackend(NativeToolBackendMixin, StreamingBufferMixin, LLMBac
         from ..tool.workflow_toolkits.base import WORKFLOW_TOOL_NAMES
         from .base import build_workflow_instructions, parse_workflow_tool_calls
 
+        # Pick up agent_id from kwargs so transcript-emitter events label the
+        # right agent (siblings do the same). Falls back to construction-time id.
+        self.agent_id = self.agent_id or kwargs.get("agent_id")
+
+        try:
+            await self._ensure_authenticated()
+        except RuntimeError as exc:
+            yield StreamChunk(type="error", error=str(exc))
+            return
+
         prompt = self._build_prompt_from_messages(messages)
         if not prompt.strip():
             yield StreamChunk(type="error", error="No user message found in messages")
@@ -765,11 +822,26 @@ class AntigravityCLIBackend(NativeToolBackendMixin, StreamingBufferMixin, LLMBac
         if latest_system:
             self.system_prompt = latest_system
 
-        # Workflow tools via text fallback: detect them in the tools arg, inject
-        # formatting guidance into the prompt, and parse stdout for matching calls.
-        workflow_tools_present = any((t.get("function", {}).get("name") or t.get("name")) in WORKFLOW_TOOL_NAMES for t in (tools or []))
-        workflow_instructions = build_workflow_instructions(tools or []) if workflow_tools_present else ""
-        workflow_allowed_names = {(t.get("function", {}).get("name") or t.get("name")) for t in (tools or []) if (t.get("function", {}).get("name") or t.get("name")) in WORKFLOW_TOOL_NAMES}
+        # Workflow-mode inference (parity with gemini_cli): when prior rounds
+        # produced no candidate answers, `vote` is not a valid action this
+        # turn — strip it from both the tool exposure to agy and from any
+        # text-fallback calls we parse back.
+        self._workflow_call_mode = self._infer_workflow_call_mode(messages, tools or [])
+        mode_filtered_tools = self._filter_workflow_tools_for_mode(tools or [], self._workflow_call_mode)
+        if self._workflow_call_mode == "new_answer_only" and len(mode_filtered_tools) != len(tools or []):
+            logger.info("Antigravity CLI: new_answer_only mode active; omitting vote from workflow toolset")
+
+        # Reset per-turn dedup flag now that we know we're entering a new stream.
+        self._workflow_call_emitted_this_turn = False
+
+        # Workflow tools via text fallback: detect them in the (mode-filtered)
+        # tools arg, inject formatting guidance into the prompt, and parse
+        # stdout for matching calls. agy 1.0.x does not expose MCP tools as
+        # native tools in print mode (confirmed by binary-strings probe + live
+        # test), so text fallback is the only path.
+        workflow_tools_present = any((t.get("function", {}).get("name") or t.get("name")) in WORKFLOW_TOOL_NAMES for t in mode_filtered_tools)
+        workflow_instructions = build_workflow_instructions(mode_filtered_tools) if workflow_tools_present else ""
+        workflow_allowed_names = {(t.get("function", {}).get("name") or t.get("name")) for t in mode_filtered_tools if (t.get("function", {}).get("name") or t.get("name")) in WORKFLOW_TOOL_NAMES}
 
         # agy -p has no separate system channel — anything prepended to the
         # prompt ends up inside <USER_REQUEST>, which confused the model. The
@@ -777,6 +849,12 @@ class AntigravityCLIBackend(NativeToolBackendMixin, StreamingBufferMixin, LLMBac
         # as workspace context); the -p argument carries only workflow tool
         # guidance and the actual user message.
         prompt_parts: list[str] = []
+        # Post-evaluation phase guard (parity with gemini_cli) — only fires when
+        # `submit` AND `restart_orchestration` are both in the tools list.
+        phase_prefix = self._build_phase_prompt_prefix(tools or [])
+        if phase_prefix:
+            prompt_parts.append(phase_prefix)
+            logger.info("Antigravity CLI: applying post-evaluation prompt guard")
         if workflow_instructions:
             prompt_parts.append(workflow_instructions)
         prompt_parts.append(prompt)
@@ -807,20 +885,40 @@ class AntigravityCLIBackend(NativeToolBackendMixin, StreamingBufferMixin, LLMBac
                     continue
                 yield chunk
 
+            yielded_any_workflow_call = False
             if workflow_tools_present and accumulated_content:
                 tool_calls = parse_workflow_tool_calls(
                     accumulated_content,
                     allowed_tool_names=workflow_allowed_names or None,
                 )
+                original_count = len(tool_calls)
+                tool_calls = self._filter_workflow_tool_calls_for_mode(tool_calls, self._workflow_call_mode)
+                if len(tool_calls) != original_count:
+                    logger.info(
+                        f"Antigravity CLI: dropped {original_count - len(tool_calls)} parsed " f"workflow tool call(s) invalid for mode={self._workflow_call_mode}",
+                    )
+                if tool_calls and self._workflow_call_emitted_this_turn:
+                    # Already yielded one workflow call this stream; suppress
+                    # duplicates so the orchestrator doesn't see multiple
+                    # new_answer submissions in a single turn.
+                    logger.info("Antigravity CLI: suppressing duplicate workflow tool call(s) (already emitted this turn)")
+                    tool_calls = []
                 if tool_calls:
                     logger.info(
                         f"Antigravity CLI: parsed {len(tool_calls)} workflow tool call(s) " f"from agy stdout (text fallback path)",
                     )
+                    self._workflow_call_emitted_this_turn = True
+                    yielded_any_workflow_call = True
                     yield StreamChunk(
                         type="tool_calls",
                         tool_calls=tool_calls,
                         source="antigravity_cli",
                     )
+
+            # Track for next-turn diagnostics + retry-mode logic. Mirrors
+            # gemini_cli.py:1553 — when set, callers (or future logic here)
+            # can treat the prior turn as a no-decision turn.
+            self._last_turn_missing_workflow_call = workflow_tools_present and not yielded_any_workflow_call
 
             if done_chunk is not None:
                 yield done_chunk
@@ -887,6 +985,113 @@ class AntigravityCLIBackend(NativeToolBackendMixin, StreamingBufferMixin, LLMBac
             if msg.get("role") == "system":
                 latest = self._message_content_to_text(msg.get("content", ""))
         return latest
+
+    # ── Workflow-mode inference (parity with gemini_cli.py) ───────────────
+
+    @staticmethod
+    def _extract_latest_current_answers_block(messages: list[dict[str, Any]]) -> str | None:
+        """Extract the latest <CURRENT ANSWERS …> block from messages.
+
+        Ported verbatim from gemini_cli.py:347. The orchestrator embeds prior-
+        round candidate answers in this block; presence + emptiness drives
+        whether ``vote`` is a valid action this turn.
+        """
+        for msg in reversed(messages or []):
+            content = msg.get("content", "") if isinstance(msg, dict) else ""
+            text = AntigravityCLIBackend._message_content_to_text(content)
+            matches = list(_RE_CURRENT_ANSWERS.finditer(text))
+            if matches:
+                return matches[-1].group(1)
+        return None
+
+    @staticmethod
+    def _current_answers_block_has_answers(block: str) -> bool:
+        """True iff the block contains at least one ``<agent…>`` tag.
+
+        Mirrors gemini_cli.py:358.
+        """
+        return bool(_RE_AGENT_TAG.search(block or ""))
+
+    def _infer_workflow_call_mode(self, messages: list[dict[str, Any]], tools: list[dict[str, Any]]) -> str:
+        """Infer whether ``vote`` is valid this turn or only ``new_answer``.
+
+        Returns ``"new_answer_only"`` when a CURRENT ANSWERS block exists but
+        contains no candidate answers (so voting has no target). Returns
+        ``"any"`` otherwise. Retry-sticky: once ``new_answer_only`` is set,
+        sticks until a non-empty CURRENT ANSWERS block appears.
+
+        Mirrors gemini_cli.py:448 exactly so cross-backend behavior stays
+        consistent in multi-agent runs.
+        """
+        tool_names = {t.get("function", {}).get("name") for t in (tools or [])}
+        if "vote" not in tool_names or "new_answer" not in tool_names:
+            return "any"
+
+        current_answers_block = self._extract_latest_current_answers_block(messages)
+        if current_answers_block is not None:
+            if self._current_answers_block_has_answers(current_answers_block):
+                return "any"
+            return "new_answer_only"
+
+        # No block at all → preserve any prior new_answer_only sticky decision.
+        if self._workflow_call_mode == "new_answer_only":
+            return "new_answer_only"
+        return "any"
+
+    @staticmethod
+    def _filter_workflow_tools_for_mode(
+        tools: list[dict[str, Any]],
+        workflow_call_mode: str,
+    ) -> list[dict[str, Any]]:
+        """Hide ``vote`` from the toolset when no answers exist to vote on.
+
+        Mirrors gemini_cli.py:472.
+        """
+        if workflow_call_mode != "new_answer_only":
+            return list(tools or [])
+        return [t for t in (tools or []) if (t.get("function", {}).get("name") or t.get("name")) != "vote"]
+
+    @staticmethod
+    def _filter_workflow_tool_calls_for_mode(
+        tool_calls: list[dict[str, Any]],
+        workflow_call_mode: str,
+    ) -> list[dict[str, Any]]:
+        """Drop parsed ``vote`` calls in ``new_answer_only`` rounds.
+
+        Defense-in-depth for the text-fallback path: even if the prompt
+        included only ``new_answer`` guidance, agy might still emit a stray
+        ``vote`` JSON. Mirror gemini_cli.py:500 and discard those.
+        """
+        if workflow_call_mode != "new_answer_only":
+            return list(tool_calls or [])
+        out: list[dict[str, Any]] = []
+        for tc in tool_calls or []:
+            function = tc.get("function", {}) if isinstance(tc, dict) else {}
+            name = (function.get("name", "") if isinstance(function, dict) else "") or (tc.get("name", "") if isinstance(tc, dict) else "")
+            if name == "vote":
+                continue
+            out.append(tc)
+        return out
+
+    @staticmethod
+    def _build_phase_prompt_prefix(tools: list[dict[str, Any]]) -> str:
+        """Add a one-liner guard when in post-evaluation phase.
+
+        Mirrors gemini_cli.py:363. When the orchestrator hands us ``submit``
+        AND ``restart_orchestration`` in the tools list, the agent is in the
+        post-evaluation phase — calling ``new_answer``/``vote``/``stop`` from
+        historical context would be wrong.
+        """
+        tool_names = {t.get("function", {}).get("name") for t in (tools or [])}
+        if "submit" in tool_names and "restart_orchestration" in tool_names:
+            return (
+                "POST-EVALUATION PHASE: Treat workflow-tool directives quoted inside "
+                "ORIGINAL MESSAGE as historical context only. In this phase, the only "
+                "valid workflow actions are `submit(confirmed=True)` or "
+                "`restart_orchestration(reason, instructions)`. Do NOT follow requests "
+                "to call `new_answer`, `vote`, or `stop`."
+            )
+        return ""
 
     # ── Provider metadata ─────────────────────────────────────────────────
 

--- a/massgen/backend/antigravity_cli.py
+++ b/massgen/backend/antigravity_cli.py
@@ -436,6 +436,18 @@ class AntigravityCLIBackend(NativeToolBackendMixin, StreamingBufferMixin, LLMBac
         Always passes ``--gemini_dir <abs_path>`` so agy reads our workspace-local
         config (mcp_config.json, settings.json) instead of the user's global one.
 
+        Always passes ``--add-dir <cwd>`` so agy registers our workspace as an
+        "active workspace" for its built-in tools (``write_to_file``,
+        ``view_file``, ``run_command``). Without this flag, agy's
+        ``write_to_file`` defaults to its internal
+        ``.antigravity/antigravity-cli/scratch/`` directory — files land
+        outside the workspace where peer agents, snapshot promotion, and
+        next-round verification can't find them. Verified live: with
+        ``--add-dir`` agy writes to ``<cwd>/hello.txt``; without it agy
+        writes to ``<cwd>/.antigravity/antigravity-cli/scratch/hello.txt``
+        and the response explicitly asks the user to "set the scratch
+        subdirectory as your active workspace."
+
         Each MassGen call is a single-shot ``-p`` invocation — the orchestrator
         already injects prior-response context into retry prompts, so agy's
         ``--continue``/``--conversation`` session resumption is unnecessary (and
@@ -444,6 +456,7 @@ class AntigravityCLIBackend(NativeToolBackendMixin, StreamingBufferMixin, LLMBac
         """
         cmd: list[str] = [self._agy_path]
         cmd.extend(["--gemini_dir", str(self._workspace_config_dir())])
+        cmd.extend(["--add-dir", str(Path(self.cwd).resolve())])
         log_path = self._agy_log_file_path()
         log_path.parent.mkdir(parents=True, exist_ok=True)
         cmd.extend(["--log-file", str(log_path)])

--- a/massgen/mcp_tools/native_hook_adapters/antigravity_cli_adapter.py
+++ b/massgen/mcp_tools/native_hook_adapters/antigravity_cli_adapter.py
@@ -1,18 +1,23 @@
 """Antigravity CLI native hook adapter.
 
-agy 1.0.0 inherits Gemini CLI's hook framework verbatim — same ``exa.hooks_pb``
-proto schema, same ``BeforeTool`` / ``AfterTool`` / ``Stop`` event names,
-same ``settings.json`` shape, and the same ``~/.gemini/trusted_hooks.json``
-trust file. Confirmed by inspecting binary strings on agy 1.0.0:
+agy 1.0.x inherits Gemini CLI's hook *proto schema* (``exa.hooks_pb`` —
+same ``BeforeTool`` / ``AfterTool`` / ``Stop`` event shape, same
+``hooks.json`` payload structure) but stores it in a **standalone
+``hooks.json`` file**, not embedded inside ``settings.json`` like
+Gemini CLI does. Confirmed by inspecting binary strings on agy 1.0.1:
 
 - ``PreToolHookArgs`` / ``PostToolHookArgs`` / ``StopHookArgs`` protos
 - ``"Loaded hooks.json from %s: %d named hooks, %d total handlers"``
-- ``"json-hooks-enabled"`` / ``"trustedHooks"`` literals
+- ``"No hooks.json found at %s"``
+- ``"failed to parse hooks.json at %s: %v"``
+- ``Hooks json:"hooks"`` proto field tag (outer ``"hooks"`` key required)
+- ``"json-hooks-enabled"`` / ``EnableJsonHooks`` cliSetting gate
 
+Wiring lives in :class:`AntigravityCLIBackend` (see
+``_write_hooks_json`` + ``_write_workspace_settings_json(has_hooks=True)``).
 The hook script (``gemini_cli_hook_script.py``) is reusable as-is — the
-JSON-on-stdin / JSON-on-stdout contract is identical. This adapter exists
-only so backend dispatch is explicit and we can diverge cleanly if Google
-changes the hook protocol in a future agy release.
+JSON-on-stdin / JSON-on-stdout IPC contract is identical, only the
+on-disk location of the config differs.
 """
 
 from __future__ import annotations
@@ -21,9 +26,12 @@ from .gemini_cli_adapter import GeminiCLINativeHookAdapter
 
 
 class AntigravityCLINativeHookAdapter(GeminiCLINativeHookAdapter):
-    """Adapt MassGen hooks to agy's settings.json hook format.
+    """Adapt MassGen hooks to agy's hooks.json format.
 
-    Identical to ``GeminiCLINativeHookAdapter`` because agy v1.0.0 reuses
-    the Gemini CLI ``exa.hooks_pb`` proto schema. Subclassed solely so
-    backend dispatch is explicit and divergence is cheap if needed later.
+    Inherits ``build_native_hooks_config`` from
+    :class:`GeminiCLINativeHookAdapter` unchanged — the returned
+    ``{"hooks": {"BeforeTool": [...], "AfterTool": [...]}}`` payload is
+    valid for both Gemini CLI ``settings.json["hooks"]`` and agy's
+    standalone ``hooks.json``. The backend handles the destination-file
+    divergence.
     """

--- a/massgen/system_message_builder.py
+++ b/massgen/system_message_builder.py
@@ -631,10 +631,13 @@ class SystemMessageBuilder:
                 logger.info(f"[SystemMessageBuilder] Added subagent section for {agent_id} (max_concurrent: {max_concurrent}, specialized_types: {len(specialized_subagents)})")
 
         # PRIORITY 10 (MEDIUM): Task Context (when multimodal tools OR subagents are enabled)
-        # This instructs agents to create CONTEXT.md before using tools that make external API calls
+        # This instructs agents to create CONTEXT.md before using tools that make external API calls.
+        # We pass `subagents_enabled` so the section only advertises `spawn_subagents` when it's
+        # actually wired — otherwise models hallucinate phantom subagent MCP calls (e.g.,
+        # `mcp__subagent_<8hex>__list_subagents`) and retry-loop against a non-existent server.
         enable_multimodal = agent.backend.config.get("enable_multimodal_tools", False) if agent.backend else False
         if enable_multimodal or enable_subagents:
-            builder.add_section(TaskContextSection())
+            builder.add_section(TaskContextSection(subagents_enabled=enable_subagents))
             logger.info(f"[SystemMessageBuilder] Added task context section for {agent_id} (multimodal: {enable_multimodal}, subagents: {enable_subagents})")
 
         # PRIORITY 10 (MEDIUM): Task Planning

--- a/massgen/system_prompt_sections.py
+++ b/massgen/system_prompt_sections.py
@@ -6319,21 +6319,52 @@ class TaskContextSection(SystemPromptSection):
     task-specific terminology.
 
     MEDIUM priority - included when multimodal tools or subagents are enabled.
+
+    Args:
+        subagents_enabled: When True, the prompt advertises `spawn_subagents`
+            and explains the inheritance behavior. When False (multimodal-only
+            agents), all subagent affordances are suppressed — otherwise the
+            model fabricates phantom MCP calls like
+            `mcp__subagent_<8hex>__list_subagents` for a tool that was never
+            registered. Per the "remove affordances at the source" rule:
+            mode-gating a capability means stripping it from the prompt, not
+            blocking it at runtime.
     """
 
-    def __init__(self):
+    def __init__(self, subagents_enabled: bool = False):
         super().__init__(
             title="Task Context",
             priority=Priority.MEDIUM,
             xml_tag="task_context",
         )
+        self.subagents_enabled = subagents_enabled
 
     def build_content(self) -> str:
-        return """## Task Context for Tools and Subagents
+        if self.subagents_enabled:
+            header = (
+                "**REQUIRED**: Before spawning subagents or using `read_media`,\n"
+                "you MUST create a `CONTEXT.md` file in your workspace with task context.\n"
+                "This ordering is strict even for background jobs: write `CONTEXT.md` first, then start `read_media`."
+            )
+            when_to_create = (
+                "Create CONTEXT.md **before** your first use of:\n" "- `spawn_subagents` - subagents will inherit this context\n" "- `read_media` - image/audio/video analysis will use this context"
+            )
+            title_suffix = "Tools and Subagents"
+            audience = "tools or subagents"
+        else:
+            header = (
+                "**REQUIRED**: Before using `read_media`, you MUST create a "
+                "`CONTEXT.md` file in your workspace with task context.\n"
+                "This ordering is strict even for background jobs: write "
+                "`CONTEXT.md` first, then start `read_media`."
+            )
+            when_to_create = "Create CONTEXT.md **before** your first use of:\n" "- `read_media` - image/audio/video analysis will use this context"
+            title_suffix = "Multimodal Tools"
+            audience = "tools"
 
-**REQUIRED**: Before spawning subagents or using `read_media`,
-you MUST create a `CONTEXT.md` file in your workspace with task context.
-This ordering is strict even for background jobs: write `CONTEXT.md` first, then start `read_media`.
+        return f"""## Task Context for {title_suffix}
+
+{header}
 
 `generate_media` does **not** require CONTEXT.md — it works without it.
 
@@ -6347,7 +6378,7 @@ Write a brief file explaining:
 - **What we're building/doing** - the core task in 1-2 sentences
 - **Key terminology** - project-specific terms that could be misinterpreted
 - **Visual/brand details** - style, colors, aesthetic if relevant
-- **Any other context** tools or subagents need to understand the task
+- **Any other context** {audience} need to understand the task
 
 ### Example CONTEXT.md
 ```markdown
@@ -6368,9 +6399,7 @@ that coordinates parallel AI agents through voting and consensus.
 ```
 
 ### When to Create It
-Create CONTEXT.md **before** your first use of:
-- `spawn_subagents` - subagents will inherit this context
-- `read_media` - image/audio/video analysis will use this context
+{when_to_create}
 
 The file will be read automatically and injected into external API calls.
 `generate_media` does not require CONTEXT.md."""

--- a/massgen/tests/test_antigravity_cli_backend.py
+++ b/massgen/tests/test_antigravity_cli_backend.py
@@ -395,6 +395,45 @@ class TestStdoutStreamingParser:
         assert any("Antigravity CLI ERROR" in (c.content or "") for c in contents)
 
 
+class TestWorkspaceProjectMarker:
+    """agy walks up from cwd looking for `.antigravitycli/` to identify its
+    project root. Without an anchor at the workspace level, agy adopts
+    whichever ancestor directory happens to contain one — making --add-dir
+    ineffective and routing file writes to agy's internal scratch directory.
+    """
+
+    def test_project_marker_path_is_under_workspace_cwd(self, backend, tmp_path):
+        marker = backend._workspace_project_marker_dir()
+        assert marker.name == ".antigravitycli"
+        # Must be in the workspace ROOT, not inside .antigravity/
+        assert marker.parent == Path(backend.cwd).resolve()
+
+    def test_ensure_creates_empty_marker_dir_when_missing(self, backend, tmp_path):
+        marker = backend._workspace_project_marker_dir()
+        assert not marker.exists()
+        backend._ensure_workspace_project_marker()
+        assert marker.exists() and marker.is_dir()
+
+    def test_ensure_is_idempotent_when_marker_already_exists(self, backend, tmp_path):
+        marker = backend._workspace_project_marker_dir()
+        marker.mkdir(parents=True, exist_ok=True)
+        # Add a sentinel file so we can detect destructive recreation.
+        (marker / "sentinel.json").write_text("preserve me")
+        backend._ensure_workspace_project_marker()
+        assert (marker / "sentinel.json").exists()
+        assert (marker / "sentinel.json").read_text() == "preserve me"
+
+    def test_ensure_does_not_raise_on_oserror(self, backend, tmp_path, monkeypatch):
+        # Simulate a filesystem error — the warning is logged but we must
+        # not abort the backend startup over a non-fatal anchor failure.
+        def _boom(*a, **kw):
+            raise OSError("simulated")
+
+        monkeypatch.setattr(Path, "mkdir", _boom)
+        # Must not raise.
+        backend._ensure_workspace_project_marker()
+
+
 class TestHooksJsonWiring:
     """agy reads hooks from a standalone hooks.json (NOT embedded in
     settings.json like gemini_cli) and only when ``enableJsonHooks: true``

--- a/massgen/tests/test_antigravity_cli_backend.py
+++ b/massgen/tests/test_antigravity_cli_backend.py
@@ -395,6 +395,88 @@ class TestStdoutStreamingParser:
         assert any("Antigravity CLI ERROR" in (c.content or "") for c in contents)
 
 
+class TestHooksJsonWiring:
+    """agy reads hooks from a standalone hooks.json (NOT embedded in
+    settings.json like gemini_cli) and only when ``enableJsonHooks: true``
+    is set in settings.json. Verified via binary-strings probe + live test.
+    """
+
+    def test_hooks_json_path_lives_in_workspace_config_dir(self, backend, tmp_path):
+        path = backend._workspace_hooks_json_path()
+        assert path.name == "hooks.json"
+        # Must be under .antigravity/ so --gemini_dir points agy at it.
+        assert ".antigravity" in str(path)
+
+    def test_write_hooks_json_returns_false_when_no_hooks(self, backend, tmp_path):
+        backend._config_cwd = str(tmp_path)
+        backend._massgen_hooks_config = None
+        assert backend._write_hooks_json() is False
+        assert not backend._workspace_hooks_json_path().exists()
+
+    def test_write_hooks_json_returns_false_for_empty_hooks_payload(self, backend, tmp_path):
+        backend._config_cwd = str(tmp_path)
+        backend._massgen_hooks_config = {"hooks": {}}
+        assert backend._write_hooks_json() is False
+
+    def test_write_hooks_json_emits_file_when_hooks_present(self, backend, tmp_path):
+        backend._config_cwd = str(tmp_path)
+        backend._massgen_hooks_config = {
+            "hooks": {
+                "BeforeTool": [{"matcher": ".*", "hooks": [{"type": "command", "command": "echo x"}]}],
+            },
+        }
+        assert backend._write_hooks_json() is True
+        path = backend._workspace_hooks_json_path()
+        assert path.exists()
+        written = json.loads(path.read_text())
+        # Outer "hooks" key is required by agy's proto field tag
+        # (`Hooks json:"hooks"` in the binary).
+        assert "hooks" in written
+        assert "BeforeTool" in written["hooks"]
+
+    def test_settings_json_enables_json_hooks_flag_when_hooks_written(self, backend, tmp_path):
+        backend._config_cwd = str(tmp_path)
+        backend._write_workspace_settings_json(has_hooks=True)
+        settings_path = backend._workspace_config_dir() / "settings.json"
+        settings = json.loads(settings_path.read_text())
+        # The `json-hooks-enabled` feature flag in agy binary is read from
+        # this settings key; without it agy logs "skipping hooks.json".
+        assert settings.get("enableJsonHooks") is True
+
+    def test_settings_json_omits_flag_when_no_hooks(self, backend, tmp_path):
+        backend._config_cwd = str(tmp_path)
+        backend._write_workspace_settings_json(has_hooks=False)
+        settings_path = backend._workspace_config_dir() / "settings.json"
+        settings = json.loads(settings_path.read_text())
+        # Don't set the flag if we have nothing to gate — leaves the user's
+        # global default in place (and avoids the appearance of hooks being
+        # configured when they aren't).
+        assert "enableJsonHooks" not in settings
+
+    def test_restore_removes_managed_hooks_json(self, backend, tmp_path):
+        backend._config_cwd = str(tmp_path)
+        backend._massgen_hooks_config = {
+            "hooks": {"BeforeTool": [{"matcher": ".*", "hooks": [{"type": "command", "command": "x"}]}]},
+        }
+        backend._write_hooks_json()
+        assert backend._workspace_hooks_json_path().exists()
+        backend._restore_hooks_json()
+        assert not backend._workspace_hooks_json_path().exists()
+
+    def test_write_sets_adapter_hook_dir_to_workspace_config_dir(self, backend, tmp_path):
+        # Mirrors gemini_cli.py:1163-1164 — the adapter needs a hook_dir so
+        # `build_native_hooks_config` knows where IPC payload files live.
+        backend._config_cwd = str(tmp_path)
+        backend._massgen_hooks_config = {
+            "hooks": {"BeforeTool": [{"matcher": ".*", "hooks": [{"type": "command", "command": "x"}]}]},
+        }
+        backend._write_hooks_json()
+        adapter = getattr(backend, "_native_hook_adapter", None)
+        assert adapter is not None
+        if hasattr(adapter, "hook_dir"):
+            assert adapter.hook_dir == backend._workspace_config_dir()
+
+
 class TestAgentsMdAtomicity:
     """AGENTS.md write/restore must survive interruptions cleanly."""
 

--- a/massgen/tests/test_antigravity_cli_backend.py
+++ b/massgen/tests/test_antigravity_cli_backend.py
@@ -10,7 +10,9 @@ Run with: uv run pytest massgen/tests/test_antigravity_cli_backend.py -v
 
 from __future__ import annotations
 
+import asyncio
 import json
+import os
 from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
@@ -24,9 +26,13 @@ from massgen.backend.antigravity_cli import (
 
 @pytest.fixture
 def backend(tmp_path):
-    """AntigravityCLIBackend with binary mocked and cwd in a temp dir."""
+    """AntigravityCLIBackend with binary mocked and cwd in a temp dir.
+
+    Uses ``skip_health_check=True`` so we don't try to subprocess-invoke the
+    fake binary path — health-check coverage lives in TestBinaryHealthCheck.
+    """
     with patch.object(AntigravityCLIBackend, "_find_agy_cli", return_value="/fake/bin/agy"):
-        return AntigravityCLIBackend(cwd=str(tmp_path))
+        return AntigravityCLIBackend(cwd=str(tmp_path), skip_health_check=True)
 
 
 class TestBinaryDiscovery:
@@ -54,6 +60,50 @@ class TestBinaryDiscovery:
         with patch.object(AntigravityCLIBackend, "_find_agy_cli", return_value=None):
             with pytest.raises(RuntimeError, match="install.sh"):
                 AntigravityCLIBackend()
+
+
+class TestBinaryHealthCheck:
+    """At construction, the backend must verify `agy --version` actually runs.
+
+    This catches stale/corrupt installs (binary file exists but doesn't execute)
+    BEFORE the orchestrator burns a coordination round on it.
+    """
+
+    def test_construction_runs_version_subprocess(self, tmp_path):
+        with patch.object(AntigravityCLIBackend, "_find_agy_cli", return_value="/fake/bin/agy"):
+            with patch("subprocess.run") as run_mock:
+                run_mock.return_value.returncode = 0
+                run_mock.return_value.stdout = "1.0.0\n"
+                run_mock.return_value.stderr = ""
+                AntigravityCLIBackend(cwd=str(tmp_path))
+                assert run_mock.called
+                args = run_mock.call_args[0][0]
+                assert args[0] == "/fake/bin/agy"
+                assert "--version" in args
+
+    def test_construction_raises_clear_error_on_nonzero_exit(self, tmp_path):
+        with patch.object(AntigravityCLIBackend, "_find_agy_cli", return_value="/fake/bin/agy"):
+            with patch("subprocess.run") as run_mock:
+                run_mock.return_value.returncode = 127
+                run_mock.return_value.stdout = ""
+                run_mock.return_value.stderr = "agy: ELF load failure"
+                with pytest.raises(RuntimeError, match="exited with code 127"):
+                    AntigravityCLIBackend(cwd=str(tmp_path))
+
+    def test_construction_raises_clear_error_on_timeout(self, tmp_path):
+        import subprocess
+
+        with patch.object(AntigravityCLIBackend, "_find_agy_cli", return_value="/fake/bin/agy"):
+            with patch("subprocess.run", side_effect=subprocess.TimeoutExpired(cmd="agy", timeout=5)):
+                with pytest.raises(RuntimeError, match="won't run"):
+                    AntigravityCLIBackend(cwd=str(tmp_path))
+
+    def test_skip_health_check_bypasses_subprocess(self, tmp_path):
+        # Escape hatch for tests / unusual environments.
+        with patch.object(AntigravityCLIBackend, "_find_agy_cli", return_value="/fake/bin/agy"):
+            with patch("subprocess.run") as run_mock:
+                AntigravityCLIBackend(cwd=str(tmp_path), skip_health_check=True)
+                assert not run_mock.called
 
 
 class TestCommandConstruction:
@@ -173,7 +223,7 @@ class TestMCPConfigFile:
     def test_write_mcp_config_writes_to_workspace_gemini_dir(self, tmp_path):
         # No monkeypatching needed — the path is derived from cwd, not a module global.
         with patch.object(AntigravityCLIBackend, "_find_agy_cli", return_value="/fake/agy"):
-            be = AntigravityCLIBackend(cwd=str(tmp_path / "cwd"))
+            be = AntigravityCLIBackend(cwd=str(tmp_path / "cwd"), skip_health_check=True)
             be.mcp_servers = [{"name": "only_one", "command": "/x"}]
             be._write_mcp_config()
 
@@ -192,7 +242,7 @@ class TestMCPConfigFile:
             sentinel,
         )
         with patch.object(AntigravityCLIBackend, "_find_agy_cli", return_value="/fake/agy"):
-            be = AntigravityCLIBackend(cwd=str(tmp_path / "cwd"))
+            be = AntigravityCLIBackend(cwd=str(tmp_path / "cwd"), skip_health_check=True)
             be.mcp_servers = [{"name": "mine", "command": "/m"}]
             be._write_mcp_config()
             be._restore_mcp_config()
@@ -210,8 +260,8 @@ class TestMCPConfigFile:
     def test_workspace_mcp_path_is_isolated_per_cwd(self, tmp_path):
         """Each backend instance writes to its own cwd-scoped mcp_config.json."""
         with patch.object(AntigravityCLIBackend, "_find_agy_cli", return_value="/fake/agy"):
-            be_a = AntigravityCLIBackend(cwd=str(tmp_path / "a"))
-            be_b = AntigravityCLIBackend(cwd=str(tmp_path / "b"))
+            be_a = AntigravityCLIBackend(cwd=str(tmp_path / "a"), skip_health_check=True)
+            be_b = AntigravityCLIBackend(cwd=str(tmp_path / "b"), skip_health_check=True)
             assert be_a._workspace_mcp_config_path() != be_b._workspace_mcp_config_path()
             for be in (be_a, be_b):
                 assert be._workspace_mcp_config_path().is_absolute()
@@ -328,6 +378,204 @@ class TestStdoutStreamingParser:
         # User-visible content chunk should also flag the failure so the TUI
         # shows what happened instead of an empty agent panel.
         assert any("Antigravity CLI ERROR" in (c.content or "") for c in contents)
+
+
+class TestAgentsMdAtomicity:
+    """AGENTS.md write/restore must survive interruptions cleanly."""
+
+    def test_write_uses_temp_then_rename(self, backend, tmp_path, monkeypatch):
+        backend._config_cwd = str(tmp_path)
+        backend.system_prompt = "system prompt body"
+
+        # Capture the order of write+replace operations to assert atomicity.
+        seen: list[tuple[str, str]] = []
+        real_write_text = Path.write_text
+        real_replace = os.replace
+
+        def tracking_write_text(self, *a, **kw):
+            seen.append(("write_text", str(self)))
+            return real_write_text(self, *a, **kw)
+
+        def tracking_replace(src, dst):
+            seen.append(("replace", f"{src}->{dst}"))
+            return real_replace(src, dst)
+
+        monkeypatch.setattr(Path, "write_text", tracking_write_text)
+        monkeypatch.setattr(os, "replace", tracking_replace)
+
+        backend._write_system_prompt_md()
+        final_path = backend._workspace_agents_md_path()
+        assert final_path.read_text() == "system prompt body"
+        # The write must hit the temp file first, then be renamed onto target.
+        write_op = next(op for op in seen if op[0] == "write_text")
+        replace_op = next(op for op in seen if op[0] == "replace")
+        assert ".massgen_tmp" in write_op[1], f"write_text should target temp file, got {write_op}"
+        assert ".massgen_tmp" in replace_op[1] and "AGENTS.md" in replace_op[1]
+
+    def test_restore_cleans_up_stale_temp_file(self, backend, tmp_path):
+        # Simulate a previous call that crashed between write-to-temp and rename:
+        # a `.massgen_tmp` file lingers but no AGENTS.md was ever published.
+        backend._config_cwd = str(tmp_path)
+        target = backend._workspace_agents_md_path()
+        tmp_file = target.with_suffix(target.suffix + ".massgen_tmp")
+        tmp_file.parent.mkdir(parents=True, exist_ok=True)
+        tmp_file.write_text("partial write from a crashed run")
+
+        backend._restore_system_prompt_md()
+        assert not tmp_file.exists(), "stale .massgen_tmp must be cleaned up on restore"
+        assert not target.exists(), "no original AGENTS.md should be created from temp leftovers"
+
+    def test_restore_runs_even_if_backup_missing(self, backend, tmp_path):
+        # Common case: no pre-existing AGENTS.md, we wrote one, we remove it.
+        backend._config_cwd = str(tmp_path)
+        target = backend._workspace_agents_md_path()
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text("managed content")
+
+        backend._restore_system_prompt_md()
+        assert not target.exists()
+
+    def test_restore_preserves_user_owned_agents_md(self, backend, tmp_path):
+        # User had their own AGENTS.md. We wrote ours over it (with a backup).
+        # Restore must put theirs back, not leave ours behind.
+        backend._config_cwd = str(tmp_path)
+        backend.system_prompt = "MassGen-injected"
+        target = backend._workspace_agents_md_path()
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text("USER OWNED CONTENT")
+
+        backend._write_system_prompt_md()
+        assert target.read_text() == "MassGen-injected"
+        backend._restore_system_prompt_md()
+        assert target.read_text() == "USER OWNED CONTENT"
+
+
+class TestMultimodalContent:
+    """Non-text message parts must be surfaced to agy as readable references
+    (paths/URLs) rather than silently dropped — agy has filesystem/shell tools
+    and can ``read`` an image path or fetch a URL when prompted.
+    """
+
+    def test_plain_text_passthrough(self, backend):
+        assert backend._message_content_to_text("just text") == "just text"
+
+    def test_text_parts_concatenate(self, backend):
+        content = [
+            {"type": "text", "text": "Hello "},
+            {"type": "text", "text": "world"},
+        ]
+        assert backend._message_content_to_text(content) == "Hello world"
+
+    def test_image_path_part_surfaces_as_reference(self, backend):
+        content = [
+            {"type": "text", "text": "Look at this: "},
+            {"type": "image", "source_path": "/abs/path/photo.jpg"},
+        ]
+        out = backend._message_content_to_text(content)
+        assert "Look at this:" in out
+        assert "/abs/path/photo.jpg" in out
+        # Must include a delimiter so the model can tell it's a reference
+        assert "[" in out and "]" in out
+
+    def test_image_url_part_surfaces_url(self, backend):
+        content = [
+            {"type": "image", "image_url": "https://example.com/x.jpg"},
+        ]
+        out = backend._message_content_to_text(content)
+        assert "https://example.com/x.jpg" in out
+
+    def test_audio_path_part_surfaces(self, backend):
+        content = [{"type": "audio", "audio_path": "/clip.wav"}]
+        assert "/clip.wav" in backend._message_content_to_text(content)
+
+    def test_base64_inline_image_is_not_silently_dropped(self, backend):
+        # We don't want to inline 100kb of base64 in the agy prompt, but we
+        # also must not silently drop it. Surface a stub so the agent knows.
+        content = [
+            {"type": "image", "base64": "iVBORw0KGgo..." * 100, "mime_type": "image/png"},
+        ]
+        out = backend._message_content_to_text(content)
+        assert out, "base64 image must produce SOME output, not empty string"
+        assert "inline" in out.lower() or "base64" in out.lower() or "attachment" in out.lower()
+
+    def test_unknown_typed_part_at_least_acknowledges_existence(self, backend):
+        content = [{"type": "weird_custom_type"}]
+        out = backend._message_content_to_text(content)
+        assert "weird_custom_type" in out
+
+
+class TestSubprocessCancellation:
+    """When the orchestrator cancels the streaming generator, agy must die cleanly."""
+
+    @pytest.mark.asyncio
+    async def test_cancellation_terminates_agy_subprocess(self, backend):
+        # Build a fake proc that's "still running" (returncode=None) until killed.
+        proc_mock = AsyncMock()
+        proc_mock.returncode = None
+        terminate_called = {"value": False}
+        kill_called = {"value": False}
+
+        def _terminate():
+            terminate_called["value"] = True
+            proc_mock.returncode = 0  # simulate graceful exit after SIGTERM
+
+        def _kill():
+            kill_called["value"] = True
+            proc_mock.returncode = -9
+
+        proc_mock.terminate = _terminate
+        proc_mock.kill = _kill
+        proc_mock.wait = AsyncMock(return_value=0)
+
+        async def _aiter_stdout():
+            # Block forever so the consumer must cancel us
+            await asyncio.sleep(60)
+            return
+            yield  # pragma: no cover
+
+        proc_mock.stdout = _aiter_stdout()
+
+        async def _consume():
+            chunks = []
+            async for chunk in backend._stream_local("hi"):
+                chunks.append(chunk)
+            return chunks
+
+        with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=proc_mock)):
+            task = asyncio.create_task(_consume())
+            # Give the generator a moment to start the subprocess
+            await asyncio.sleep(0.05)
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+
+        assert terminate_called["value"], "agy subprocess must be SIGTERM'd on cancellation"
+        # No SIGKILL needed because our fake terminate sets returncode=0 immediately
+        assert not kill_called["value"]
+
+    @pytest.mark.asyncio
+    async def test_terminate_falls_back_to_kill_on_stubborn_subprocess(self, backend):
+        # If SIGTERM doesn't elicit exit within grace, we must SIGKILL.
+        proc_mock = AsyncMock()
+        proc_mock.returncode = None
+        proc_mock.terminate = lambda: None  # ignores SIGTERM
+
+        kill_called = {"value": False}
+
+        def _kill():
+            kill_called["value"] = True
+            proc_mock.returncode = -9
+
+        proc_mock.kill = _kill
+        proc_mock.wait = AsyncMock(side_effect=[asyncio.TimeoutError(), 0])
+
+        async def _waiter():
+            raise TimeoutError()
+
+        # Use very short grace so the test is fast.
+        with patch("asyncio.wait_for", AsyncMock(side_effect=[asyncio.TimeoutError(), 0])):
+            await backend._terminate_subprocess(proc_mock, grace_seconds=0.01)
+        assert kill_called["value"], "must SIGKILL when SIGTERM grace expires"
 
 
 class TestWorkflowToolTextFallback:
@@ -473,6 +721,7 @@ class TestDockerModeApiKeyAuth:
                 AntigravityCLIBackend(
                     cwd=str(tmp_path / "cwd"),
                     command_line_execution_mode="docker",
+                    skip_health_check=True,
                 )
 
     def test_docker_mode_writes_api_key_settings_json(self, tmp_path, monkeypatch):
@@ -481,6 +730,7 @@ class TestDockerModeApiKeyAuth:
             be = AntigravityCLIBackend(
                 cwd=str(tmp_path / "cwd"),
                 command_line_execution_mode="docker",
+                skip_health_check=True,
             )
             be._write_workspace_settings_json()
             settings_path = be._workspace_config_dir() / "settings.json"
@@ -493,7 +743,7 @@ class TestDockerModeApiKeyAuth:
         monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
         # Local mode uses OAuth from the host's ~/.gemini/google_accounts.json.
         with patch.object(AntigravityCLIBackend, "_find_agy_cli", return_value="/fake/agy"):
-            AntigravityCLIBackend(cwd=str(tmp_path / "cwd"))  # must not raise
+            AntigravityCLIBackend(cwd=str(tmp_path / "cwd"), skip_health_check=True)  # must not raise
 
 
 class TestNativeHookAdapter:

--- a/massgen/tests/test_antigravity_cli_backend.py
+++ b/massgen/tests/test_antigravity_cli_backend.py
@@ -146,6 +146,21 @@ class TestCommandConstruction:
         assert Path(path_arg).is_absolute(), f"--gemini_dir path must be absolute, got {path_arg!r}"
         assert ".antigravity" in path_arg
 
+    def test_command_passes_add_dir_for_workspace_registration(self, backend, tmp_path):
+        # Without --add-dir, agy writes files to .antigravity/antigravity-cli/
+        # scratch/, hiding them from peers + snapshot promotion. We must pass
+        # --add-dir <cwd> so write_to_file/view_file act on the workspace root.
+        cmd = backend._build_exec_command("hello")
+        assert "--add-dir" in cmd, f"--add-dir flag missing from: {cmd}"
+        idx = cmd.index("--add-dir")
+        path_arg = cmd[idx + 1]
+        assert Path(path_arg).is_absolute(), f"--add-dir path must be absolute, got {path_arg!r}"
+        # Must match the workspace cwd, NOT a subdir like .antigravity/ — that
+        # would defeat the purpose (agy would still write outside the workspace).
+        assert ".antigravity" not in path_arg, f"--add-dir must target workspace root, not config dir: {path_arg}"
+        # And it must equal the backend's reported cwd (resolved).
+        assert path_arg == str(Path(backend.cwd).resolve())
+
     def test_command_passes_log_file_for_error_surfacing(self, backend, tmp_path):
         # agy exits 0 with empty stdout on quota/auth failures. We capture
         # `--log-file` so silent failures can be surfaced as real errors.

--- a/massgen/tests/test_antigravity_cli_backend.py
+++ b/massgen/tests/test_antigravity_cli_backend.py
@@ -578,6 +578,186 @@ class TestSubprocessCancellation:
         assert kill_called["value"], "must SIGKILL when SIGTERM grace expires"
 
 
+class TestWorkflowModeInference:
+    """Mirrors gemini_cli's workflow-mode trio — without these, agy ends up
+    being told both `vote` and `new_answer` are valid in rounds where no
+    candidate answers exist yet, which causes spurious vote calls and
+    contributes to the over-submission behavior observed in v0.1.88 runs.
+    """
+
+    @staticmethod
+    def _vote_and_new_answer_tools():
+        return [
+            {"type": "function", "function": {"name": "new_answer", "description": "..."}},
+            {"type": "function", "function": {"name": "vote", "description": "..."}},
+        ]
+
+    def test_no_current_answers_block_returns_any(self, backend):
+        # First-ever turn: no <CURRENT ANSWERS> block exists yet.
+        messages = [{"role": "user", "content": "Build me something."}]
+        mode = backend._infer_workflow_call_mode(messages, self._vote_and_new_answer_tools())
+        assert mode == "any"
+
+    def test_empty_current_answers_block_returns_new_answer_only(self, backend):
+        # Block exists but contains no <agent…> tag → no one has answered yet.
+        messages = [
+            {
+                "role": "user",
+                "content": "<CURRENT ANSWERS from the agents>\n(no answers yet)\n<END OF CURRENT ANSWERS>",
+            },
+        ]
+        mode = backend._infer_workflow_call_mode(messages, self._vote_and_new_answer_tools())
+        assert mode == "new_answer_only"
+
+    def test_populated_current_answers_block_returns_any(self, backend):
+        messages = [
+            {
+                "role": "user",
+                "content": "<CURRENT ANSWERS from the agents>\n<agent agent1>foo</agent>\n<END OF CURRENT ANSWERS>",
+            },
+        ]
+        mode = backend._infer_workflow_call_mode(messages, self._vote_and_new_answer_tools())
+        assert mode == "any"
+
+    def test_filter_tools_drops_vote_in_new_answer_only(self, backend):
+        tools = self._vote_and_new_answer_tools()
+        filtered = backend._filter_workflow_tools_for_mode(tools, "new_answer_only")
+        names = [t["function"]["name"] for t in filtered]
+        assert "new_answer" in names
+        assert "vote" not in names
+
+    def test_filter_tools_no_op_in_any_mode(self, backend):
+        tools = self._vote_and_new_answer_tools()
+        filtered = backend._filter_workflow_tools_for_mode(tools, "any")
+        assert {t["function"]["name"] for t in filtered} == {"new_answer", "vote"}
+
+    def test_filter_parsed_calls_drops_vote_in_new_answer_only(self, backend):
+        calls = [
+            {"id": "x", "type": "function", "function": {"name": "vote", "arguments": {}}},
+            {"id": "y", "type": "function", "function": {"name": "new_answer", "arguments": {}}},
+        ]
+        filtered = backend._filter_workflow_tool_calls_for_mode(calls, "new_answer_only")
+        assert [c["function"]["name"] for c in filtered] == ["new_answer"]
+
+    def test_new_answer_only_is_sticky_across_calls_with_no_block(self, backend):
+        # Once we infer new_answer_only, a subsequent call with no block at all
+        # should keep us there (mirrors gemini_cli's retry-sticky guard).
+        msgs1 = [{"role": "user", "content": "<CURRENT ANSWERS from the agents>(empty)<END OF CURRENT ANSWERS>"}]
+        assert backend._infer_workflow_call_mode(msgs1, self._vote_and_new_answer_tools()) == "new_answer_only"
+        backend._workflow_call_mode = "new_answer_only"
+        # Now no block — sticky should keep us in new_answer_only.
+        msgs2 = [{"role": "user", "content": "Try again please."}]
+        assert backend._infer_workflow_call_mode(msgs2, self._vote_and_new_answer_tools()) == "new_answer_only"
+
+    def test_mode_inference_requires_both_vote_and_new_answer(self, backend):
+        # If only `new_answer` is in tools, mode inference doesn't activate —
+        # caller is in a non-coordination phase.
+        tools = [{"type": "function", "function": {"name": "new_answer"}}]
+        messages = [{"role": "user", "content": "<CURRENT ANSWERS from the agents>(empty)<END OF CURRENT ANSWERS>"}]
+        assert backend._infer_workflow_call_mode(messages, tools) == "any"
+
+
+class TestPhasePromptPrefix:
+    """When the orchestrator hands us `submit` + `restart_orchestration`,
+    we're in the post-evaluation phase. Mirror gemini_cli's behavior and
+    prefix the prompt so agy doesn't follow stale `new_answer`/`vote`
+    directives quoted in conversation history.
+    """
+
+    def test_post_eval_tools_emit_guard_prefix(self, backend):
+        tools = [
+            {"type": "function", "function": {"name": "submit"}},
+            {"type": "function", "function": {"name": "restart_orchestration"}},
+        ]
+        prefix = backend._build_phase_prompt_prefix(tools)
+        assert "POST-EVALUATION PHASE" in prefix
+        assert "submit" in prefix and "restart_orchestration" in prefix
+
+    def test_regular_workflow_tools_emit_no_prefix(self, backend):
+        tools = [
+            {"type": "function", "function": {"name": "vote"}},
+            {"type": "function", "function": {"name": "new_answer"}},
+        ]
+        assert backend._build_phase_prompt_prefix(tools) == ""
+
+    def test_partial_post_eval_tools_emit_no_prefix(self, backend):
+        # Both must be present; one alone isn't post-eval.
+        tools = [{"type": "function", "function": {"name": "submit"}}]
+        assert backend._build_phase_prompt_prefix(tools) == ""
+
+
+class TestAuthenticationPrecheck:
+    """At stream time, the backend must refuse to launch agy if no
+    credential source exists. Avoids burning a coordination round on a
+    silent UNAUTHENTICATED 401 from the language server.
+    """
+
+    def test_has_creds_when_api_key_set(self, backend):
+        backend.api_key = "test-key"
+        assert backend._has_cached_credentials() is True
+
+    def test_has_creds_when_google_accounts_json_exists(self, backend, tmp_path, monkeypatch):
+        backend.api_key = None
+        fake_home = tmp_path / "home"
+        (fake_home / ".gemini").mkdir(parents=True)
+        (fake_home / ".gemini" / "google_accounts.json").write_text("{}")
+        monkeypatch.setattr(Path, "home", staticmethod(lambda: fake_home))
+        assert backend._has_cached_credentials() is True
+
+    def test_no_creds_returns_false(self, backend, tmp_path, monkeypatch):
+        backend.api_key = None
+        fake_home = tmp_path / "empty_home"
+        fake_home.mkdir()
+        monkeypatch.setattr(Path, "home", staticmethod(lambda: fake_home))
+        assert backend._has_cached_credentials() is False
+
+    @pytest.mark.asyncio
+    async def test_stream_with_tools_yields_error_chunk_when_unauthenticated(self, backend, tmp_path, monkeypatch):
+        backend.api_key = None
+        fake_home = tmp_path / "empty_home"
+        fake_home.mkdir()
+        monkeypatch.setattr(Path, "home", staticmethod(lambda: fake_home))
+
+        chunks = []
+        async for chunk in backend.stream_with_tools(
+            messages=[{"role": "user", "content": "hi"}],
+            tools=[],
+        ):
+            chunks.append(chunk)
+        errors = [c for c in chunks if c.type == "error"]
+        assert errors, "must yield an error chunk when not authenticated"
+        assert "not authenticated" in (errors[0].error or "").lower() or "GEMINI_API_KEY" in (errors[0].error or "")
+
+
+class TestAgentIdRefreshFromKwargs:
+    """Parity with sibling backends — pick up agent_id from kwargs so the
+    transcript emitter labels events for the right agent across calls.
+    """
+
+    @pytest.mark.asyncio
+    async def test_agent_id_picked_up_from_kwargs(self, backend, tmp_path, monkeypatch):
+        from massgen.backend.base import StreamChunk
+
+        # Make auth check pass so we can exercise the agent_id assignment.
+        backend.api_key = "x"
+        backend.agent_id = None
+        # Stub _stream_local to skip subprocess and just yield a done chunk.
+
+        async def _stub_stream(prompt):
+            yield StreamChunk(type="done", usage={})
+
+        monkeypatch.setattr(backend, "_stream_local", _stub_stream)
+
+        chunks = []
+        async for chunk in backend.stream_with_tools(
+            messages=[{"role": "user", "content": "hi"}],
+            tools=[],
+            agent_id="agent_b",
+        ):
+            chunks.append(chunk)
+        assert backend.agent_id == "agent_b"
+
+
 class TestWorkflowToolTextFallback:
     """When MassGen orchestrator passes vote/new_answer tools, agy can't expose
     them as native MCP tools — agy 1.0.0 doesn't load MCP tools per invocation.

--- a/massgen/tests/test_system_prompt_sections.py
+++ b/massgen/tests/test_system_prompt_sections.py
@@ -7,6 +7,7 @@ from massgen.system_prompt_sections import (
     FilesystemOperationsSection,
     MemorySection,
     OutputFirstVerificationSection,
+    TaskContextSection,
     TaskPlanningSection,
     _build_checklist_analysis,
     _build_checklist_gated_decision,
@@ -530,3 +531,41 @@ def test_background_tool_guidance_discourages_immediate_wait():
     assert "continue with your next task" in lower
     assert "do not immediately call" in lower
     assert "exhausted all" in lower or "genuinely need the result" in lower
+
+
+def test_task_context_section_omits_subagent_affordances_when_disabled():
+    """When `subagents_enabled=False` (multimodal-only agents), the section
+    must not mention `spawn_subagents` or imply subagent capabilities exist.
+
+    Regression for the phantom-MCP bug: models with subagent affordances in
+    their prompt but no connected subagent server hallucinate calls to
+    `mcp__subagent_<8hex>__list_subagents` and retry-loop against an
+    unconnected server. The section is the affordance-source per the
+    "remove affordances at the source" rule.
+    """
+    content = TaskContextSection(subagents_enabled=False).build_content()
+    assert "spawn_subagents" not in content
+    # The word "subagent" itself can still appear historically in titles, but
+    # the inheritance bullet must not — that's what hallucinations latch onto.
+    assert "subagents will inherit" not in content
+    # CONTEXT.md / read_media guidance must remain — that's the actual use
+    # case for multimodal-only agents.
+    assert "CONTEXT.md" in content
+    assert "read_media" in content
+
+
+def test_task_context_section_includes_subagent_affordances_when_enabled():
+    """When subagents are actually wired, the prompt should advertise them."""
+    content = TaskContextSection(subagents_enabled=True).build_content()
+    assert "spawn_subagents" in content
+    assert "subagents will inherit this context" in content
+
+
+def test_task_context_section_defaults_to_subagents_disabled():
+    """Safe default: a bare TaskContextSection() must not leak subagent
+    affordances. The caller must opt in via subagents_enabled=True.
+    """
+    default_content = TaskContextSection().build_content()
+    explicit_content = TaskContextSection(subagents_enabled=False).build_content()
+    assert default_content == explicit_content
+    assert "spawn_subagents" not in default_content


### PR DESCRIPTION
## Summary

Four hardening fixes for the `antigravity_cli` backend shipped in v0.1.88 (#1097), in response to failure modes hit during live testing.

1. **Atomic AGENTS.md write + crash-safe restore** — write-to-temp + `os.replace()` so a kill between backup-rename and write-new can't lose the user's original AGENTS.md. Restore cleans up stale `.massgen_tmp` files.
2. **Subprocess termination on cancellation** — `except CancelledError` in the streaming generator SIGTERMs agy (with grace period before SIGKILL) when the orchestrator cancels the agent task. Prevents orphan processes.
3. **Startup health check via `agy --version`** — construction now subprocess-invokes the binary, so stale/corrupt installs fail fast with a clear error instead of burning a coordination round on a silent crash. `skip_health_check=True` opt-out for tests / unusual envs.
4. **Multimodal content surfacing** — `_message_content_to_text` no longer silently drops non-text parts; images/audio/video/file refs with a path or URL inline as `[image: /path/to/x.jpg]` so agy's filesystem tools can act on them. Base64-inlined parts surface a stub instead of vanishing.

## Live verification (not just unit tests)

Confirmed against a real multi-agent run (`log_20260522_022649_265681`, 02:28:03–02:28:05):

```
Stream chunk [content]:   "tool_name": "new_answer",
Antigravity CLI: parsed 1 workflow tool call(s) from agy stdout (text fallback path)
```

The v0.1.88 production failure (empty retry loops in TUI) was **purely the `RESOURCE_EXHAUSTED 429` quota** — agy was silently exiting on 429 and our orchestrator retried against nothing. The text-fallback path itself works correctly when agy actually runs; our log-scanner from v0.1.88 now surfaces the quota class of failure as a real error chunk.

## Scope decisions

Investigated but deferred:
- **Token usage from agy log file** — verified: agy's `--log-file` doesn't include token counts (only HTTP URLs), nor does `transcript.jsonl`. Skip until/unless agy adds it.
- **PTY-based real-time stdout streaming** — current transcript.jsonl tailing already provides real-time event visibility (PLANNER_RESPONSE, RUN_COMMAND); stdout buffering only delays the final assistant message. Adequate as-is.
- **Subagent / interactive mode** — feature work, not hardening; defer to v0.1.90+.

## Test plan

- [x] `uv run pytest massgen/tests/test_antigravity_cli_backend.py` — 50/50 green (7 new multimodal, 6 new atomicity+cancellation, 4 new health-check)
- [x] Live single-agent: `uv run massgen --automation --config massgen/configs/providers/antigravity/antigravity_cli_local.yaml "What is 2+2?"` → "Four", `vote` fired, 21.7s
- [x] Live multi-agent: `uv run massgen --config massgen/configs/features/fast_iteration_gemini_antigravity.yaml "..."` → agent_b `new_answer` parsed at 02:28:05
- [ ] CI Fast Tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Binary health-check at startup, stronger subprocess shutdown (TERM→KILL), workspace registration for built-in tools, workspace marker and workspace-local hooks gating, streaming sets/refreshes agent ID and fails early when unauthenticated.

* **Bug Fixes**
  * Atomic AGENTS.md writes with backup/restore and stale-temp cleanup, include workspace in command args, multimodal messages preserve non-text parts, suppress duplicate/invalid workflow votes.

* **Tests**
  * Expanded coverage for health checks, workspace markers/hooks, AGENTS.md, multimodal conversion, workflow modes, auth precheck, and subprocess cancellation.

* **Documentation**
  * Updated native-hook adapter and prompt section docs; .gitignore updated for CLI artifacts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/massgen/MassGen/pull/1099?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->