### PR TITLE
feat: add Atlas Cloud Chat Completions support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -48,6 +48,9 @@ POE_API_KEY=your-poe-api-key-here
 #QWEN API KEY
 QWEN_API_KEY=your-qwen-key-here
 
+# Atlas Cloud API Key
+ATLASCLOUD_API_KEY=your-atlascloud-key-here
+
 # Exa API Key (for Exa AI-powered web search MCP server)
 EXA_API_KEY=your-exa-api-key-here
 

--- a/docs/source/reference/supported_models.rst
+++ b/docs/source/reference/supported_models.rst
@@ -156,7 +156,7 @@ The ``chatcompletion`` backend provides a generic way to connect to any OpenAI-c
    * - **Backend Type**
      - ``chatcompletion``
    * - **Compatible Providers**
-     - Cerebras AI, Together AI, Fireworks AI, Groq, OpenRouter, POE, and any OpenAI-compatible API
+     - Cerebras AI, Together AI, Fireworks AI, Groq, OpenRouter, Atlas Cloud, POE, and any OpenAI-compatible API
    * - **Required Config**
      - ``base_url`` pointing to the provider's API endpoint
    * - **API Key**
@@ -216,6 +216,9 @@ The ``chatcompletion`` backend provides a generic way to connect to any OpenAI-c
    * - **POE**
      - Platform-specific
      - Platform credentials
+   * - **Atlas Cloud**
+     - ``https://api.atlascloud.ai/v1``
+     - ``ATLASCLOUD_API_KEY``
 
 **Common Models:**
 
@@ -223,6 +226,7 @@ The ``chatcompletion`` backend provides a generic way to connect to any OpenAI-c
 * **Together AI**: ``meta-llama/Meta-Llama-3.1-405B-Instruct-Turbo``, ``mistralai/Mixtral-8x7B-Instruct-v0.1``
 * **Fireworks AI**: ``accounts/fireworks/models/llama-v3p1-405b-instruct``
 * **Groq**: ``llama-3.1-70b-versatile``, ``mixtral-8x7b-32768``
+* **Atlas Cloud**: use a model ID available to your Atlas Cloud account
 
 Tool Enablement Reference
 --------------------------

--- a/massgen/backend/chat_completions.py
+++ b/massgen/backend/chat_completions.py
@@ -33,6 +33,7 @@ from ..formatter import ChatCompletionsFormatter
 from ..logger_config import log_backend_agent_message, log_stream_chunk, logger
 from ..stream_chunk import ChunkType
 from ..structured_logging import trace_llm_api_call
+from ..utils.provider_urls import is_atlascloud_url
 
 # Local imports
 from ._constants import configure_openrouter_extra_body
@@ -1146,7 +1147,7 @@ class ChatCompletionsBackend(StreamingBufferMixin, CustomToolAndMCPBackend):
             return "POE"
         elif "aliyuncs.com" in base_url:
             return "Qwen"
-        elif "atlascloud.ai" in base_url:
+        elif is_atlascloud_url(base_url):
             return "Atlas Cloud"
         else:
             return "ChatCompletion"

--- a/massgen/backend/chat_completions.py
+++ b/massgen/backend/chat_completions.py
@@ -15,6 +15,7 @@ Supported Providers and Environment Variables:
 - ZAI: ZAI_API_KEY
 - POE: POE_API_KEY
 - Qwen: QWEN_API_KEY
+- Atlas Cloud: ATLASCLOUD_API_KEY
 """
 
 from __future__ import annotations
@@ -1145,6 +1146,8 @@ class ChatCompletionsBackend(StreamingBufferMixin, CustomToolAndMCPBackend):
             return "POE"
         elif "aliyuncs.com" in base_url:
             return "Qwen"
+        elif "atlascloud.ai" in base_url:
+            return "Atlas Cloud"
         else:
             return "ChatCompletion"
 

--- a/massgen/cli/backends.py
+++ b/massgen/cli/backends.py
@@ -38,6 +38,7 @@ from ..dspy_paraphraser import (
 )
 from ..logger_config import logger
 from ..utils import get_backend_type_from_model
+from ..utils.provider_urls import is_atlascloud_url
 
 # --- cross-module references within the cli package ---
 from .config_loading import (
@@ -239,7 +240,7 @@ def create_backend(backend_type: str, **kwargs) -> Any:
                     raise ConfigurationError(
                         "Qwen API key not found. Set QWEN_API_KEY environment variable.\n" "You can add it to a .env file in:\n" "  - Current directory: .env\n" "  - Global config: ~/.massgen/.env",
                     )
-            elif base_url and "atlascloud.ai" in base_url:
+            elif is_atlascloud_url(base_url):
                 api_key = os.getenv("ATLASCLOUD_API_KEY")
                 if not api_key:
                     raise ConfigurationError(

--- a/massgen/cli/backends.py
+++ b/massgen/cli/backends.py
@@ -92,6 +92,7 @@ def create_backend(backend_type: str, **kwargs) -> Any:
     - Nvidia NIM (nvidia.com) -> NGC_API_KEY
     - POE (poe.com) -> POE_API_KEY
     - Qwen (dashscope.aliyuncs.com) -> QWEN_API_KEY
+    - Atlas Cloud (atlascloud.ai) -> ATLASCLOUD_API_KEY
 
     External agent frameworks are supported via the adapter registry.
     """
@@ -237,6 +238,15 @@ def create_backend(backend_type: str, **kwargs) -> Any:
                 if not api_key:
                     raise ConfigurationError(
                         "Qwen API key not found. Set QWEN_API_KEY environment variable.\n" "You can add it to a .env file in:\n" "  - Current directory: .env\n" "  - Global config: ~/.massgen/.env",
+                    )
+            elif base_url and "atlascloud.ai" in base_url:
+                api_key = os.getenv("ATLASCLOUD_API_KEY")
+                if not api_key:
+                    raise ConfigurationError(
+                        "Atlas Cloud API key not found. Set ATLASCLOUD_API_KEY environment variable.\n"
+                        "You can add it to a .env file in:\n"
+                        "  - Current directory: .env\n"
+                        "  - Global config: ~/.massgen/.env",
                     )
 
         return ChatCompletionsBackend(api_key=api_key, **kwargs)

--- a/massgen/configs/BACKEND_CONFIGURATION.md
+++ b/massgen/configs/BACKEND_CONFIGURATION.md
@@ -328,7 +328,7 @@ backend:
 
 Generic backend supporting multiple providers (v0.0.18+ with MCP).
 
-Supports: Cerebras AI, Together AI, Fireworks AI, Groq, Nebius AI Studio, OpenRouter, Kimi/Moonshot, and any OpenAI-compatible API.
+Supports: Cerebras AI, Together AI, Fireworks AI, Groq, Nebius AI Studio, OpenRouter, Kimi/Moonshot, Atlas Cloud, and any OpenAI-compatible API.
 
 ```yaml
 backend:
@@ -365,6 +365,7 @@ backend:
 - **OpenRouter**: `https://openrouter.ai/api/v1`
 - **Nvidia NIM**: `https://integrate.api.nvidia.com/v1`
 - **Kimi/Moonshot**: `https://api.moonshot.cn/v1`
+- **Atlas Cloud**: `https://api.atlascloud.ai/v1`
 
 ---
 

--- a/massgen/configs/basic/single/single_atlascloud.yaml
+++ b/massgen/configs/basic/single/single_atlascloud.yaml
@@ -1,0 +1,12 @@
+# MassGen Atlas Cloud Configuration
+# uv run massgen --automation --config massgen/configs/basic/single/single_atlascloud.yaml "Hello"
+agents:
+  - id: "atlascloud_agent"
+    backend:
+      type: "chatcompletion"
+      model: "qwen/qwen3.8-max"
+      base_url: "https://api.atlascloud.ai/v1"
+
+ui:
+  display_type: "textual_terminal"
+  logging_enabled: true

--- a/massgen/configs/basic/single/single_atlascloud.yaml
+++ b/massgen/configs/basic/single/single_atlascloud.yaml
@@ -1,5 +1,9 @@
 # MassGen Atlas Cloud Configuration
 # uv run massgen --automation --config massgen/configs/basic/single/single_atlascloud.yaml "Hello"
+# Requires ATLASCLOUD_API_KEY in the environment.
+# What happens: MassGen sends the prompt to Atlas Cloud through the
+# OpenAI-compatible Chat Completions endpoint and renders the response in
+# the textual terminal UI.
 agents:
   - id: "atlascloud_agent"
     backend:

--- a/massgen/tests/test_chat_completions_refactor.py
+++ b/massgen/tests/test_chat_completions_refactor.py
@@ -15,6 +15,8 @@ from massgen.backend.base_with_custom_tool_and_mcp import (
     BACKGROUND_TOOL_STATUS_NAME,
     BACKGROUND_TOOL_WAIT_NAME,
 )
+from massgen.cli.backends import create_backend
+from massgen.cli.config_loading import ConfigurationError
 
 
 def test_openai_backend_defaults():
@@ -45,6 +47,41 @@ def test_cerebras_backend():
     )
     assert backend.get_provider_name() == "Cerebras AI"
     assert backend.config["base_url"] == "https://api.cerebras.ai/v1"
+
+
+def test_atlascloud_backend():
+    """Provider should be inferred from the Atlas Cloud base URL."""
+    backend = ChatCompletionsBackend(
+        base_url="https://api.atlascloud.ai/v1",
+        api_key="test-key",
+    )
+    assert backend.get_provider_name() == "Atlas Cloud"
+    assert backend.config["base_url"] == "https://api.atlascloud.ai/v1"
+
+
+def test_atlascloud_api_key_is_detected(monkeypatch: pytest.MonkeyPatch):
+    """Atlas Cloud configs should use ATLASCLOUD_API_KEY automatically."""
+    monkeypatch.setenv("ATLASCLOUD_API_KEY", "test-atlas-key")
+
+    backend = create_backend(
+        "chatcompletion",
+        base_url="https://api.atlascloud.ai/v1",
+        model="qwen/qwen3.8-max",
+    )
+
+    assert backend.api_key == "test-atlas-key"
+
+
+def test_atlascloud_api_key_error_is_actionable(monkeypatch: pytest.MonkeyPatch):
+    """Missing Atlas Cloud credentials should name the expected variable."""
+    monkeypatch.delenv("ATLASCLOUD_API_KEY", raising=False)
+
+    with pytest.raises(ConfigurationError, match="ATLASCLOUD_API_KEY"):
+        create_backend(
+            "chatcompletion",
+            base_url="https://api.atlascloud.ai/v1",
+            model="qwen/qwen3.8-max",
+        )
 
 
 @pytest.mark.asyncio

--- a/massgen/tests/test_chat_completions_refactor.py
+++ b/massgen/tests/test_chat_completions_refactor.py
@@ -17,6 +17,7 @@ from massgen.backend.base_with_custom_tool_and_mcp import (
 )
 from massgen.cli.backends import create_backend
 from massgen.cli.config_loading import ConfigurationError
+from massgen.utils.provider_urls import is_atlascloud_url
 
 
 def test_openai_backend_defaults():
@@ -49,27 +50,73 @@ def test_cerebras_backend():
     assert backend.config["base_url"] == "https://api.cerebras.ai/v1"
 
 
-def test_atlascloud_backend():
-    """Provider should be inferred from the Atlas Cloud base URL."""
+@pytest.mark.parametrize(
+    ("base_url", "expected"),
+    [
+        ("https://atlascloud.ai/v1", True),
+        ("https://api.atlascloud.ai/v1", True),
+        ("https://atlascloud.ai.evil.example/v1", False),
+        ("https://notatlascloud.ai/v1", False),
+        ("https://atlascloud.ai@evil.example/v1", False),
+        ("https://user@api.atlascloud.ai/v1", False),
+        ("https://evil.example/v1?next=https://api.atlascloud.ai/v1", False),
+    ],
+)
+def test_atlascloud_url_detection(base_url: str, expected: bool):
+    """Only exact Atlas Cloud hosts and valid subdomains should be detected."""
+    assert is_atlascloud_url(base_url) is expected
+
     backend = ChatCompletionsBackend(
-        base_url="https://api.atlascloud.ai/v1",
+        base_url=base_url,
         api_key="test-key",
     )
-    assert backend.get_provider_name() == "Atlas Cloud"
-    assert backend.config["base_url"] == "https://api.atlascloud.ai/v1"
+    expected_provider = "Atlas Cloud" if expected else "ChatCompletion"
+    assert backend.get_provider_name() == expected_provider
+    assert backend.config["base_url"] == base_url
 
 
-def test_atlascloud_api_key_is_detected(monkeypatch: pytest.MonkeyPatch):
+@pytest.mark.parametrize(
+    "base_url",
+    ["https://atlascloud.ai/v1", "https://api.atlascloud.ai/v1"],
+)
+def test_atlascloud_api_key_is_detected(
+    monkeypatch: pytest.MonkeyPatch,
+    base_url: str,
+):
     """Atlas Cloud configs should use ATLASCLOUD_API_KEY automatically."""
     monkeypatch.setenv("ATLASCLOUD_API_KEY", "test-atlas-key")
 
     backend = create_backend(
         "chatcompletion",
-        base_url="https://api.atlascloud.ai/v1",
+        base_url=base_url,
         model="qwen/qwen3.8-max",
     )
 
     assert backend.api_key == "test-atlas-key"
+
+
+@pytest.mark.parametrize(
+    "base_url",
+    [
+        "https://atlascloud.ai.evil.example/v1",
+        "https://atlascloud.ai@evil.example/v1",
+        "https://evil.example/v1?next=https://api.atlascloud.ai/v1",
+    ],
+)
+def test_atlascloud_api_key_is_not_used_for_untrusted_urls(
+    monkeypatch: pytest.MonkeyPatch,
+    base_url: str,
+):
+    """Untrusted hosts must not receive the Atlas Cloud credential."""
+    monkeypatch.setenv("ATLASCLOUD_API_KEY", "test-atlas-key")
+
+    backend = create_backend(
+        "chatcompletion",
+        base_url=base_url,
+        model="qwen/qwen3.8-max",
+    )
+
+    assert backend.api_key is None
 
 
 def test_atlascloud_api_key_error_is_actionable(monkeypatch: pytest.MonkeyPatch):

--- a/massgen/utils/provider_urls.py
+++ b/massgen/utils/provider_urls.py
@@ -1,0 +1,26 @@
+"""Provider URL validation helpers."""
+
+from __future__ import annotations
+
+from urllib.parse import urlsplit
+
+_ATLASCLOUD_HOST = "atlascloud.ai"
+
+
+def is_atlascloud_url(base_url: str | None) -> bool:
+    """Return whether a URL targets Atlas Cloud or one of its subdomains."""
+    if not base_url:
+        return False
+
+    try:
+        parsed = urlsplit(base_url)
+        hostname = parsed.hostname
+        has_userinfo = parsed.username is not None or parsed.password is not None
+    except (TypeError, ValueError):
+        return False
+
+    if parsed.scheme.lower() not in {"http", "https"} or has_userinfo or not hostname:
+        return False
+
+    hostname = hostname.rstrip(".").lower()
+    return hostname == _ATLASCLOUD_HOST or hostname.endswith(f".{_ATLASCLOUD_HOST}")


### PR DESCRIPTION
## Description

Adds Atlas Cloud support to the generic Chat Completions backend by:

- detecting `ATLASCLOUD_API_KEY` for `https://api.atlascloud.ai/v1`
- identifying Atlas Cloud in provider-specific logging and diagnostics
- documenting the endpoint and environment variable
- adding a validated single-agent example configuration

## Type of change

- [x] New feature (`feat:`) - Non-breaking change which adds functionality

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove the feature works
- [x] New and existing focused unit tests pass locally

## Pre-commit status

All applicable hooks pass. The configured `pyupgrade` hook crashes under Python 3.14 before inspecting files due to an upstream compatibility error; the same configured `pyupgrade --py311-plus` check passes under Python 3.13.

## How to Test

```bash
uv run pytest massgen/tests/test_chat_completions_refactor.py -q
uv run python scripts/validate_all_configs.py
uv build --wheel
```

A live request through the MassGen-created backend to `qwen/qwen3.8-max` at the Atlas Cloud endpoint also completed successfully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Atlas Cloud as a supported Chat Completions provider.
  * Added automatic API key detection using `ATLASCLOUD_API_KEY`.
  * Added a ready-to-use single-agent configuration with a Qwen model.
  * Documented Atlas Cloud’s endpoint and account-specific model IDs.

* **Bug Fixes**
  * Added clear configuration errors when the Atlas Cloud API key is missing.
  * Improved validation for Atlas Cloud endpoints.

* **Tests**
  * Added coverage for provider detection, API key resolution, and missing-key errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->