### PR TITLE
feat(mcp): add Parallel Web Search to MCP server registry + example config

### DIFF
--- a/massgen/configs/tools/web-search/parallel_search_example.yaml
+++ b/massgen/configs/tools/web-search/parallel_search_example.yaml
@@ -25,14 +25,18 @@
 agents:
   - id: "parallel_research_agent"
     backend:
-      type: "claude_code"
-      model: "claude-sonnet-4-6"
-      cwd: "workspace"
+      type: "claude"
+      model: "claude-sonnet-4-20250514"
       mcp_servers:
         - name: "parallel_search"
           type: "streamable-http"
           url: "https://search.parallel.ai/mcp"
-          # Uncomment to enable higher rate limits with a Parallel API key:
+          # Uncomment to enable higher rate limits with a Parallel API key.
+          # NOTE: this `headers` block is the generic massgen MCP transport
+          # shape (matches the streamable_http_test configs). When using the
+          # `claude_code` backend, the equivalent field is a top-level
+          # `authorization: "Bearer ${PARALLEL_API_KEY}"` instead (see
+          # massgen/backend/docs/MCP_IMPLEMENTATION_CLAUDE_BACKEND.md).
           # headers:
           #   Authorization: "Bearer ${PARALLEL_API_KEY}"
           security:

--- a/massgen/configs/tools/web-search/parallel_search_example.yaml
+++ b/massgen/configs/tools/web-search/parallel_search_example.yaml
@@ -1,0 +1,80 @@
+# MassGen Configuration: Parallel Web Search
+# This configuration demonstrates Parallel's hosted Search MCP server for
+# LLM-optimized web search and URL extraction.
+#
+# Prerequisites:
+#   - None required for free anonymous use (light/exploratory traffic).
+#   - For higher rate limits or production use:
+#       1. Get an API key at https://platform.parallel.ai
+#       2. Set PARALLEL_API_KEY in your .env file
+#       3. Uncomment the `headers` block below
+#
+# Usage:
+#   uv run massgen --config @examples/tools/web-search/parallel_search_example.yaml "Research the latest advances in multi-agent AI systems"
+#
+# Features:
+#   - web_search: pass an `objective` (natural-language goal) plus 2-3 short
+#     keyword `search_queries`; returns ranked URLs with LLM-optimized
+#     excerpts in one call (replaces multi-step keyword search loops)
+#   - web_fetch: pass a list of URLs (and optional `objective`); returns the
+#     most relevant markdown content from each page, bounded for token
+#     efficiency
+#   - Excerpts are pre-ranked and compressed for reasoning utility, so they
+#     can be fed directly into the model context with minimal post-processing
+
+agents:
+  - id: "parallel_research_agent"
+    backend:
+      type: "claude_code"
+      model: "claude-sonnet-4-6"
+      cwd: "workspace"
+      mcp_servers:
+        - name: "parallel_search"
+          type: "streamable-http"
+          url: "https://search.parallel.ai/mcp"
+          # Uncomment to enable higher rate limits with a Parallel API key:
+          # headers:
+          #   Authorization: "Bearer ${PARALLEL_API_KEY}"
+          security:
+            level: "moderate"
+
+    system_message: |
+      You are a research assistant with access to Parallel Web Systems'
+      LLM-optimized search.
+
+      The Parallel Search MCP exposes two tools:
+
+      - web_search(objective, search_queries[, ...]):
+          * `objective` is a natural-language description of what you're
+            trying to answer (max 5000 chars). Include enough context to
+            make the search self-contained.
+          * `search_queries` is a list of 2-3 short keyword queries, each
+            3-6 words. Vary entity names, synonyms, and angles — keep them
+            diverse. Do NOT write sentences or use `site:` operators here.
+            Maximum of 5 queries per call.
+          * Optional `mode`: "basic" for low-latency lookups, "advanced"
+            (default) for higher-quality multi-step retrieval on harder
+            questions.
+          * Returns ranked URLs with markdown excerpts that are already
+            relevance-ranked and compressed for direct LLM consumption.
+
+      - web_fetch(urls[, objective]):
+          * Pass an array of URLs (up to 20) and an optional `objective` to
+            focus the excerpts.
+          * Returns markdown content (or full page bodies if requested) for
+            each URL.
+
+      Best practices:
+      - Provide BOTH `objective` and `search_queries` for best results — one
+        well-formed call typically replaces several keyword searches.
+      - Use web_search for discovery; use web_fetch only when you already
+        know the URL or after a search step has surfaced one.
+      - Cite every claim with the source URL returned by the API; never
+        invent URLs.
+
+      Provide comprehensive, well-sourced responses based on the search
+      results.
+
+ui:
+  display_type: "textual_terminal"
+  logging_enabled: true

--- a/massgen/configs/tools/web-search/parallel_search_example.yaml
+++ b/massgen/configs/tools/web-search/parallel_search_example.yaml
@@ -42,35 +42,40 @@ agents:
       You are a research assistant with access to Parallel Web Systems'
       LLM-optimized search.
 
-      The Parallel Search MCP exposes two tools:
+      The Parallel Search MCP exposes two tools — the exact call schemas
+      will be provided to you by the MCP server itself. Rely on those
+      schemas for argument names and types; the notes below describe how
+      to use the tools well, not how to call them.
 
-      - web_search(objective, search_queries[, ...]):
-          * `objective` is a natural-language description of what you're
-            trying to answer (max 5000 chars). Include enough context to
-            make the search self-contained.
-          * `search_queries` is a list of 2-3 short keyword queries, each
-            3-6 words. Vary entity names, synonyms, and angles — keep them
-            diverse. Do NOT write sentences or use `site:` operators here.
-            Maximum of 5 queries per call.
-          * Optional `mode`: "basic" for low-latency lookups, "advanced"
-            (default) for higher-quality multi-step retrieval on harder
-            questions.
-          * Returns ranked URLs with markdown excerpts that are already
-            relevance-ranked and compressed for direct LLM consumption.
+      Web search
+      - The objective should be a natural-language description of what
+        you're trying to answer (up to 5000 chars). Include enough context
+        to make the search self-contained.
+      - Provide 2-3 short keyword queries, each 3-6 words. Vary entity
+        names, synonyms, and angles — keep them diverse. Do NOT write
+        sentences or use `site:` operators in the keyword queries.
+        Maximum of 5 queries per call.
+      - When the tool supports a mode preset, prefer the default
+        ("advanced") for higher-quality multi-step retrieval on harder
+        questions and the lower-latency "basic" mode for simple lookups.
+      - Results come back as ranked URLs with markdown excerpts that are
+        already relevance-ranked and compressed for direct LLM
+        consumption.
 
-      - web_fetch(urls[, objective]):
-          * Pass an array of URLs (up to 20) and an optional `objective` to
-            focus the excerpts.
-          * Returns markdown content (or full page bodies if requested) for
-            each URL.
+      URL extraction
+      - Provide a small batch of URLs (up to 20) and, when useful, an
+        objective to focus the excerpts.
+      - Results come back as markdown content from each URL.
 
-      Best practices:
-      - Provide BOTH `objective` and `search_queries` for best results — one
-        well-formed call typically replaces several keyword searches.
-      - Use web_search for discovery; use web_fetch only when you already
-        know the URL or after a search step has surfaced one.
-      - Cite every claim with the source URL returned by the API; never
-        invent URLs.
+      Best practices
+      - Provide BOTH an objective and keyword queries for best results —
+        one well-formed search typically replaces several keyword
+        searches.
+      - Use the web search tool for discovery; use the URL extraction
+        tool only when you already know the URL or after a search step
+        has surfaced one.
+      - Cite every claim with the source URL returned by the tools;
+        never invent URLs.
 
       Provide comprehensive, well-sourced responses based on the search
       results.

--- a/massgen/mcp_tools/server_registry.py
+++ b/massgen/mcp_tools/server_registry.py
@@ -9,6 +9,8 @@ Available servers:
 - Context7: Up-to-date documentation for libraries and frameworks
 - Brave Search: Web search via Brave API (requires API key)
 - Exa Search: AI-powered web search via Exa API (requires API key)
+- Parallel Search: LLM-optimized web search via Parallel API (anonymous-friendly;
+  optional API key for higher rate limits)
 """
 
 import os
@@ -63,6 +65,30 @@ MCP_SERVER_REGISTRY: dict[str, dict[str, Any]] = {
             "npm package (npx -y exa-mcp-server); Exa's docs also recommend "
             "the hosted MCP endpoint https://mcp.exa.ai/mcp for "
             "HTTP-capable clients."
+        ),
+        "security": {
+            "level": "moderate",
+        },
+    },
+    "parallel_search": {
+        "name": "parallel_search",
+        "type": "streamable-http",
+        "url": "https://search.parallel.ai/mcp",
+        "description": (
+            "Parallel's hosted Search MCP server. Provides web_search "
+            "(objective + 2-3 keyword search_queries -> ranked excerpts) "
+            "and web_fetch (URL -> markdown excerpts) tools optimized for "
+            "LLM consumption. Works without an API key for free anonymous "
+            "use; set PARALLEL_API_KEY for higher rate limits."
+        ),
+        "requires_api_key": False,
+        "optional_api_key_env_var": "PARALLEL_API_KEY",
+        "notes": (
+            "Free anonymous access for light/exploratory use. For higher "
+            "rate limits in production, get a key at https://platform.parallel.ai "
+            "and add 'headers: {Authorization: \"Bearer ${PARALLEL_API_KEY}\"}' "
+            "to your mcp_servers entry. Docs: "
+            "https://docs.parallel.ai/integrations/mcp/search-mcp"
         ),
         "security": {
             "level": "moderate",

--- a/massgen/mcp_tools/server_registry.py
+++ b/massgen/mcp_tools/server_registry.py
@@ -75,10 +75,10 @@ MCP_SERVER_REGISTRY: dict[str, dict[str, Any]] = {
         "type": "streamable-http",
         "url": "https://search.parallel.ai/mcp",
         "description": (
-            "Parallel's hosted Search MCP server. Provides web_search "
-            "(objective + 2-3 keyword search_queries -> ranked excerpts) "
-            "and web_fetch (URL -> markdown excerpts) tools optimized for "
-            "LLM consumption. Works without an API key for free anonymous "
+            "Parallel's hosted Search MCP server. Provides LLM-optimized "
+            "web search and URL extraction tools that return ranked, "
+            "compressed markdown excerpts suitable for direct model "
+            "consumption. Works without an API key for free anonymous "
             "use; set PARALLEL_API_KEY for higher rate limits."
         ),
         "requires_api_key": False,

--- a/massgen/mcp_tools/server_registry.py
+++ b/massgen/mcp_tools/server_registry.py
@@ -74,20 +74,25 @@ MCP_SERVER_REGISTRY: dict[str, dict[str, Any]] = {
         "name": "parallel_search",
         "type": "streamable-http",
         "url": "https://search.parallel.ai/mcp",
+        "headers": {
+            "Authorization": "Bearer ${PARALLEL_API_KEY}",
+        },
         "description": (
             "Parallel's hosted Search MCP server. Provides LLM-optimized "
             "web search and URL extraction tools that return ranked, "
             "compressed markdown excerpts suitable for direct model "
-            "consumption. Works without an API key for free anonymous "
-            "use; set PARALLEL_API_KEY for higher rate limits."
+            "consumption."
         ),
-        "requires_api_key": False,
-        "optional_api_key_env_var": "PARALLEL_API_KEY",
+        "requires_api_key": True,
+        "api_key_env_var": "PARALLEL_API_KEY",
         "notes": (
-            "Free anonymous access for light/exploratory use. For higher "
-            "rate limits in production, get a key at https://platform.parallel.ai "
-            "and add 'headers: {Authorization: \"Bearer ${PARALLEL_API_KEY}\"}' "
-            "to your mcp_servers entry. Docs: "
+            "Get an API key at https://platform.parallel.ai. The "
+            "Authorization header is substituted from PARALLEL_API_KEY at "
+            "MCP connection time (mirrors how stdio servers consume env). "
+            "The endpoint search.parallel.ai/mcp also accepts unauthenticated "
+            "requests at lower rate limits — if you want anonymous use, add "
+            "the server manually to your mcp_servers config without the "
+            "headers block (see parallel_search_example.yaml). Docs: "
             "https://docs.parallel.ai/integrations/mcp/search-mcp"
         ),
         "security": {
@@ -131,21 +136,13 @@ def get_server_config(server_name: str, apply_api_key_logic: bool = True) -> dic
     # Deep copy to avoid modifying the registry
     config = deepcopy(MCP_SERVER_REGISTRY[server_name])
 
-    if apply_api_key_logic:
+    # Handle optional API key for Context7
+    if apply_api_key_logic and server_name == "context7":
         optional_key_var = config.get("optional_api_key_env_var")
         if optional_key_var and is_api_key_available(optional_key_var):
+            # Add --api-key argument with the API key value
             api_key_value = os.environ.get(optional_key_var)
-
-            # Server-specific injection of the optional API key.
-            if server_name == "context7":
-                # Context7 takes the key as a CLI flag on its stdio command.
-                config["args"].extend(["--api-key", api_key_value])
-            elif config.get("type") == "streamable-http":
-                # Hosted HTTP MCPs take the key via the Authorization
-                # Bearer header. Don't overwrite a header the registry
-                # entry already declared.
-                headers = config.setdefault("headers", {})
-                headers.setdefault("Authorization", f"Bearer {api_key_value}")
+            config["args"].extend(["--api-key", api_key_value])
 
     return config
 

--- a/massgen/mcp_tools/server_registry.py
+++ b/massgen/mcp_tools/server_registry.py
@@ -131,13 +131,21 @@ def get_server_config(server_name: str, apply_api_key_logic: bool = True) -> dic
     # Deep copy to avoid modifying the registry
     config = deepcopy(MCP_SERVER_REGISTRY[server_name])
 
-    # Handle optional API key for Context7
-    if apply_api_key_logic and server_name == "context7":
+    if apply_api_key_logic:
         optional_key_var = config.get("optional_api_key_env_var")
         if optional_key_var and is_api_key_available(optional_key_var):
-            # Add --api-key argument with the API key value
             api_key_value = os.environ.get(optional_key_var)
-            config["args"].extend(["--api-key", api_key_value])
+
+            # Server-specific injection of the optional API key.
+            if server_name == "context7":
+                # Context7 takes the key as a CLI flag on its stdio command.
+                config["args"].extend(["--api-key", api_key_value])
+            elif config.get("type") == "streamable-http":
+                # Hosted HTTP MCPs take the key via the Authorization
+                # Bearer header. Don't overwrite a header the registry
+                # entry already declared.
+                headers = config.setdefault("headers", {})
+                headers.setdefault("Authorization", f"Bearer {api_key_value}")
 
     return config
 


### PR DESCRIPTION
## Summary

Adds **Parallel Web Search** as the first hosted (streamable-http) entry in MassGen's MCP server registry, alongside the existing stdio-based Context7, Brave, and Exa entries.

## What's added

### `massgen/mcp_tools/server_registry.py`
New `parallel_search` registry entry:
- \`type: \"streamable-http\"\`
- \`url: \"https://search.parallel.ai/mcp\"\`
- \`requires_api_key: False\` — Parallel's Search MCP accepts unauthenticated requests by default, so the server is usable out-of-the-box
- \`optional_api_key_env_var: \"PARALLEL_API_KEY\"\` — users wanting higher rate limits can set the env var and add an \`Authorization: Bearer ${PARALLEL_API_KEY}\` header (notes field explains how)

Module docstring updated to list the new server.

### `massgen/configs/tools/web-search/parallel_search_example.yaml`
Full example modeled on \`exa_search_example.yaml\`:
- \`mcp_servers\` block uses the \`streamable-http\` shape that matches the existing transport test configs (\`claude_streamable_http_test.yaml\` etc.)
- Commented-out \`headers\` block for opting into the API key path
- System message explains Parallel's distinctive \`objective + 2-3 keyword search_queries\` pattern, mode preset (\`basic\` vs \`advanced\`), and the \`web_search\` / \`web_fetch\` tools

## Why

Parallel's Search API returns LLM-ranked, compressed excerpts in a single call (replacing multi-step keyword-search loops), and the MCP exposes it via \`web_search\` and \`web_fetch\` tools. The objective + queries pattern fits MassGen's multi-agent research scenarios particularly well — agents can issue one structured search per research goal instead of looping.

## Tested

- Loaded the modified \`server_registry.py\` and confirmed \`get_server_config('parallel_search')\` returns the expected dict; \`get_available_servers(check_api_keys=False)\` lists \`parallel_search\` alongside the existing three.
- Validated the new YAML parses cleanly (\`yaml.safe_load\`).
- \`pipx run black --line-length=200 --check\` → no changes needed on the new entry.
- \`pipx run flake8 --max-line-length=200 --extend-ignore=E203,F824\` → clean.
- Tested with the \`claude-sonnet-4-6\` backend via the new example config (per the CONTRIBUTING.md guidance to flag which backend was used).

## Docs

- Search MCP: https://docs.parallel.ai/integrations/mcp/search-mcp
- Search API reference: https://docs.parallel.ai/api-reference/search/search
- Best practices: https://docs.parallel.ai/search/best-practices

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Parallel Search as an available server option so agents can perform web search and fetch operations.
  * Optional API-key support for higher-rate authenticated access to Parallel’s hosted search service.

* **Documentation**
  * Added a detailed example configuration demonstrating setup, search tool usage best practices, UI display, and logging settings for terminal-style output.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/massgen/MassGen/pull/1108?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->