### PR TITLE
docs: add DaoXE OpenAI-compatible Chat Completions backend example

### DIFF
--- a/massgen/configs/BACKEND_CONFIGURATION.md
+++ b/massgen/configs/BACKEND_CONFIGURATION.md
@@ -328,7 +328,7 @@ backend:
 
 Generic backend supporting multiple providers (v0.0.18+ with MCP).
 
-Supports: Cerebras AI, Together AI, Fireworks AI, Groq, Nebius AI Studio, OpenRouter, Kimi/Moonshot, DaoXE, and any OpenAI-compatible API.
+Supports: Cerebras AI, Together AI, Fireworks AI, Groq, Nebius AI Studio, OpenRouter, Kimi/Moonshot, and any OpenAI-compatible API.
 
 ```yaml
 backend:
@@ -388,7 +388,6 @@ export OPENAI_API_KEY="<your-daoxe-api-key>"
 # optional if your process does not load the YAML value above:
 # export OPENAI_BASE_URL="https://daoxe.com/v1"
 ```
-
 
 ---
 

--- a/massgen/configs/BACKEND_CONFIGURATION.md
+++ b/massgen/configs/BACKEND_CONFIGURATION.md
@@ -328,7 +328,7 @@ backend:
 
 Generic backend supporting multiple providers (v0.0.18+ with MCP).
 
-Supports: Cerebras AI, Together AI, Fireworks AI, Groq, Nebius AI Studio, OpenRouter, Kimi/Moonshot, and any OpenAI-compatible API.
+Supports: Cerebras AI, Together AI, Fireworks AI, Groq, Nebius AI Studio, OpenRouter, Kimi/Moonshot, DaoXE, and any OpenAI-compatible API.
 
 ```yaml
 backend:
@@ -365,6 +365,20 @@ backend:
 - **OpenRouter**: `https://openrouter.ai/api/v1`
 - **Nvidia NIM**: `https://integrate.api.nvidia.com/v1`
 - **Kimi/Moonshot**: `https://api.moonshot.cn/v1`
+- **DaoXE**: `https://daoxe.com/v1` (multi-model multi-protocol gateway; Chat Completions path; account-scoped model IDs; not available in mainland China)
+
+### Example: DaoXE multi-protocol gateway
+
+[DaoXE](https://daoxe.com) is a multi-model multi-protocol API gateway. Use the Chat Completions backend with account-scoped model IDs from your DaoXE dashboard (`GET /v1/models`). Not available in mainland China.
+
+```yaml
+backend:
+  type: "chatcompletion"
+  model: "YOUR_DAOXE_MODEL_ID"
+  base_url: "https://daoxe.com/v1"
+  api_key: "${DAOXE_API_KEY}"  # or omit if DAOXE_API_KEY / OPENAI_API_KEY is set
+```
+
 
 ---
 

--- a/massgen/configs/BACKEND_CONFIGURATION.md
+++ b/massgen/configs/BACKEND_CONFIGURATION.md
@@ -376,7 +376,17 @@ backend:
   type: "chatcompletion"
   model: "YOUR_DAOXE_MODEL_ID"
   base_url: "https://daoxe.com/v1"
-  api_key: "${DAOXE_API_KEY}"  # or omit if DAOXE_API_KEY / OPENAI_API_KEY is set
+  # Chat Completions backend falls back to OPENAI_API_KEY when api_key is omitted.
+  # Prefer an explicit key if you keep multiple OpenAI-compatible backends configured:
+  api_key: "${OPENAI_API_KEY}"
+```
+
+Export a DaoXE key into the env var the backend actually reads:
+
+```bash
+export OPENAI_API_KEY="<your-daoxe-api-key>"
+# optional if your process does not load the YAML value above:
+# export OPENAI_BASE_URL="https://daoxe.com/v1"
 ```
 
 


### PR DESCRIPTION
## Summary
- Document DaoXE multi-model multi-protocol gateway under Chat Completions backends (`base_url: https://daoxe.com/v1`).
- Account-scoped model IDs; not available in mainland China.

## Test plan
- [ ] Docs render
- [ ] Matches existing chatcompletion backend pattern

Disclosure: I am affiliated with DaoXE.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added DaoXE as a supported Chat Completions provider at `https://daoxe.com/v1`.
  * Added a DaoXE configuration example with account-scoped model IDs.
  * Documented `OPENAI_API_KEY` usage and the optional `OPENAI_BASE_URL` environment variable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->