### PR TITLE
fix(docs): repair the broken Star History chart in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1634,4 +1634,4 @@ Made with ❤️ by the MassGen team
 
 ## ⭐ Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=Leezekun/MassGen&type=Date)](https://www.star-history.com/#Leezekun/MassGen&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=Leezekun/MassGen&type=Date)](https://star-history.dera.page/#Leezekun/MassGen&Date)

--- a/README_PYPI.md
+++ b/README_PYPI.md
@@ -1633,4 +1633,4 @@ Made with ❤️ by the MassGen team
 
 ## ⭐ Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=Leezekun/MassGen&type=Date)](https://www.star-history.com/#Leezekun/MassGen&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=Leezekun/MassGen&type=Date)](https://star-history.dera.page/#Leezekun/MassGen&Date)


### PR DESCRIPTION
The Star History chart in README.md and README_PYPI.md has been broken by GitHub stargazer API restrictions, so the chart no longer renders. This PR moves the chart to star-history.dera.page, a working alternative, so the chart displays correctly again. No badges are affected and no API token is required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated Star History chart links in the project README files.
  - Charts now use the current Star History domain for improved accessibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->