### PR TITLE
fix(cli): wizard CSS_PATH broken after cli.py package split

### DIFF
--- a/massgen/cli/entrypoint.py
+++ b/massgen/cli/entrypoint.py
@@ -2242,7 +2242,7 @@ def _cli_main_continued(args):
             )
 
             class _QuickstartWizardApp(_QApp):
-                CSS_PATH = Path(__file__).parent / "frontend" / "displays" / "textual_themes" / "dark.tcss"
+                CSS_PATH = Path(__file__).parent.parent / "frontend" / "displays" / "textual_themes" / "dark.tcss"
                 BINDINGS = [("ctrl+c", "quit", "Quit")]
 
                 def __init__(self, quickstart_config_filename: str | None = None):
@@ -2363,7 +2363,7 @@ def _cli_main_continued(args):
             class SetupWizardApp(App):
                 """Standalone app for setup wizard."""
 
-                CSS_PATH = Path(__file__).parent / "frontend" / "displays" / "textual_themes" / "dark.tcss"
+                CSS_PATH = Path(__file__).parent.parent / "frontend" / "displays" / "textual_themes" / "dark.tcss"
                 SCREENS = {"wizard": SetupWizard}
                 BINDINGS = [("ctrl+c", "quit", "Quit")]
 
@@ -2803,7 +2803,7 @@ def _cli_main_continued(args):
                 )
 
                 class _FirstRunSetupApp(_FirstRunApp):
-                    CSS_PATH = Path(__file__).parent / "frontend" / "displays" / "textual_themes" / "dark.tcss"
+                    CSS_PATH = Path(__file__).parent.parent / "frontend" / "displays" / "textual_themes" / "dark.tcss"
                     SCREENS = {"wizard": SetupWizard}
                     BINDINGS = [("ctrl+c", "quit", "Quit")]
 

--- a/massgen/tests/test_cli_wizard_css_paths.py
+++ b/massgen/tests/test_cli_wizard_css_paths.py
@@ -1,0 +1,65 @@
+"""Regression test for wizard CSS path resolution.
+
+The setup/quickstart/first-run wizards in ``massgen/cli/entrypoint.py`` reference
+``textual_themes/dark.tcss`` relative to ``__file__``. When ``cli.py`` was split
+into the ``massgen/cli/`` package, ``Path(__file__).parent`` shifted one level
+deeper, breaking those paths and making ``massgen --setup`` crash with
+``StylesheetError: unable to read CSS file ...``.
+
+These tests assert that every ``CSS_PATH`` declaration in ``entrypoint.py``
+points at a real ``.tcss`` file, so the same regression cannot reappear if the
+module is moved again.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import massgen.cli.entrypoint as entrypoint_module
+
+_ENTRYPOINT_PATH = Path(entrypoint_module.__file__)
+_CSS_PATH_PATTERN = re.compile(
+    r"CSS_PATH\s*=\s*(Path\(__file__\)(?:\.parent)+\s*/\s*(?:\"[^\"]+\"\s*/?\s*)+)",
+)
+
+
+def _resolve_css_path(expression: str) -> Path:
+    """Evaluate a literal ``Path(__file__).parent[...] / "a" / "b"`` expression.
+
+    Restricted to the exact shape used in ``entrypoint.py`` so we can avoid
+    ``eval`` on arbitrary code while still asserting the real filesystem result.
+    """
+
+    parents = expression.count(".parent")
+    segments = re.findall(r"\"([^\"]+)\"", expression)
+    base = _ENTRYPOINT_PATH
+    for _ in range(parents):
+        base = base.parent
+    return base.joinpath(*segments)
+
+
+def test_entrypoint_declares_at_least_one_css_path():
+    source = _ENTRYPOINT_PATH.read_text(encoding="utf-8")
+    matches = _CSS_PATH_PATTERN.findall(source)
+    assert matches, "Expected entrypoint.py to declare wizard CSS_PATH constants"
+
+
+def test_every_wizard_css_path_resolves_to_an_existing_file():
+    """Each ``CSS_PATH = Path(__file__).parent... / "*.tcss"`` must exist on disk."""
+
+    source = _ENTRYPOINT_PATH.read_text(encoding="utf-8")
+    expressions = _CSS_PATH_PATTERN.findall(source)
+
+    missing: list[Path] = []
+    for expression in expressions:
+        resolved = _resolve_css_path(expression)
+        if not resolved.is_file():
+            missing.append(resolved)
+
+    assert not missing, (
+        "Wizard CSS_PATH declarations resolve to non-existent files. "
+        "If massgen/cli/entrypoint.py was moved, update the .parent chain to "
+        "point back at massgen/frontend/displays/textual_themes/.\n"
+        f"Missing: {[str(p) for p in missing]}"
+    )

--- a/massgen/tests/test_cli_wizard_css_paths.py
+++ b/massgen/tests/test_cli_wizard_css_paths.py
@@ -22,13 +22,25 @@ _ENTRYPOINT_PATH = Path(entrypoint_module.__file__)
 _CSS_PATH_PATTERN = re.compile(
     r"CSS_PATH\s*=\s*(Path\(__file__\)(?:\.parent)+\s*/\s*(?:\"[^\"]+\"\s*/?\s*)+)",
 )
+# Setup, quickstart, and first-run wizards each declare their own CSS_PATH.
+# If a wizard is removed intentionally, lower this and update the comment;
+# do not silently drop coverage.
+_EXPECTED_WIZARD_CSS_PATH_COUNT = 3
 
 
 def _resolve_css_path(expression: str) -> Path:
-    """Evaluate a literal ``Path(__file__).parent[...] / "a" / "b"`` expression.
+    """Resolve a literal ``Path(__file__).parent[...] / "a" / "b"`` expression.
 
     Restricted to the exact shape used in ``entrypoint.py`` so we can avoid
     ``eval`` on arbitrary code while still asserting the real filesystem result.
+
+    Args:
+        expression: The matched ``Path(__file__).parent... / "..."`` source text
+            captured from ``entrypoint.py``.
+
+    Returns:
+        The filesystem path obtained by applying each ``.parent`` to
+        ``entrypoint.py`` and then joining the quoted segments.
     """
 
     parents = expression.count(".parent")
@@ -39,14 +51,31 @@ def _resolve_css_path(expression: str) -> Path:
     return base.joinpath(*segments)
 
 
-def test_entrypoint_declares_at_least_one_css_path():
+def test_entrypoint_declares_expected_wizard_css_paths():
+    """Pin the wizard CSS_PATH count so silent loss-of-coverage fails the test.
+
+    The wizards in ``entrypoint.py`` (setup, quickstart, first-run) each declare
+    their own ``CSS_PATH``. If one is removed by accident, the existence check
+    below would still pass on whatever remained; this test forces the count to
+    stay in sync with the wizard surface area.
+    """
+
     source = _ENTRYPOINT_PATH.read_text(encoding="utf-8")
     matches = _CSS_PATH_PATTERN.findall(source)
-    assert matches, "Expected entrypoint.py to declare wizard CSS_PATH constants"
+    assert len(matches) == _EXPECTED_WIZARD_CSS_PATH_COUNT, (
+        f"Expected {_EXPECTED_WIZARD_CSS_PATH_COUNT} wizard CSS_PATH declarations "
+        f"in entrypoint.py (setup, quickstart, first-run); found {len(matches)}. "
+        "If a wizard was intentionally removed, update _EXPECTED_WIZARD_CSS_PATH_COUNT."
+    )
 
 
 def test_every_wizard_css_path_resolves_to_an_existing_file():
-    """Each ``CSS_PATH = Path(__file__).parent... / "*.tcss"`` must exist on disk."""
+    """Verify each wizard ``CSS_PATH`` literal resolves to a real ``.tcss`` file.
+
+    This is the regression for the ``massgen/cli/`` package split, where every
+    wizard ``CSS_PATH`` silently pointed at a nonexistent
+    ``massgen/cli/frontend/...`` directory and crashed the TUI on launch.
+    """
 
     source = _ENTRYPOINT_PATH.read_text(encoding="utf-8")
     expressions = _CSS_PATH_PATTERN.findall(source)


### PR DESCRIPTION
## Summary
- `massgen --setup`, `--quickstart`, and the first-run wizard crash on launch with `StylesheetError: unable to read CSS file ... textual_themes/dark.tcss`. After commit 68fcd74b moved `massgen/cli.py` into the `massgen/cli/` package, `Path(__file__).parent` in `entrypoint.py` now resolves to `massgen/cli/`, so the wizard `CSS_PATH` definitions point at the nonexistent `massgen/cli/frontend/displays/textual_themes/dark.tcss`.
- Fix: bump the three `CSS_PATH` declarations in `massgen/cli/entrypoint.py` (lines 2245, 2366, 2806) from `.parent` to `.parent.parent` so they resolve back to `massgen/frontend/displays/textual_themes/dark.tcss`.
- Add `massgen/tests/test_cli_wizard_css_paths.py`: parses every `CSS_PATH = Path(__file__).parent... / "*.tcss"` literal in `entrypoint.py` and asserts each resolves to a real file, so a future module relocation surfaces the breakage in CI instead of via user crash.

## Test plan
- [x] `uv run pytest massgen/tests/test_cli_wizard_css_paths.py -v` — 2 passed
- [x] Red/green verified: reverting only the fix (keeping the test) makes `test_every_wizard_css_path_resolves_to_an_existing_file` fail with the three missing `massgen/cli/frontend/...` paths
- [ ] Manual: `uv run massgen --setup` should reach the wizard UI instead of raising `StylesheetError`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated how the CLI resolves and loads the Textual theme stylesheet for the quickstart, API key setup, and first-run wizard screens, improving reliability of theme discovery at runtime.

* **Tests**
  * Added regression coverage that verifies the CLI declares exactly three wizard stylesheet paths and that each resolved `.tcss` file exists on disk, preventing future regressions from layout/path changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->